### PR TITLE
docs: full option reference, in-file vocabulary, and reviewer/gate guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,28 @@ CI (`.github/workflows/ci.yml`) runs on every PR; please make sure it's green. A
 - The robust-link format is specified in [FORMAT.md](FORMAT.md) <!-- uuid: 9052d864-2a45-4ed4-8725-d8a394e7a7ef --> — it's tool-agnostic, so changes to
   the format are a bigger deal than changes to the tool; discuss them first.
 
+### Automated review
+
+This repo has **GitHub Copilot code review** enabled. When you open a PR, Copilot reviews it
+automatically and leaves inline comments. Please address them before asking a human to merge: fix the
+valid ones, and reply to any you're dismissing with the reason. It has a good hit rate here — on a
+recent PR all four of its findings were real (two correctness, two performance).
+
+Two gotchas worth knowing:
+
+- **It reviews once, on open.** Pushing a fix does **not** trigger a re-review — you have to request
+  one. In the GitHub UI: the *Reviewers* gear → re-request Copilot.
+- **From the CLI, the REST endpoint silently ignores it** (Copilot is a bot, and
+  `POST /pulls/{n}/requested_reviewers` only takes users — it returns 200 and does nothing). Use
+  GraphQL with the bot's node id:
+
+  ```bash
+  # find the bot id from an existing review, then:
+  gh api graphql -f query='mutation($pr:ID!,$b:[ID!]) {
+    requestReviews(input:{pullRequestId:$pr, botIds:$b, union:true}) { pullRequest { number } } }' \
+    -f pr='<PR node id>' -f b='<copilot bot node id>'
+  ```
+
 ## License
 
 By contributing you agree your contributions are licensed under the

--- a/FORMAT.md
+++ b/FORMAT.md
@@ -60,16 +60,43 @@ ignored: they are examples, not navigational links, and rewriting them would cor
 
 ## 5. Opting a file out
 
-darnlink asks two independent questions about a file, and there is a marker for each. Both are
-invisible when rendered, and (per §4) an occurrence inside a code block is treated as an example, not
-as opting the file out. Both are self-contained: the generator just emits the marker — no external
-ignore list, no config (Principle III).
+Everything darnlink reads lives **in the file** — no database, no config (Principle III). Beyond the
+link anchor (§1) and frontmatter `uuid` (§2), a file has three ways to tell darnlink to leave some or
+all of its links alone:
+
+| In the file | Means |
+|---|---|
+| `<!-- NAME-start --> … <!-- NAME-end -->` | Leave the links in this **region** alone (opt-in via `--ignore-block NAME`). |
+| `<!-- darnlink-ignore-links -->` | Leave **my** links alone — but keep anchoring to me. |
+| `<!-- darnlink-ignore-file -->` | Pretend I don't exist (neither source nor target). |
+
+The two `ignore-*` markers are the two independent axes darnlink cares about — *do you rewrite my
+links?* and *may others anchor to me?*:
 
 | Marker | Its own links rewritten? | Still a target (its `uuid` resolves)? |
 |---|---|---|
 | *(none — default)* | yes | yes |
 | `<!-- darnlink-ignore-links -->` | **no** | **yes** |
 | `<!-- darnlink-ignore-file -->` | **no** | **no** |
+
+All three are invisible when rendered, and (per §4) an occurrence inside a code block is treated as
+an example, not as an opt-out.
+
+### Generated regions — `<!-- NAME-start --> … <!-- NAME-end -->`
+
+Links inside such a region are left untouched, exactly as if they were code. Unlike the two markers
+below, the region is **opt-in from the command line**: darnlink only honours the names it is told
+about (`--ignore-block NAME`, repeatable), because `NAME` is yours to choose:
+
+```markdown
+<!-- autogrid-start -->
+| Doc | Path |
+| A   | [a.md](docs/a.md) |
+<!-- autogrid-end -->
+```
+
+Use it when a generator owns **part** of a file a human owns the rest of. If the generator owns the
+**whole** file, `<!-- darnlink-ignore-links -->` says so with no CLI flag at all.
 
 ### `<!-- darnlink-ignore-links -->` — leave my links alone
 

--- a/README.md
+++ b/README.md
@@ -82,12 +82,48 @@ or submodule content, mirrors, generated output:
 darnlink <folder> --exclude vendor --exclude mirror --ignore-block autogrid
 ```
 
-- `--exclude NAME` — skip any directory named `NAME` (repeatable).
-- `--ignore-block NAME` — leave links inside generated blocks
-  `<!-- NAME-start --> … <!-- NAME-end -->` untouched (repeatable).
-- `--no-create-frontmatter-for GLOB` — for files a pipeline regenerates (e.g. `content.md`, a
-  generated `INDEX.md`): never seed a uuid there (it would be wiped on the next refresh), so the
-  link is left plain.
+`--exclude` and `--ignore-block` are repeatable. For a whole file rather than a directory or a
+region, a file can opt itself out from the inside — see [FORMAT.md §5](FORMAT.md#5-opting-a-file-out) <!-- uuid: 9052d864-2a45-4ed4-8725-d8a394e7a7ef -->.
+The full flag list is under [All options](#all-options) below.
+
+## All options
+
+The sections above introduce these in context; this is the full list (same as `darnlink --help`).
+
+| Option | What it does |
+|---|---|
+| `path` *(positional)* | Root directory to scan. Default: `.` — darnlink takes a **directory**, not a file list. |
+| `--write` | Apply the changes. Without it darnlink only **reports** — it never modifies a file. |
+| `--robustify` | Upgrade plain links to robust. Without it the operation is *repair* (fix robust links whose target moved). |
+| `--create-frontmatter` | *(robustify)* Allow creating frontmatter on a target that has none, so it can take a `uuid`. Opt-in on purpose. |
+| `--no-create-frontmatter-for GLOB` | *(robustify)* Basename glob whose targets **never** get a `uuid` — no block created, no line inserted — regardless of `--create-frontmatter`. Reusing a `uuid` the target already has is unaffected. Repeatable. |
+| `--exclude NAME` | Skip any directory named `NAME`. Repeatable. |
+| `--ignore-block NAME` | Leave links inside `<!-- NAME-start --> … <!-- NAME-end -->` blocks alone. Repeatable. |
+| `--json` | Machine-readable output (see below). |
+
+Files can also opt themselves out from the inside, with no CLI flag: see
+[FORMAT.md §5](FORMAT.md#5-opting-a-file-out) <!-- uuid: 9052d864-2a45-4ed4-8725-d8a394e7a7ef --> for `<!-- darnlink-ignore-links -->` (leave *my* links
+alone, but keep anchoring to me) and `<!-- darnlink-ignore-file -->` (drop me from the graph).
+
+### `--json` output
+
+Stable shape, meant for gates and scripts:
+
+```json
+{
+  "wrote": 0,
+  "applied": false,
+  "ignored_files": ["path/to/opted-out.md"],
+  "link_ignored_files": ["path/to/generated/INDEX.md"],
+  "invalid_frontmatter_files": [],
+  "findings": [{ "kind": "robustify", "file": "docs/a.md", "detail": "b.md +uuid <uuid>" }]
+}
+```
+
+`kind` is one of: `repair`, `conflict`, `robustify`, `unresolvable`, `ambiguous`, `no_frontmatter`,
+`deny_listed`, `ignored_links`, `invalid_frontmatter`. A gate that wants "is anything left to do?"
+should count the kinds it cares about (e.g. `robustify`) rather than the length of `findings` — the
+non-actionable kinds are reported precisely so nothing is skipped silently.
 
 ## For language models / agents
 
@@ -172,6 +208,15 @@ repos:
 
 To adopt it on an existing repo: anchor what's already anchorable once with
 `darnlink . --robustify --write` (review the diff, commit), then the gate stays green.
+
+> **Scope note for repos with many contributors.** All the hooks run over the **whole tree**
+> (`pass_filenames: false` — darnlink takes a directory, not a file list), and the strict check is
+> *fail-closed*. So a plain, un-anchored link that **someone else** left in a file you never touched
+> will block **your** commit. That is fine for a small repo, but with several people (or parallel
+> agents) committing at once it means one un-anchored link blocks everyone. A practical split: run
+> `darnlink-strict` in **CI** (the real wall — nothing un-anchored lands on the main branch), and the
+> plain `darnlink` hook **locally** (fast, and it only fails on links that actually broke), so a
+> teammate's in-flight plain link doesn't stop your commit.
 
 **Generated files** with plain links you don't want to anchor: have the generator emit
 `<!-- darnlink-ignore-links -->` (just below the frontmatter). darnlink then leaves the links inside


### PR DESCRIPTION
Docs-only follow-up to #3. No code change; `git diff --stat` is README / FORMAT.md / CONTRIBUTING.md.
Fills gaps found while actually using the tool this week.

## README
- **`## All options`** — the full flag list was scattered across prose, and **`--json` was documented
  nowhere**, even though it's the contract gates parse. Adds a reference table, the stable `--json`
  shape, and the list of `kind`s — with the note to count the kinds you care about rather than
  `len(findings)` (the non-actionable kinds are emitted precisely so nothing is skipped silently).
- **Strict-gate scope note** — every published hook runs over the whole tree (`pass_filenames:
  false`; darnlink takes a directory, not a file list) and strict is fail-closed, so a plain link
  *someone else* left in a file you never touched blocks *your* commit. Fine solo; with several
  contributors it deadlocks. Documents the practical split: `darnlink-strict` in CI (the real wall),
  the plain `darnlink` hook locally.

## FORMAT.md §5
- Adds the one in-file construct that was missing here — the `<!-- NAME-start --> … <!-- NAME-end -->`
  region (it lived only in the README, as if it were a flag) — plus a summary table of the **whole**
  in-file vocabulary, so §5 is now the single place that answers "what can a file say to darnlink?".
- The `## 5. Opting a file out` heading is kept verbatim, so the anchor other docs link to
  (`#5-opting-a-file-out`) still resolves.

## CONTRIBUTING.md
- Documents that Copilot review is enabled and how to work with it — including the two things that
  cost time this week: it reviews **once, on open** (a re-review must be *requested*), and the REST
  `requested_reviewers` endpoint **silently ignores the bot**, so you need GraphQL `botIds`.

## Checks
Docs only, but darnlink dogfoods its own links: the strict gate flagged the two new FORMAT.md links I
added (now anchored), and `darnlink .` + `darnlink . --robustify` + the 58 tests stay green.