### PR TITLE
feat(exclude): --exclude matches directory names by glob (spec 009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **`--exclude` now takes a glob** (`fnmatch`, case-sensitive), not just an exact name — so a repo can
+  skip a whole family in one declarative line instead of listing every directory and letting the list
+  drift: `--exclude old --exclude 'old_*' --exclude '*_old' --exclude '*.old'`. **Backward-compatible**:
+  a pattern with no wildcards matches exactly, so every existing `--exclude NAME` is unchanged. Spec
+  `009-glob-excludes`.
+
 ## [0.3.0] — 2026-07-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ or submodule content, mirrors, generated output:
 darnlink <folder> --exclude vendor --exclude mirror --ignore-block autogrid
 ```
 
-`--exclude` and `--ignore-block` are repeatable. For a whole file rather than a directory or a
-region, a file can opt itself out from the inside — see [FORMAT.md §5](FORMAT.md#5-opting-a-file-out) <!-- uuid: 9052d864-2a45-4ed4-8725-d8a394e7a7ef -->.
+`--exclude` and `--ignore-block` are repeatable. `--exclude` is a glob — **keep patterns tight**: a
+wide one like `*` silently drops directories from the scan (their links stop being checked). Prefer
+word-boundary patterns (`old`, `old_*`, `*_old`) over a greedy `*old*`. For a whole file rather than a
+directory or a region, a file can opt itself out from the inside — see [FORMAT.md §5](FORMAT.md#5-opting-a-file-out) <!-- uuid: 9052d864-2a45-4ed4-8725-d8a394e7a7ef -->.
 The full flag list is under [All options](#all-options) below.
 
 ## All options

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The sections above introduce these in context; this is the full list (same as `d
 | `--robustify` | Upgrade plain links to robust. Without it the operation is *repair* (fix robust links whose target moved). |
 | `--create-frontmatter` | *(robustify)* Allow creating frontmatter on a target that has none, so it can take a `uuid`. Opt-in on purpose. |
 | `--no-create-frontmatter-for GLOB` | *(robustify)* Basename glob whose targets **never** get a `uuid` — no block created, no line inserted — regardless of `--create-frontmatter`. Reusing a `uuid` the target already has is unaffected. Repeatable. |
-| `--exclude NAME` | Skip any directory named `NAME`. Repeatable. |
+| `--exclude PATTERN` | Skip any directory whose name matches `PATTERN` (glob / `fnmatch`, case-sensitive; a plain name matches exactly). Repeatable — e.g. `--exclude old --exclude 'old_*' --exclude '*_old'` skips the whole `old` family. |
 | `--ignore-block NAME` | Leave links inside `<!-- NAME-start --> … <!-- NAME-end -->` blocks alone. Repeatable. |
 | `--json` | Machine-readable output (see below). |
 

--- a/specs/009-glob-excludes/spec.md
+++ b/specs/009-glob-excludes/spec.md
@@ -1,0 +1,70 @@
+# Feature Specification: glob patterns in `--exclude`
+
+**Feature Branch**: `009-glob-excludes`
+
+**Created**: 2026-07-17
+
+**Status**: Draft
+
+**Input**: `--exclude` matches a directory by **exact name** only. A repo that wants to skip a *family*
+of directories (a naming convention, e.g. "ignore everything named `old`": `old`, `old_html`,
+`001_old`, `.github.old`) must list every one by hand and keep the list in sync as new ones appear —
+drift. Let `--exclude` take a **glob**.
+
+## The change
+
+`--exclude PATTERN` matches a directory name by **glob** (`fnmatch`, case-sensitive) instead of exact
+name. **Backward-compatible:** a pattern with no wildcards matches exactly, so every existing invocation
+(`--exclude node_modules`, `--exclude external_repos`) behaves identically. The glob is purely additive.
+
+```
+darnlink . --exclude 'old' --exclude 'old_*' --exclude '*_old' --exclude '*.old'   # the whole 'old' family, no drift
+```
+
+### Why word-boundary globs, not `*old*`
+
+`--exclude '*old*'` would over-match — `folder` (f-**old**-er), `holder`, `bold`. So the *pattern
+author* expresses the boundary with a small set of globs (`old`, `old_*`, `*_old`, `*.old`) rather than
+darnlink guessing intent. darnlink just does plain `fnmatch`; the boundaries live in the patterns.
+
+## Constitution Check
+
+- **P-I (Links & UUIDs Only, NON-NEGOTIABLE):** this only refines *which directories are scanned* — the
+  same knob `--exclude` already is. No new external state, no git, no document semantics. In-bounds. ✅
+- **P-III (self-contained):** nothing new stored; a CLI arg, like `ruff`/`ripgrep` globs. ✅
+- **P-IV (Deterministic):** `fnmatchcase` is case-sensitive and pure → output stays a function of the
+  tree + the patterns (no locale/OS case-folding surprises). ✅
+- No naming or scope tension — this is a straightforward capability bump to an existing flag.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001** `--exclude PATTERN` MUST skip any directory whose **name** matches PATTERN by `fnmatch`
+  (case-sensitive).
+- **FR-002** A PATTERN with no wildcard characters MUST match exactly the same directories as before
+  (backward compatibility — `--exclude node_modules` is unchanged).
+- **FR-003** Matching is on the directory **basename** only (not the path), consistent with today's
+  behaviour and with how `iter_markdown_files` prunes `os.walk`'s `dirnames`.
+- **FR-004** `DEFAULT_EXCLUDES` (plain names) MUST keep matching exactly (they contain no wildcards).
+
+### Key Entities
+
+- No new entity. `iter_markdown_files`'s prune step changes from `d not in excludes` to
+  `not any(fnmatchcase(d, pat) for pat in excludes)`.
+
+## Acceptance
+
+- `--exclude old` skips `old/` but **not** `folder/`, `bold/`, `old_html/` (exact, no wildcard).
+- `--exclude 'old_*'` skips `old_html/`, `old_impl/` but not `old/` or `holder/`.
+- `--exclude '*_old'` skips `001_old/` but not `folder/`.
+- `--exclude '*.old'` skips `.github.old/`.
+- `--exclude node_modules` behaves exactly as before (regression).
+- The four `old` globs together skip the whole family and nothing spurious (`folder/`, `holder/` stay).
+
+## Out of scope
+
+- Path/glob-star matching across separators (`**/build`) — basename-only, as today.
+- Regex excludes — globs cover the need; regex would be heavier and less familiar.
+- File-level excludes (this is directory pruning); opting a single file out is the
+  `<!-- darnlink-ignore-file -->` / `ignore-links` markers' job (spec 003/006).

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -194,7 +194,7 @@ def _run_check_cli(argv: List[str]) -> int:
         "over PATH and exit 0 (clean) / 2 (integrity) / 3 (strict). Never writes.",
     )
     parser.add_argument("path", nargs="?", default=".", help="root directory to scan (default: .)")
-    parser.add_argument("--exclude", action="append", default=[], metavar="NAME", help="directory name to skip (repeatable)")
+    parser.add_argument("--exclude", action="append", default=[], metavar="PATTERN", help="directory-name glob to skip (fnmatch, case-sensitive; a plain name matches exactly) (repeatable)")
     parser.add_argument("--ignore-block", action="append", default=[], metavar="NAME",
                         help="ignore links inside <!-- NAME-start --> … <!-- NAME-end --> blocks (repeatable)")
     parser.add_argument("--json", action="store_true", help="machine-readable output")
@@ -231,7 +231,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         "--create-frontmatter (repeatable; e.g. --no-create-frontmatter-for content.md). For files a "
         "pipeline regenerates. Reusing a uuid the target already has is unaffected.",
     )
-    parser.add_argument("--exclude", action="append", default=[], metavar="NAME", help="directory name to skip (repeatable)")
+    parser.add_argument("--exclude", action="append", default=[], metavar="PATTERN", help="directory-name glob to skip (fnmatch, case-sensitive; a plain name matches exactly) (repeatable)")
     parser.add_argument(
         "--ignore-block",
         action="append",

--- a/src/darnlink/frontmatter_index.py
+++ b/src/darnlink/frontmatter_index.py
@@ -5,6 +5,7 @@ This plain dictionary replaces the predecessor's heavy entity model
 """
 from __future__ import annotations
 
+import fnmatch
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -13,6 +14,13 @@ from typing import Dict, Iterator, List
 import frontmatter
 
 DEFAULT_EXCLUDES = {".git", "node_modules", ".venv", "__pycache__", "_build", ".tox", "dist", "build"}
+
+
+def _dir_excluded(name: str, excludes) -> bool:
+    """A directory name is excluded if it matches any pattern by glob (fnmatch, case-sensitive).
+    A pattern with no wildcards matches exactly, so plain names (`node_modules`) still work — the
+    glob is purely additive. Lets a repo exclude a family with one line, e.g. `old`, `old_*`, `*_old`."""
+    return any(fnmatch.fnmatchcase(name, pat) for pat in excludes)
 
 
 @dataclass
@@ -32,7 +40,7 @@ def iter_markdown_files(root: Path, excludes: set[str] = DEFAULT_EXCLUDES) -> It
     """Yield all `.md` files under `root`, skipping excluded directory names."""
     root = root.resolve()
     for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = [d for d in dirnames if d not in excludes]
+        dirnames[:] = [d for d in dirnames if not _dir_excluded(d, excludes)]
         for fn in filenames:
             if fn.lower().endswith(".md"):
                 yield Path(dirpath) / fn

--- a/tests/test_glob_excludes.py
+++ b/tests/test_glob_excludes.py
@@ -1,0 +1,65 @@
+"""Feature 009: `--exclude` matches directory names by glob (fnmatch), backward-compatible.
+
+Acceptance (specs/009-glob-excludes/spec.md): word-boundary `old` globs skip the family without
+over-matching `folder`/`holder`; no-wildcard patterns still match exactly.
+"""
+from pathlib import Path
+
+from darnlink.frontmatter_index import iter_markdown_files
+
+
+def _tree(root: Path, *dirs: str) -> None:
+    for d in dirs:
+        p = root / d
+        p.mkdir(parents=True, exist_ok=True)
+        (p / "x.md").write_text("# x\n", encoding="utf-8")
+
+
+def _dirs_scanned(root: Path, excludes) -> set[str]:
+    # the parent directory name of every .md that survived the exclude
+    return {p.parent.name for p in iter_markdown_files(root, set(excludes))}
+
+
+def test_exact_pattern_no_wildcard_matches_exactly(tmp_path):
+    _tree(tmp_path, "old", "folder", "bold", "old_html")
+    got = _dirs_scanned(tmp_path, {"old"})
+    assert "old" not in got                      # excluded
+    assert {"folder", "bold", "old_html"} <= got  # NOT excluded (no substring match)
+
+
+def test_prefix_glob(tmp_path):
+    _tree(tmp_path, "old", "old_html", "old_impl", "holder")
+    got = _dirs_scanned(tmp_path, {"old_*"})
+    assert "old_html" not in got and "old_impl" not in got
+    assert {"old", "holder"} <= got              # `old` (no underscore) and `holder` survive
+
+
+def test_suffix_glob(tmp_path):
+    _tree(tmp_path, "001_old", "folder", "cold")
+    got = _dirs_scanned(tmp_path, {"*_old"})
+    assert "001_old" not in got
+    assert {"folder", "cold"} <= got             # `cold` has no `_old`, `folder` unaffected
+
+
+def test_dot_suffix_glob(tmp_path):
+    _tree(tmp_path, ".github.old", "keep")
+    got = _dirs_scanned(tmp_path, {"*.old"})
+    assert ".github.old" not in got
+    assert "keep" in got
+
+
+def test_old_family_together_no_over_match(tmp_path):
+    _tree(tmp_path, "old", "old_html", "001_old", ".github.old", "old_implementation",
+          "folder", "holder", "keep")
+    got = _dirs_scanned(tmp_path, {"old", "old_*", "*_old", "*.old"})
+    # whole 'old' family gone…
+    for gone in ("old", "old_html", "001_old", ".github.old", "old_implementation"):
+        assert gone not in got
+    # …and nothing spurious
+    assert {"folder", "holder", "keep"} <= got
+
+
+def test_default_style_names_regression(tmp_path):
+    _tree(tmp_path, "node_modules", "src")
+    got = _dirs_scanned(tmp_path, {"node_modules"})
+    assert "node_modules" not in got and "src" in got


### PR DESCRIPTION
Implements spec `009-glob-excludes`. `--exclude` now matches a directory **name** by glob (`fnmatch`, case-sensitive) instead of exact name.

## Why
A repo that skips a *family* of dirs (a convention like "ignore everything named `old`": `old`, `old_html`, `001_old`, `.github.old`) had to list each by hand and keep it in sync — drift. Now: `--exclude old --exclude 'old_*' --exclude '*_old' --exclude '*.old'`. Unblocks the toolbelt `darnlink-gate` recipe for **txnet1** (its bespoke gate excluded `*old*` dynamically).

## Backward-compatible
A pattern with **no wildcards matches exactly** — every existing `--exclude NAME` is unchanged; `DEFAULT_EXCLUDES` are plain names. `--exclude old` does **not** match `folder`/`bold` (no substring surprise). Word-boundary is expressed by the pattern set, not guessed.

## Constitution
Refines *which directories are scanned* (same knob `--exclude` already is) — no git, no new state, no doc semantics. `fnmatchcase` is pure/deterministic (P-IV). In-bounds; no naming/scope tension.

## Test plan
- [x] `uv run pytest -q` → 75 passed (6 new: exact/prefix/suffix/dot-suffix, family-together no-over-match, regression)
- [x] smoke: txnet1 with `--exclude old --exclude 'old_*' --exclude '*_old' --exclude '*.old'` → repair clean

@pma — low constitution-tension one; flagging for your client/constitution review per the agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)