### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-07-17
+
 ### Added
 - **`<!-- darnlink-ignore-links -->` — a source-only opt-out.** darnlink never rewrites the links
   *inside* a file carrying it (neither robustified nor repaired), but the file stays a first-class
@@ -56,6 +58,7 @@ First public release.
 - Ships a [pre-commit](https://pre-commit.com/) hook (`darnlink`, `darnlink-repair`).
 - Format specification: [FORMAT.md](FORMAT.md) <!-- uuid: 9052d864-2a45-4ed4-8725-d8a394e7a7ef -->.
 
-[Unreleased]: https://github.com/txemi/darnlink/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/txemi/darnlink/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/txemi/darnlink/releases/tag/v0.2.0
 [0.1.1]: https://github.com/txemi/darnlink/releases/tag/v0.1.1
 [0.1.0]: https://github.com/txemi/darnlink/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.1.1"
+version = "0.2.0"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/darnlink/__init__.py
+++ b/src/darnlink/__init__.py
@@ -8,4 +8,4 @@ Plain Markdown, no database, no editor lock-in. Dry-run by default.
 See the project Constitution in .specify/memory/constitution.md.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"


### PR DESCRIPTION
## What

Cuts **v0.2.0**, releasing what's already on `main` since v0.1.1:

- **Fail-closed strict gate + `darnlink-strict` hook** (#2)
- **`<!-- darnlink-ignore-links -->`** source-only opt-out for generated files (#3)
- **Full CLI option reference** docs (#4)

Downstream consumers pinned to `@v0.1.1` don't have these; this tag lets them pin the strict hook and the marker.

## Changes
- `pyproject.toml` → `0.2.0`.
- `src/darnlink/__init__.py` → `0.2.0` (also **fixes** `__version__`, which was stale at `0.1.0` since the 0.1.1 release — pyproject and `__version__` had drifted).
- `CHANGELOG.md`: `[Unreleased]` → `[0.2.0] — 2026-07-17` + compare/ref links.

## Test plan
- [x] `uv run pytest -q` → 58 passed
- [x] `uv run darnlink .` (repair) → clean
- [x] `uv run darnlink . --robustify` (strict) → clean
- [x] pyproject `0.2.0` == `__version__` `0.2.0`

## Context
First step of the cross-session agreement to unify darnlink usage (recorded in txnet1 DARNLINK-001_ISSUE_3 step03). After this tag land the `darnlink gate` (run repair+strict, distinguishable exit codes) and `--staged` PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)