### PR TITLE
release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-07-17
+
 ### Added
 - **`--exclude` now takes a glob** (`fnmatch`, case-sensitive), not just an exact name — so a repo can
   skip a whole family in one declarative line instead of listing every directory and letting the list
@@ -77,7 +79,8 @@ First public release.
 - Ships a [pre-commit](https://pre-commit.com/) hook (`darnlink`, `darnlink-repair`).
 - Format specification: [FORMAT.md](FORMAT.md) <!-- uuid: 9052d864-2a45-4ed4-8725-d8a394e7a7ef -->.
 
-[Unreleased]: https://github.com/txemi/darnlink/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/txemi/darnlink/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/txemi/darnlink/releases/tag/v0.4.0
 [0.3.0]: https://github.com/txemi/darnlink/releases/tag/v0.3.0
 [0.2.0]: https://github.com/txemi/darnlink/releases/tag/v0.2.0
 [0.1.1]: https://github.com/txemi/darnlink/releases/tag/v0.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.3.0"
+version = "0.4.0"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/darnlink/__init__.py
+++ b/src/darnlink/__init__.py
@@ -8,4 +8,4 @@ Plain Markdown, no database, no editor lock-in. Dry-run by default.
 See the project Constitution in .specify/memory/constitution.md.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"


### PR DESCRIPTION
Ships glob `--exclude` (#8, spec 009) — consumers can pin `@v0.4.0` to exclude directory families (unblocks the txnet1 migration to the toolbelt `darnlink-gate` recipe). Version bump + CHANGELOG only; feature already on main and CI-green (push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)