### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-07-17
+
 ### Added
 - **`darnlink check` — a report-only gate subcommand.** Runs **both** axes in one invocation — repair
   (integrity: broken/unresolvable robust links + invalid frontmatter) and robustify (strict:
@@ -68,7 +70,8 @@ First public release.
 - Ships a [pre-commit](https://pre-commit.com/) hook (`darnlink`, `darnlink-repair`).
 - Format specification: [FORMAT.md](FORMAT.md) <!-- uuid: 9052d864-2a45-4ed4-8725-d8a394e7a7ef -->.
 
-[Unreleased]: https://github.com/txemi/darnlink/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/txemi/darnlink/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/txemi/darnlink/releases/tag/v0.3.0
 [0.2.0]: https://github.com/txemi/darnlink/releases/tag/v0.2.0
 [0.1.1]: https://github.com/txemi/darnlink/releases/tag/v0.1.1
 [0.1.0]: https://github.com/txemi/darnlink/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ pre-commit hook with the `darnlink-strict` id:
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/txemi/darnlink
-    rev: v0.2.0   # first release that ships darnlink-strict (until it's tagged, pin rev: to a main SHA that has it)
+    rev: v0.2.0   # darnlink-strict ships here
     hooks:
       - id: darnlink            # links that *are* robust must not break
       - id: darnlink-strict     # …and every anchorable link *must* be robust (fail-closed)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.2.0"
+version = "0.3.0"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/darnlink/__init__.py
+++ b/src/darnlink/__init__.py
@@ -8,4 +8,4 @@ Plain Markdown, no database, no editor lock-in. Dry-run by default.
 See the project Constitution in .specify/memory/constitution.md.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"


### PR DESCRIPTION
Ships `darnlink check` (#6): the report-only gate subcommand (runs both axes, exit 0/2/3/1). Downstream consumers need a tag that includes `check` to pin it (v0.2.0 predates the merge) — this is that tag. Version bump + CHANGELOG only; the feature is already on main and CI-green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)