### PR TITLE
feat(markers): add `<!-- darnlink-ignore-links -->` — a source-only opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to darnlink are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- **`<!-- darnlink-ignore-links -->` — a source-only opt-out.** darnlink never rewrites the links
+  *inside* a file carrying it (neither robustified nor repaired), but the file stays a first-class
+  **target**: its `uuid` is still indexed, so inbound robust links keep resolving and still heal when
+  it moves. This is what a **generated** file needs — its generator rewrites it wholesale, so
+  anchoring inside it is churn, yet a generated `INDEX.md` is usually the file everything links *to*.
+  `<!-- darnlink-ignore-file -->` could not serve that case: it drops the file from the graph on both
+  axes, taking inbound links down with it, so projects worked around it with external allowlists —
+  which darnlink cannot honour, so `--robustify --write` wrote into those files anyway and the
+  workaround could only complain afterwards. Put the marker **after** the frontmatter (a marker on
+  line 1 hides the file's own `uuid`). Reported as `link-ignored` / kind `ignored_links` and listed
+  under `link_ignored_files` in `--json`; a strict `--robustify` gate passes on a tree whose
+  generated files carry it. Documented in FORMAT.md §5; spec `006-ignore-links-marker`.
 - **Strict, fail-closed gate** — a first-class way to require that every *anchorable* link is robust,
   not just that existing robust links keep working. Run `darnlink . --robustify` (dry-run: it reports
   and exits non-zero, it does not write) or wire the new `darnlink-strict` pre-commit hook id. A target

--- a/FORMAT.md
+++ b/FORMAT.md
@@ -60,18 +60,49 @@ ignored: they are examples, not navigational links, and rewriting them would cor
 
 ## 5. Opting a file out
 
-A file can remove itself from the darnlink graph entirely with a marker comment:
+darnlink asks two independent questions about a file, and there is a marker for each. Both are
+invisible when rendered, and (per §4) an occurrence inside a code block is treated as an example, not
+as opting the file out. Both are self-contained: the generator just emits the marker — no external
+ignore list, no config (Principle III).
+
+| Marker | Its own links rewritten? | Still a target (its `uuid` resolves)? |
+|---|---|---|
+| *(none — default)* | yes | yes |
+| `<!-- darnlink-ignore-links -->` | **no** | **yes** |
+| `<!-- darnlink-ignore-file -->` | **no** | **no** |
+
+### `<!-- darnlink-ignore-links -->` — leave my links alone
+
+```markdown
+<!-- darnlink-ignore-links -->
+```
+
+darnlink never rewrites the links **inside** this file: they are not robustified, and not repaired
+even when their target moves. The file stays a first-class **target**, so other documents can anchor
+to it and their links keep healing when it moves.
+
+This is what a **generated** file wants. Its generator rewrites it wholesale on every run, so any
+anchoring darnlink does there is churn — but a generated index (`INDEX.md`, `PRIORITIES.md`) is
+usually the file everything else links *to*, so it cannot afford to stop being a target. Stale links
+inside it are not darnlink's problem to fix: the generator re-emits the correct paths on its next run.
+
+> **Placement matters.** Put the marker **after** the frontmatter block, never before it. Frontmatter
+> is only recognised at the very top of the file (§2), so a marker on line 1 pushes `---` down and
+> hides the file's own `uuid` — silently costing it the target axis, which is the whole point of this
+> marker. Detection itself is position-free; this ordering comes from the frontmatter format.
+
+### `<!-- darnlink-ignore-file -->` — pretend I don't exist
 
 ```markdown
 <!-- darnlink-ignore-file -->
 ```
 
 A file carrying this marker (anywhere, outside a code span) is **never** scanned as a source (its
-links are left untouched) and **never** indexed as a target (its `uuid` does not resolve links).
-This is the self-contained way to protect a generated file (e.g. an auto-built `INDEX.md`) that
-lives in a directory darnlink otherwise processes — the generator just emits the marker, and no
-external ignore list is needed. The marker is invisible when rendered, and (per §4) an occurrence
-inside a code block is treated as an example, not as opting the file out.
+links are left untouched) and **never** indexed as a target (its `uuid` does not resolve links). Use
+it for a file that should leave the graph completely — not merely for a generated one, which almost
+always still wants inbound links (use `ignore-links` for that).
+
+If a file carries both markers, `ignore-file` wins: the stronger claim takes precedence.
 
 ## 6. Properties
 

--- a/README.md
+++ b/README.md
@@ -171,10 +171,16 @@ repos:
 ```
 
 To adopt it on an existing repo: anchor what's already anchorable once with
-`darnlink . --robustify --write` (review the diff, commit), then the gate stays green. **Generated
-files** with plain links you don't want to anchor: put `<!-- darnlink-ignore-file -->` at the top of
-each (or have the generator emit it), or `--exclude <dir>` a whole tree. darnlink itself is gated
-this way (see `tools/check.sh` / CI).
+`darnlink . --robustify --write` (review the diff, commit), then the gate stays green.
+
+**Generated files** with plain links you don't want to anchor: have the generator emit
+`<!-- darnlink-ignore-links -->` (just below the frontmatter). darnlink then leaves the links inside
+them alone — no churn when the generator re-runs — while they stay linkable targets, which matters
+because a generated `INDEX.md` is usually what everything else links *to*. Use
+`<!-- darnlink-ignore-file -->` only for a file that should leave the graph entirely (it also stops
+resolving inbound links), or `--exclude <dir>` for a whole tree. See
+[FORMAT.md §5](FORMAT.md#5-opting-a-file-out) <!-- uuid: 9052d864-2a45-4ed4-8725-d8a394e7a7ef -->
+for the two markers side by side. darnlink itself is gated this way (see `tools/check.sh` / CI).
 
 ## Used by
 

--- a/specs/006-ignore-links-marker/spec.md
+++ b/specs/006-ignore-links-marker/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: source-only opt-out via an in-file marker (`darnlink-ignore-links`)
+
+**Feature Branch**: `006-ignore-links-marker`
+
+**Created**: 2026-07-17
+
+**Status**: Draft
+
+**Input**: A Markdown file must be able to declare, **from within itself**, that darnlink should
+never rewrite *its own* links — while still being a first-class **target** that others can anchor to.
+The motivating case is the same one feature 003 was written for (a generator rewrites the file, so
+any anchoring darnlink does is churn), but 003 cannot serve it: `<!-- darnlink-ignore-file -->`
+removes the file from the graph **entirely**, including as a target. Generated indexes such as an
+auto-built `INDEX.md` / `PRIORITIES.md` are exactly the files other documents link to *most*, and
+those inbound links must stay robust. This feature splits the two axes that 003 fused, so a file can
+opt out of being a **source** without giving up being a **target**.
+
+## The two axes (and why 003 fused them)
+
+darnlink asks two independent questions about every file:
+
+| Axis | Question | Today |
+|---|---|---|
+| **Source** | Do I rewrite the links *inside* this file? | `ignore-file` (all) · `--ignore-block` (a region) |
+| **Target** | May others anchor to this file by its `uuid`? | `ignore-file` (all) |
+
+`ignore-file` answers **both** with "no" — it is a single switch on two axes. FR-019 says so
+explicitly: an opted-out file "is neither scanned as a source … nor indexed as a target". For its
+stated motivating case that is the wrong trade: a generated index wants **source: no** (or the
+generator's next run overwrites the anchors) and **target: yes** (or every inbound link to it breaks
+the moment it moves). There is no way to ask for that combination today.
+
+## Evidence this gap is real (not hypothetical)
+
+A consumer repository (`project_map`, ~1500 uuids) hit exactly this and **could not adopt the
+marker**. Its generated files are heavily-linked targets, so `ignore-file` was not an option. It
+worked around it with an **external allowlist** consumed by its own gate — a list of globs the gate
+refuses to complain about (~675 exempt findings). The workaround is strictly worse than a marker:
+
+- **It cannot prevent, only detect.** darnlink does not know the allowlist exists, so
+  `darnlink --robustify --write` still writes into those files. The gate only notices afterwards,
+  and a human must restore them by hand. This misfired **three times** (2026-06-11, 07-16, 07-17) —
+  the same accident, by different people, because the tool offers the write and the list only
+  complains later.
+- **It lives outside the files**, which is what the constitution's Principle III ("everything needed
+  is in the files themselves") exists to avoid, and what 003's own rationale argued against.
+
+## Why `ignore-links` and not `generated`
+
+The obvious name for the motivating case is `darnlink-generated`. It is rejected: "generated" is a
+claim about *what a document means*, and Principle I is explicit that darnlink "knows about Markdown
+files, links, and a `uuid` frontmatter field — nothing else … Any feature that needs to understand
+the *meaning* of a document is out of scope." `ignore-links` describes only the mechanism — *do not
+touch the links in this file* — which is structural, checkable, and semantics-free. Being generated
+is merely the most common *reason* a file asks for it; a hand-written file may ask for the same and
+darnlink neither knows nor cares why.
+
+This feature refines *which files participate, on which axis*. It adds no new capability and no
+document semantics, so it does not amend Principle I.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-033**: A Markdown file containing the marker `<!-- darnlink-ignore-links -->` (outside any
+  code span) MUST have the links **inside it** left untouched by every operation: they are never
+  robustified and never repaired. This is default behavior for such a file, not opt-in.
+- **FR-034**: The same file MUST remain indexed as a **target**: its frontmatter `uuid` resolves,
+  inbound robust links pointing at it keep working, and they MUST still be repaired when the file
+  moves. (This is the whole point of the feature, and the only difference from FR-019.)
+- **FR-035**: Under `--robustify`, such a file MUST still be eligible to *receive* a `uuid` under the
+  existing rules (reuse if present; creation still gated by `--create-frontmatter` and the
+  `--no-create-frontmatter-for` deny-list). Opting out as a source says nothing about the target axis.
+- **FR-036**: Marker detection MUST ignore occurrences inside fenced or inline code (composing with
+  feature 002), so documentation showing the marker is unaffected.
+- **FR-037**: Detection MUST be a pure textual check (deterministic, no network), tolerant of
+  internal whitespace, matching the canonical keyword `darnlink-ignore-links`.
+- **FR-038**: A link left plain (or left stale) because of this marker MUST be reported with a
+  dedicated kind, in human and `--json` output — never skipped silently (Constitution II: no silent
+  caps). It MUST NOT be reported as an actionable `robustify`/`repair` finding, so a strict gate
+  (`--robustify` as a fail-closed check) passes on a tree whose generated files carry the marker.
+- **FR-039**: If a file carries **both** markers, `darnlink-ignore-file` wins and the file is removed
+  from the graph entirely (FR-019). The stronger claim takes precedence; the combination is not an
+  error.
+- **FR-040**: The marker MUST NOT be placed **before** the frontmatter block. The canonical reader
+  (FR-023) only recognises a *leading* frontmatter block, so a marker on line 1 pushes `---` off the
+  top and the file's `uuid` becomes unreadable — silently costing it the target axis, which is the
+  entire point of this feature. Placement is therefore part of the contract: **frontmatter first,
+  marker after it**. (003 is unaffected by this: an `ignore-file` file is dropped from the graph
+  anyway, which is why its examples can lead with the marker.) Detection itself stays position-free
+  (FR-037) — only the *interaction with frontmatter* imposes this ordering, and it is a property of
+  the frontmatter format, not of the marker.
+
+### Key Entities
+
+- **Ignore-links marker**: an HTML comment `<!-- darnlink-ignore-links -->` that opts the file out of
+  the **source** axis only. Invisible when rendered. Self-contained: no external list, no config.
+  Contrast with the **ignore-file marker** (003), which opts out of both axes.
+
+## Acceptance
+
+1. **The motivating case.** A file `INDEX.md` carries the marker and holds a plain link to `B.md`
+   (which has a `uuid`). `darnlink --robustify --write` leaves `INDEX.md` byte-identical, and the
+   run reports the skip. A strict `darnlink --robustify` check exits 0.
+2. **Still a target.** `A.md` holds a robust link to `INDEX.md` by uuid. `INDEX.md` moves.
+   `darnlink --write` repairs `A.md` to the new path — the marker does not hide `INDEX.md` from the
+   index. (This is what FR-019 makes impossible today.)
+3. **Its own links are never repaired.** `INDEX.md` holds a robust link to `B.md`; `B.md` moves.
+   `darnlink --write` leaves `INDEX.md` untouched and reports it. (The generator re-emits the correct
+   path on its next run; darnlink must not fight it.)
+4. **Documentation is safe.** A file showing `<!-- darnlink-ignore-links -->` inside a fenced code
+   block does not opt itself out (composes with 002).
+5. **Precedence.** A file with both markers behaves exactly as under FR-019.

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -26,12 +26,15 @@ def _findings_json(
     write: bool,
     ignored: Optional[List[Path]] = None,
     invalid: Optional[List[Path]] = None,
+    link_ignored: Optional[List[Path]] = None,
 ) -> str:
     return json.dumps(
         {
             "wrote": wrote,
             "applied": write,
             "ignored_files": [str(p) for p in (ignored or [])],
+            # feature 006: opted out as a SOURCE only — still indexed as a target
+            "link_ignored_files": [str(p) for p in (link_ignored or [])],
             "invalid_frontmatter_files": [str(p) for p in (invalid or [])],
             "findings": [{"kind": f.kind.value, "file": str(f.file), "detail": f.detail} for f in findings],
         },
@@ -48,11 +51,12 @@ def _run_repair(root: Path, write: bool, excludes: set, as_json: bool, block_mar
     wrote = len(apply_repairs(result)) if write else 0
 
     if as_json:
-        print(_findings_json(result.findings, wrote, write, result.ignored, index.invalid))
+        print(_findings_json(result.findings, wrote, write, result.ignored, index.invalid,
+                             result.link_ignored))
     else:
         print(f"darnlink repair — root: {root}")
         print(f"  indexed uuids: {len(index.by_uuid)} | duplicate uuids: {len(index.duplicates)}")
-        print(f"  links to repair: {len(repairs)} | conflicts: {len(conflicts)} | unresolved: {len(unresolved)} | ignored files: {len(result.ignored)} | invalid frontmatter: {len(index.invalid)}")
+        print(f"  links to repair: {len(repairs)} | conflicts: {len(conflicts)} | unresolved: {len(unresolved)} | ignored files: {len(result.ignored)} | link-ignored: {len(result.link_ignored)} | invalid frontmatter: {len(index.invalid)}")
         for f in repairs:
             print(f"  [repair] {f.file}: {f.detail}")
         for f in conflicts:
@@ -77,16 +81,19 @@ def _run_robustify(root: Path, write: bool, create_frontmatter: bool, excludes: 
     wrote = len(apply_robustify(result)) if write else 0
 
     if as_json:
-        print(_findings_json(result.findings, wrote, write, result.ignored, result.invalid))
+        print(_findings_json(result.findings, wrote, write, result.ignored, result.invalid,
+                             result.link_ignored))
     else:
         print(f"darnlink robustify — root: {root}")
-        print(f"  plain links to robustify: {len(upgrades)} | skipped (no frontmatter): {len(skipped)} | deny-listed: {len(denied)} | ignored files: {len(result.ignored)} | invalid frontmatter: {len(result.invalid)}")
+        print(f"  plain links to robustify: {len(upgrades)} | skipped (no frontmatter): {len(skipped)} | deny-listed: {len(denied)} | ignored files: {len(result.ignored)} | link-ignored: {len(result.link_ignored)} | invalid frontmatter: {len(result.invalid)}")
         for f in upgrades:
             print(f"  [robustify] {f.file}: {f.detail}")
         for f in skipped:
             print(f"  [no-frontmatter] {f.file}: {f.detail} (use --create-frontmatter to allow)")
         for f in denied:
             print(f"  [deny-listed] {f.file}: {f.detail}")
+        for f in [x for x in result.findings if x.kind is Kind.IGNORED_LINKS]:
+            print(f"  [link-ignored] {f.file}: {f.detail}")
         for p in result.invalid:
             print(f"  [invalid-frontmatter] {p}: not valid YAML; left untouched (fix the file)")
         if write:

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -63,6 +63,8 @@ def _run_repair(root: Path, write: bool, excludes: set, as_json: bool, block_mar
             print(f"  [conflict] {f.file}: {f.detail}")
         for f in unresolved:
             print(f"  [{f.kind.value}] {f.file}: {f.detail}")
+        for f in [x for x in result.findings if x.kind is Kind.IGNORED_LINKS]:
+            print(f"  [link-ignored] {f.file}: {f.detail}")
         for p in index.invalid:
             print(f"  [invalid-frontmatter] {p}: not valid YAML; not indexed (fix the file)")
         if write:

--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -130,6 +130,27 @@ def file_is_ignored(content: str) -> bool:
     return any(not _in_spans(m.start(), code) for m in _IGNORE_FILE_RE.finditer(content))
 
 
+# A SOURCE-only opt-out: darnlink never rewrites the links inside this file, but the file stays a
+# first-class target (its uuid is indexed, so inbound robust links resolve and heal). This is the
+# axis `darnlink-ignore-file` fuses: that one also drops the file as a target (FR-019), which the
+# motivating case — a generated, heavily-linked INDEX.md — cannot afford. Feature 006.
+IGNORE_LINKS_MARKER = "<!-- darnlink-ignore-links -->"
+_IGNORE_LINKS_RE = re.compile(r"<!--\s*darnlink-ignore-links\s*-->")
+
+
+def file_ignores_links(content: str) -> bool:
+    """True if the file opts its OWN links out via a `<!-- darnlink-ignore-links -->` marker that is
+    NOT inside a code span. Says nothing about the target axis: the file keeps its uuid indexed.
+    FR-033/FR-036/FR-037; composes with code_spans (feature 002). Pure & deterministic.
+
+    Note (FR-040): the marker must not precede the frontmatter block — the canonical reader only
+    recognises a *leading* `---`, so a marker on line 1 would hide the file's own uuid and silently
+    cost it the target axis. Detection itself is position-free; the ordering is a property of the
+    frontmatter format, not of this check."""
+    code = code_spans(content)
+    return any(not _in_spans(m.start(), code) for m in _IGNORE_LINKS_RE.finditer(content))
+
+
 @dataclass(frozen=True)
 class RobustLink:
     text: str

--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -117,6 +117,19 @@ def code_spans(content: str) -> List[Span]:
     return fenced + _inline_code_spans(content, fenced)
 
 
+def _carries_marker(content: str, keyword: str, marker_re: "re.Pattern[str]") -> bool:
+    """True if `marker_re` matches outside a code span (so a file documenting the marker as an
+    example does not opt itself out). Pure & deterministic.
+
+    The `keyword` substring test is a cheap reject: markers are rare, and `code_spans()` parses the
+    whole file, so the common case (no marker at all) must not pay for it. It is safe because every
+    marker regex requires that keyword literally — a file that lacks the substring cannot match."""
+    if keyword not in content:
+        return False
+    code = code_spans(content)
+    return any(not _in_spans(m.start(), code) for m in marker_re.finditer(content))
+
+
 # A whole-file opt-out: a file carrying this marker is removed from the darnlink graph entirely.
 IGNORE_FILE_MARKER = "<!-- darnlink-ignore-file -->"
 _IGNORE_FILE_RE = re.compile(r"<!--\s*darnlink-ignore-file\s*-->")
@@ -126,8 +139,7 @@ def file_is_ignored(content: str) -> bool:
     """True if the file opts out of darnlink via a `<!-- darnlink-ignore-file -->` marker that is
     NOT inside a code span (so a file documenting the marker as an example does not self-ignore).
     FR-019..FR-021; composes with code_spans (feature 002). Pure & deterministic."""
-    code = code_spans(content)
-    return any(not _in_spans(m.start(), code) for m in _IGNORE_FILE_RE.finditer(content))
+    return _carries_marker(content, "darnlink-ignore-file", _IGNORE_FILE_RE)
 
 
 # A SOURCE-only opt-out: darnlink never rewrites the links inside this file, but the file stays a
@@ -147,8 +159,7 @@ def file_ignores_links(content: str) -> bool:
     recognises a *leading* `---`, so a marker on line 1 would hide the file's own uuid and silently
     cost it the target axis. Detection itself is position-free; the ordering is a property of the
     frontmatter format, not of this check."""
-    code = code_spans(content)
-    return any(not _in_spans(m.start(), code) for m in _IGNORE_LINKS_RE.finditer(content))
+    return _carries_marker(content, "darnlink-ignore-links", _IGNORE_LINKS_RE)
 
 
 @dataclass(frozen=True)

--- a/src/darnlink/repair.py
+++ b/src/darnlink/repair.py
@@ -28,8 +28,8 @@ from .report import Finding, Kind
 class RepairResult:
     findings: List[Finding] = field(default_factory=list)
     new_content: Dict[Path, str] = field(default_factory=dict)  # files that would change
-    ignored: List[Path] = field(default_factory=list)
-    link_ignored: List[Path] = field(default_factory=list)  # sources via the ignore-links marker (006)  # files skipped via the ignore-file marker
+    ignored: List[Path] = field(default_factory=list)  # files skipped via the ignore-file marker
+    link_ignored: List[Path] = field(default_factory=list)  # sources via the ignore-links marker (006)
 
 
 def plan_repairs(

--- a/src/darnlink/repair.py
+++ b/src/darnlink/repair.py
@@ -17,7 +17,8 @@ from pathlib import Path
 from typing import Dict, List
 
 from .frontmatter_index import DEFAULT_EXCLUDES, FrontmatterIndex, iter_markdown_files
-from .links import code_spans, emit_robust_link, file_is_ignored, find_robust_links, ignored_spans
+from .links import (code_spans, emit_robust_link, file_ignores_links, file_is_ignored,
+                    find_robust_links, ignored_spans)
 from .paths import relative_link, resolve_href, split_fragment
 from .frontmatter_edit import read_text_keep_newlines, write_text_keep_newlines
 from .report import Finding, Kind
@@ -27,7 +28,8 @@ from .report import Finding, Kind
 class RepairResult:
     findings: List[Finding] = field(default_factory=list)
     new_content: Dict[Path, str] = field(default_factory=dict)  # files that would change
-    ignored: List[Path] = field(default_factory=list)  # files skipped via the ignore-file marker
+    ignored: List[Path] = field(default_factory=list)
+    link_ignored: List[Path] = field(default_factory=list)  # sources via the ignore-links marker (006)  # files skipped via the ignore-file marker
 
 
 def plan_repairs(
@@ -45,6 +47,15 @@ def plan_repairs(
             continue
         if file_is_ignored(content):
             result.ignored.append(f)
+            continue
+        # Feature 006: its links are never rewritten — not even to fix a stale path. The generator
+        # re-emits the correct path on its next run; darnlink must not fight it. Unlike ignore-file
+        # this does NOT touch the target axis: the index still resolves this file's uuid (FR-034).
+        if file_ignores_links(content):
+            result.link_ignored.append(f)
+            result.findings.append(Finding(
+                Kind.IGNORED_LINKS, f,
+                "file carries darnlink-ignore-links; its links are left as-is (still a target)"))
             continue
         ignore = ignored_spans(content, block_markers) + code_spans(content)
         links = find_robust_links(content, ignore)

--- a/src/darnlink/report.py
+++ b/src/darnlink/report.py
@@ -14,6 +14,7 @@ class Kind(str, Enum):
     AMBIGUOUS = "ambiguous"        # robust link whose uuid is in more than one file
     NO_FRONTMATTER = "no_frontmatter"  # robustify target has no frontmatter (needs --create-frontmatter)
     DENY_LISTED = "deny_listed"        # robustify target matches --no-create-frontmatter-for: never given a uuid
+    IGNORED_LINKS = "ignored_links"    # source carries <!-- darnlink-ignore-links -->: its own links are left alone (it stays a target)
     INVALID_FRONTMATTER = "invalid_frontmatter"  # frontmatter present but not valid YAML; reported, never touched
 
 

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -73,10 +73,11 @@ def plan_robustify(
         # Feature 006: source-only opt-out. It stays in `files`/`contents` on purpose — it must still
         # be able to RECEIVE its own uuid as a target (FR-035), and that write lives in the Phase B
         # loop. Only the link-rewriting halves (Phase A's decide, Phase B's annotate) skip it.
-        if file_ignores_links(c):
-            link_ignored.add(f.resolve())
         files.append(f)
         contents[f] = c
+        if file_ignores_links(c):
+            link_ignored.add(f.resolve())
+            continue  # no spans: nothing reads them for this file, and computing them re-parses it
         spans[f] = ignored_spans(c, block_markers) + code_spans(c)
 
     ignored_targets = {p.resolve() for p in result.ignored}  # opted-out files: never become targets

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -21,7 +21,8 @@ from .frontmatter_edit import (
     write_text_keep_newlines,
 )
 from .frontmatter_index import DEFAULT_EXCLUDES, iter_markdown_files, read_frontmatter_uuid
-from .links import code_spans, emit_robust_link, file_is_ignored, find_plain_links, ignored_spans
+from .links import (code_spans, emit_robust_link, file_ignores_links, file_is_ignored,
+                    find_plain_links, ignored_spans)
 from .paths import is_local_md, resolve_href
 from .report import Finding, Kind
 
@@ -31,6 +32,7 @@ class RobustifyResult:
     findings: List[Finding] = field(default_factory=list)
     new_content: Dict[Path, str] = field(default_factory=dict)
     ignored: List[Path] = field(default_factory=list)  # files skipped via the ignore-file marker
+    link_ignored: List[Path] = field(default_factory=list)  # sources via the ignore-links marker (006)
     invalid: List[Path] = field(default_factory=list)  # files with non-YAML frontmatter (reported)
 
 
@@ -56,6 +58,7 @@ def plan_robustify(
     no_create_globs: Tuple[str, ...] = (),
 ) -> RobustifyResult:
     result = RobustifyResult()
+    link_ignored: Set[Path] = set()   # feature 006: sources that opt their own links out
     contents: Dict[Path, str] = {}
     spans: Dict[Path, list] = {}
     files: List[Path] = []
@@ -67,6 +70,11 @@ def plan_robustify(
         if file_is_ignored(c):
             result.ignored.append(f)  # not a source and (being absent from contents) not a target
             continue
+        # Feature 006: source-only opt-out. It stays in `files`/`contents` on purpose — it must still
+        # be able to RECEIVE its own uuid as a target (FR-035), and that write lives in the Phase B
+        # loop. Only the link-rewriting halves (Phase A's decide, Phase B's annotate) skip it.
+        if file_ignores_links(c):
+            link_ignored.add(f.resolve())
         files.append(f)
         contents[f] = c
         spans[f] = ignored_spans(c, block_markers) + code_spans(c)
@@ -109,6 +117,8 @@ def plan_robustify(
         needs_uuid_write.add(target)
 
     for f in files:
+        if f.resolve() in link_ignored:
+            continue  # FR-033: its links are never rewritten -> they must not drive uuid creation
         for link in find_plain_links(contents.get(f, ""), spans.get(f, [])):
             t = _md_target(link.href, f)
             # Skip self-links (a file linking to itself, e.g. autogrid `path` rows): robustifying
@@ -122,7 +132,15 @@ def plan_robustify(
         pieces: List[str] = []
         cursor = 0
         changed = False
-        for link in find_plain_links(original, spans.get(f, [])):
+        if f.resolve() in link_ignored:
+            # FR-033: leave every link in it alone. We still fall through to the uuid write below,
+            # because opting out as a SOURCE says nothing about being a target (FR-034/FR-035).
+            result.link_ignored.append(f)
+            result.findings.append(Finding(
+                Kind.IGNORED_LINKS, f,
+                "file carries darnlink-ignore-links; its links are left as-is (still a target)"))
+        links = () if f.resolve() in link_ignored else find_plain_links(original, spans.get(f, []))
+        for link in links:
             t = _md_target(link.href, f)
             if t is None or t.resolve() == f.resolve():
                 continue  # skip non-md/external and self-links

--- a/tests/test_ignore_links.py
+++ b/tests/test_ignore_links.py
@@ -1,0 +1,94 @@
+"""Feature 006 — `<!-- darnlink-ignore-links -->`: source-only opt-out.
+
+The file's OWN links are never touched (never robustified, never repaired), but it stays a
+first-class TARGET: its uuid is indexed, so inbound robust links keep resolving and get repaired
+when it moves. That last part is the whole difference from 003's `darnlink-ignore-file`, which
+also drops the file from the index (FR-019).
+"""
+from pathlib import Path
+
+from darnlink.frontmatter_index import build_index
+from darnlink.links import find_robust_links
+from darnlink.report import Kind
+from darnlink.repair import plan_repairs, apply_repairs
+from darnlink.robustify import plan_robustify, apply_robustify
+
+U_IDX = "aaaaaaaa-1111-2222-3333-444444444444"   # the marked file's own uuid (it is a target)
+U_B = "bbbbbbbb-1111-2222-3333-444444444444"     # a target the marked file links to
+MARK = "<!-- darnlink-ignore-links -->"
+
+
+def _w(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def test_marked_file_keeps_its_plain_links_plain(tmp_path):
+    # Acceptance 1: the motivating case — a generator rewrites INDEX.md, so anchoring it is churn.
+    _w(tmp_path / "B.md", f"---\nuuid: {U_B}\n---\n# B\n")
+    index_md = f"---\nuuid: {U_IDX}\n---\n{MARK}\n\n- [B](B.md)\n"
+    _w(tmp_path / "INDEX.md", index_md)
+
+    result = plan_robustify(tmp_path)
+    apply_robustify(result)
+
+    assert (tmp_path / "INDEX.md").read_text() == index_md  # byte-for-byte intact
+    # FR-038: reported, never silent — and NOT as an actionable robustify finding.
+    kinds = [f.kind for f in result.findings if f.file == (tmp_path / "INDEX.md")]
+    assert Kind.IGNORED_LINKS in kinds
+    assert Kind.ROBUSTIFY not in kinds
+
+
+def test_marked_file_is_still_an_indexed_target(tmp_path):
+    # FR-034 / Acceptance 2: this is exactly what darnlink-ignore-file makes impossible (FR-019).
+    _w(tmp_path / "INDEX.md", f"---\nuuid: {U_IDX}\n---\n{MARK}\n# Index\n")
+    index = build_index(tmp_path)
+    assert U_IDX in index.by_uuid  # the marker must NOT hide it from the index
+
+
+def test_inbound_robust_link_is_repaired_when_marked_file_moves(tmp_path):
+    # Acceptance 2 end-to-end: others anchor to it, and their links heal when it moves.
+    (tmp_path / "old").mkdir()
+    _w(tmp_path / "old" / "INDEX.md", f"---\nuuid: {U_IDX}\n---\n{MARK}\n# Index\n")
+    _w(tmp_path / "A.md", f"See [the index](old/INDEX.md) <!-- uuid: {U_IDX} -->\n")
+
+    (tmp_path / "new").mkdir()
+    (tmp_path / "old" / "INDEX.md").rename(tmp_path / "new" / "INDEX.md")
+
+    apply_repairs(plan_repairs(tmp_path, build_index(tmp_path)))
+    assert "(new/INDEX.md)" in (tmp_path / "A.md").read_text()
+
+
+def test_marked_file_own_robust_links_are_not_repaired(tmp_path):
+    # FR-033 / Acceptance 3: the generator re-emits the right path; darnlink must not fight it.
+    (tmp_path / "old").mkdir()
+    _w(tmp_path / "old" / "B.md", f"---\nuuid: {U_B}\n---\n# B\n")
+    index_md = f"---\nuuid: {U_IDX}\n---\n{MARK}\n\n- [B](old/B.md) <!-- uuid: {U_B} -->\n"
+    _w(tmp_path / "INDEX.md", index_md)
+
+    (tmp_path / "new").mkdir()
+    (tmp_path / "old" / "B.md").rename(tmp_path / "new" / "B.md")
+
+    result = plan_repairs(tmp_path, build_index(tmp_path))
+    apply_repairs(result)
+
+    assert (tmp_path / "INDEX.md").read_text() == index_md  # stale path left alone, on purpose
+    assert Kind.IGNORED_LINKS in [f.kind for f in result.findings if f.file == (tmp_path / "INDEX.md")]
+
+
+def test_marker_inside_a_code_block_does_not_opt_out(tmp_path):
+    # FR-036 / Acceptance 4: docs showing the marker must not self-opt-out (composes with 002).
+    _w(tmp_path / "B.md", f"---\nuuid: {U_B}\n---\n# B\n")
+    _w(tmp_path / "DOC.md", f"Use it like this:\n\n```markdown\n{MARK}\n```\n\n- [B](B.md)\n")
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    links = find_robust_links((tmp_path / "DOC.md").read_text())
+    assert len(links) == 1 and links[0].uuid == U_B  # robustified normally: not opted out
+
+
+def test_ignore_file_wins_over_ignore_links(tmp_path):
+    # FR-039 / Acceptance 5: both markers -> the stronger claim (003) applies; not an error.
+    _w(tmp_path / "G.md", f"---\nuuid: {U_IDX}\n---\n<!-- darnlink-ignore-file -->\n{MARK}\n# G\n")
+    index = build_index(tmp_path)
+    assert U_IDX not in index.by_uuid  # dropped from the graph entirely, per FR-019


### PR DESCRIPTION
## Why

`<!-- darnlink-ignore-file -->` (feature 003) answers two independent questions with a single switch:
it drops a file as a **source** (its links are never rewritten) *and* as a **target** (its uuid stops
resolving). FR-019 says so outright.

For the very case 003 was written for — its spec names *"generated files (e.g. a project's auto-built
`INDEX.md` / `PRIORITIES.md`)"* stuck in a churn loop — that trade is backwards. Those files are
precisely what everything else links **to**, so giving up the target axis breaks every inbound link
the moment they move. There is no way today to ask for *source: no, target: yes*.

## What

The missing third state. A file carrying `<!-- darnlink-ignore-links -->`:

| Marker | Own links rewritten? | Still a target? |
|---|---|---|
| *(none — default)* | yes | yes |
| **`<!-- darnlink-ignore-links -->`** ← new | **no** | **yes** |
| `<!-- darnlink-ignore-file -->` | no | no |

- FR-033 — its links are never robustified and never repaired (the generator re-emits correct paths;
  darnlink must not fight it).
- FR-034 — it stays indexed: inbound robust links resolve and still heal when it moves.
- FR-035 — it can still receive its own uuid under the existing rules.

Implementation is small because the architecture already splits these concerns: the new marker is
`file_is_ignored` **minus** the skip in `frontmatter_index.py` (the target axis).

## Why not `darnlink-generated`

"Generated" is a claim about what a document *means*, and Principle I keeps document semantics out of
darnlink ("knows about Markdown files, links, and a `uuid` frontmatter field — nothing else").
`ignore-links` names the *mechanism* — structural, checkable, semantics-free. Being generated is
merely the usual reason a file asks for it; darnlink neither knows nor cares why.

## Notes for the reviewer

- **Placement is part of the contract (FR-040).** The marker goes **after** the frontmatter. The
  canonical reader only recognises a *leading* `---`, so a marker on line 1 hides the file's own uuid
  and silently costs it the target axis — the exact failure this feature exists to prevent. Caught by
  writing the tests first (003 is unaffected: its files leave the graph anyway, which is why its
  examples can lead with the marker). Documented in FORMAT.md §5 and the spec.
- **Never silent** (FR-038, Constitution II): `link-ignored` in human output; kind `ignored_links` and
  `link_ignored_files` in `--json`. Deliberately **not** an actionable `robustify`/`repair` finding,
  so a strict `--robustify` gate passes on a tree whose generated files carry the marker.
- **Precedence** (FR-039): `ignore-file` wins if both are present. Not an error.
- **README fix:** the "Generated files" advice pointed at `ignore-file` — the very trap this fixes. It
  now recommends `ignore-links` and says when `ignore-file` is really what you want.

## Evidence this gap bites in practice

A consumer repo (~1500 uuids) **could not adopt 003** for its generated files — they are heavily
linked targets — so it built an **external allowlist** in its own gate instead. darnlink cannot honour
such a list (the word "allowlist" appears nowhere in this codebase), so `darnlink --robustify --write`
wrote into those files anyway and the workaround could only complain *afterwards*, leaving a human to
restore them by hand. **The same accident happened three times** (2026-06-11, 07-16, 07-17), by
different people. A marker prevents it at the source and keeps everything in the files themselves
(Principle III) — that allowlist can then be deleted.

## Testing

- 6 new tests (`tests/test_ignore_links.py`), one per acceptance case — written **before** the
  implementation (Principle V). **58 pass**, none changed.
- Two of them are regression pins that passed before the change too: they fail loudly if the marker
  ever costs a file its target axis.
- darnlink's own gates (`darnlink .` and the strict `darnlink . --robustify`) stay green; the strict
  one caught a plain link this PR introduced in the README, now anchored.

Spec: `specs/006-ignore-links-marker/spec.md`