### PR TITLE
feat(gate): first-class fail-closed "strict" gate (darnlink-strict) + docs + dogfood

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: uv run pytest -q
       - name: darnlink self-check (links must be clean)
         run: uv run darnlink .
+      - name: darnlink strict self-check (fail-closed — every anchorable link must be robust)
+        run: uv run darnlink . --robustify
 
   # Exercises the commands users actually run (packaging + entry point + the literal README
   # one-liner) on Linux AND Windows — so the copy-paste one-liner is proven on both.

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -22,9 +22,10 @@
 - id: darnlink-strict
   name: darnlink strict (fail-closed — require every anchorable link to be robust)
   description: >-
-    Fail (dry-run, no writes) if any plain Markdown link whose target already has a uuid is left
-    un-anchored. Stricter than `darnlink`: it does not just keep existing robust links working, it
-    requires links to be robust in the first place. Exempt generated files with a
+    Fail (dry-run, no writes) if any plain Markdown link to an anchorable target (a local file with
+    frontmatter) is left un-anchored. Stricter than `darnlink`: it does not just keep existing robust
+    links working, it requires links to be robust in the first place. Targets that can't take a uuid
+    (non-local, deny-listed, or without frontmatter) are left alone. Exempt generated files with a
     `<!-- darnlink-ignore-file -->` marker or `--exclude <dir>`.
   entry: darnlink --robustify
   language: python

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,7 @@
 #     hooks:
 #       - id: darnlink            # report broken robust links (fails if any need repair)
 #       - id: darnlink-repair     # auto-repair broken robust links (--write)
+#       - id: darnlink-strict     # fail-closed: also require every anchorable plain link to be robust
 - id: darnlink
   name: darnlink (check robust Markdown links)
   description: Report robust Markdown links whose target moved (UUID-anchored); fails if any need repair.
@@ -15,6 +16,17 @@
   name: darnlink repair (fix robust Markdown links)
   description: Repair robust Markdown links in place.
   entry: darnlink --write
+  language: python
+  pass_filenames: false
+  types: [markdown]
+- id: darnlink-strict
+  name: darnlink strict (fail-closed — require every anchorable link to be robust)
+  description: >-
+    Fail (dry-run, no writes) if any plain Markdown link whose target already has a uuid is left
+    un-anchored. Stricter than `darnlink`: it does not just keep existing robust links working, it
+    requires links to be robust in the first place. Exempt generated files with a
+    `<!-- darnlink-ignore-file -->` marker or `--exclude <dir>`.
+  entry: darnlink --robustify
   language: python
   pass_filenames: false
   types: [markdown]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ All notable changes to darnlink are documented here. The format is based on
 ### Added
 - **Strict, fail-closed gate** — a first-class way to require that every *anchorable* link is robust,
   not just that existing robust links keep working. Run `darnlink . --robustify` (dry-run: it reports
-  and exits non-zero, it does not write) or wire the new `darnlink-strict` pre-commit hook id. Links
-  whose target has no `uuid` are left alone; exempt generated files with `<!-- darnlink-ignore-file -->`
-  or `--exclude`. Documented in the README ("Stricter: require every link to be robust"); darnlink now
-  dogfoods it in its own CI and `tools/check.sh`.
+  and exits non-zero, it does not write) or wire the new `darnlink-strict` pre-commit hook id. A target
+  is anchorable when it's a local file with frontmatter; targets that can't take a `uuid` (non-local,
+  deny-listed, or without frontmatter unless `--create-frontmatter`) are left alone. Exempt generated
+  files with `<!-- darnlink-ignore-file -->` or `--exclude`. Documented in the README ("Stricter:
+  require every link to be robust"); darnlink now dogfoods it in its own CI and `tools/check.sh`.
 
 ## [0.1.1] — 2026-07-11
 
@@ -43,5 +44,6 @@ First public release.
 - Ships a [pre-commit](https://pre-commit.com/) hook (`darnlink`, `darnlink-repair`).
 - Format specification: [FORMAT.md](FORMAT.md) <!-- uuid: 9052d864-2a45-4ed4-8725-d8a394e7a7ef -->.
 
+[Unreleased]: https://github.com/txemi/darnlink/compare/v0.1.1...HEAD
 [0.1.1]: https://github.com/txemi/darnlink/releases/tag/v0.1.1
 [0.1.0]: https://github.com/txemi/darnlink/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to darnlink are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Strict, fail-closed gate** — a first-class way to require that every *anchorable* link is robust,
+  not just that existing robust links keep working. Run `darnlink . --robustify` (dry-run: it reports
+  and exits non-zero, it does not write) or wire the new `darnlink-strict` pre-commit hook id. Links
+  whose target has no `uuid` are left alone; exempt generated files with `<!-- darnlink-ignore-file -->`
+  or `--exclude`. Documented in the README ("Stricter: require every link to be robust"); darnlink now
+  dogfoods it in its own CI and `tools/check.sh`.
+
 ## [0.1.1] — 2026-07-11
 
 ### Fixed
@@ -31,7 +41,7 @@ First public release.
   `--exclude`, `--ignore-block`, `--no-create-frontmatter-for`, `--json`.
 - Cross-platform I/O: preserves original line endings (CRLF/LF); reads UTF-8 with BOM.
 - Ships a [pre-commit](https://pre-commit.com/) hook (`darnlink`, `darnlink-repair`).
-- Format specification: [FORMAT.md](FORMAT.md).
+- Format specification: [FORMAT.md](FORMAT.md) <!-- uuid: 9052d864-2a45-4ed4-8725-d8a394e7a7ef -->.
 
 [0.1.1]: https://github.com/txemi/darnlink/releases/tag/v0.1.1
 [0.1.0]: https://github.com/txemi/darnlink/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -150,18 +150,21 @@ refactor silently breaks it. To close that gap, run the **robustify check** (dry
 it does **not** write):
 
 ```bash
-darnlink . --robustify        # exits non-zero if any plain link whose target has a uuid is un-anchored
+darnlink . --robustify        # exits non-zero if any plain link to an anchorable target is un-anchored
 ```
 
-This is **fail-closed**: it fails until every link that *can* be robust *is* robust. Links whose
-target has no `uuid` (external files, generated exports, mirrors) are left alone — it only demands
-robustness where robustness is possible. Wire it as a pre-commit hook with the `darnlink-strict` id:
+This is **fail-closed**: it fails until every link that *can* be robust *is* robust. A target is
+*anchorable* when it's a local Markdown file with frontmatter (darnlink reuses its `uuid`, or adds
+one). Links whose target **can't** take a `uuid` are left alone — external/non-local targets,
+deny-listed targets, and targets **without frontmatter** (unless you opt in with
+`--create-frontmatter`). So it only demands robustness where robustness is possible. Wire it as a
+pre-commit hook with the `darnlink-strict` id:
 
 ```yaml
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/txemi/darnlink
-    rev: v0.1.1   # darnlink-strict ships in the next release; until it's tagged, pin rev: to a main commit that has it
+    rev: v0.2.0   # first release that ships darnlink-strict (until it's tagged, pin rev: to a main SHA that has it)
     hooks:
       - id: darnlink            # links that *are* robust must not break
       - id: darnlink-strict     # …and every anchorable link *must* be robust (fail-closed)

--- a/README.md
+++ b/README.md
@@ -142,6 +142,37 @@ uvx --from git+https://github.com/txemi/darnlink darnlink . || {
 > To have the gate **fix** links instead of just failing, use `--write` (Actions/hook) or the
 > `darnlink-repair` hook id (pre-commit).
 
+### Stricter: require every link to be *robust* (fail-closed)
+
+The gate above keeps the robust links you already have from breaking. It says nothing about **plain**
+relative links that were never anchored — so a fresh, un-anchored link sails through, and the next
+refactor silently breaks it. To close that gap, run the **robustify check** (dry-run — it reports,
+it does **not** write):
+
+```bash
+darnlink . --robustify        # exits non-zero if any plain link whose target has a uuid is un-anchored
+```
+
+This is **fail-closed**: it fails until every link that *can* be robust *is* robust. Links whose
+target has no `uuid` (external files, generated exports, mirrors) are left alone — it only demands
+robustness where robustness is possible. Wire it as a pre-commit hook with the `darnlink-strict` id:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/txemi/darnlink
+    rev: v0.1.1   # darnlink-strict ships in the next release; until it's tagged, pin rev: to a main commit that has it
+    hooks:
+      - id: darnlink            # links that *are* robust must not break
+      - id: darnlink-strict     # …and every anchorable link *must* be robust (fail-closed)
+```
+
+To adopt it on an existing repo: anchor what's already anchorable once with
+`darnlink . --robustify --write` (review the diff, commit), then the gate stays green. **Generated
+files** with plain links you don't want to anchor: put `<!-- darnlink-ignore-file -->` at the top of
+each (or have the generator emit it), or `--exclude <dir>` a whole tree. darnlink itself is gated
+this way (see `tools/check.sh` / CI).
+
 ## Used by
 
 - [immich-autotag](https://github.com/txemi/immich-autotag) — a rule engine for organizing Immich photo libraries — runs darnlink as a **read-only docs-link quality gate** in pre-commit, Jenkins, and GitHub Actions, so its Markdown docs links don't break when files move.

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -10,4 +10,5 @@ cd "$(git rev-parse --show-toplevel)"
 
 uv sync --extra dev   # set up the environment (project + dev deps), like CI's install step
 uv run pytest -q
-uv run darnlink .
+uv run darnlink .              # repair check: robust links must not be broken
+uv run darnlink . --robustify  # strict check (fail-closed): every anchorable link must be robust


### PR DESCRIPTION
## Why

darnlink's published quality gate only keeps the robust links you **already have** from breaking. It says nothing about **plain** relative links that were never anchored — so a fresh, un-anchored link sails through the gate and breaks on the next refactor.

The fail-closed check (`darnlink --robustify` in dry-run) already existed and exits non-zero when an anchorable plain link is un-anchored ([`cli.py:97`](https://github.com/txemi/darnlink/blob/main/src/darnlink/cli.py#L97)) — but it was **undocumented**, so downstream repos reinvented it as bespoke scripts. This makes it first-class.

## What

- **`.pre-commit-hooks.yaml`**: new `darnlink-strict` hook id → `darnlink --robustify` (dry-run, no writes).
- **README**: new *"Stricter: require every link to be robust (fail-closed)"* section — what it catches beyond the default, the generated-file escape hatch (`<!-- darnlink-ignore-file -->` / `--exclude`), and adoption steps.
- **Dogfood**: anchored the one plain link in `CHANGELOG.md` (→ `FORMAT.md`) and gated darnlink's own repo with the strict check in CI (`ci.yml`) and `tools/check.sh`.
- **CHANGELOG**: `Unreleased` entry.

Fail-closed semantics: it fails until every link that *can* be robust *is* robust. Links whose target has no `uuid` (external files, generated exports, mirrors) are left alone.

## Notes for review
- No new flags or code paths — the mechanism (`--robustify` dry-run) is unchanged; this exposes + documents + dogfoods it.
- The README's `darnlink-strict` example flags that the hook ships in the **next release** (Unreleased), so pinning `rev: v0.1.1` + `id: darnlink-strict` won't silently 404.
- Local gate + CI green: 52 tests pass, repair check clean, strict check clean.

## Test plan
- [x] `uv run pytest -q` → 52 passed
- [x] `darnlink .` (repair) → clean
- [x] `darnlink . --robustify` (strict) → clean after dogfood anchor

🤖 Generated with [Claude Code](https://claude.com/claude-code)