### PR TITLE
docs: add 'Used by' section (immich-autotag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ uvx --from git+https://github.com/txemi/darnlink darnlink . || {
 
 ## Used by
 
-- [immich-autotag](https://github.com/txemi/immich-autotag) — a rule engine for organizing Immich photo libraries — runs darnlink as a **read-only docs-link quality gate** across pre-commit, Jenkins and GitHub Actions, keeping its documentation's Markdown links from breaking when files move.
+- [immich-autotag](https://github.com/txemi/immich-autotag) — a rule engine for organizing Immich photo libraries — runs darnlink as a **read-only docs-link quality gate** in pre-commit, Jenkins, and GitHub Actions, so its Markdown docs links don't break when files move.
 
 ## Prior art & how darnlink differs
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ uvx --from git+https://github.com/txemi/darnlink darnlink . || {
 > To have the gate **fix** links instead of just failing, use `--write` (Actions/hook) or the
 > `darnlink-repair` hook id (pre-commit).
 
+## Used by
+
+- [immich-autotag](https://github.com/txemi/immich-autotag) — a rule engine for organizing Immich photo libraries — runs darnlink as a **read-only docs-link quality gate** across pre-commit, Jenkins and GitHub Actions, keeping its documentation's Markdown links from breaking when files move.
+
 ## Prior art & how darnlink differs
 
 The idea of surviving refactors by anchoring to an identity isn't new, but the specific combination is a gap:


### PR DESCRIPTION
Adds a **Used by** section to the README: [immich-autotag](https://github.com/txemi/immich-autotag) now runs darnlink as a read-only docs-link quality gate (pre-commit, Jenkins, GitHub Actions), pinned to an immutable SHA. First real downstream user — the reference is factual, not promotional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)