### PR TITLE
feat(recipes): ship darnlink-gate as a public reference recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **`recipes/darnlink-gate`** — a ready-made, config-driven gate wrapper (bash + `.ps1`), shipped as a
+  **reference recipe** (not part of the CLI/package — the tool stays "links & UUIDs only"). It runs
+  **both** checks, scopes to staged files in pre-commit vs the whole repo in CI, pins the darnlink ref,
+  and fails open on network — so a repo wires darnlink into its gate with a tiny `darnlink-gate.json` +
+  a 3-line hook instead of a bespoke wrapper that drifts. It lives in the **public** repo so any CI can
+  fetch it **without a token**. See `recipes/README.md`.
+
 ## [0.4.0] — 2026-07-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ runs it for you.
 darnlink **exits non-zero** when a robust link is broken, so any gate that runs it will block the
 breakage before it lands. Pick the one that fits your workflow — near copy-paste:
 
+> **Want a ready-made wrapper instead of wiring it yourself?** [`recipes/darnlink-gate`](recipes/README.md)
+> does all of the below (both checks, staged-in-pre-commit vs whole-repo-in-CI, pinned ref, fail-open)
+> from a tiny `darnlink-gate.json`. It's a reference recipe, fetchable in CI without a token.
+
 **1. pre-commit** (recommended — darnlink ships a hook):
 
 ```yaml

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -10,8 +10,9 @@ is that orchestration in one place; a consumer carries only a tiny config + a 3-
 ## What it does (read-only — never writes)
 
 - Runs darnlink at a **pinned ref** (deterministic).
-- `mode=check` → `darnlink check` (**both** axes: integrity + strict, exit `0/2/3`).
-  `mode=repair` → `darnlink .` (integrity only — for repos that don't robustify their links yet).
+- Always runs `darnlink check` (**both** axes, stable exit `0/2/3`); `mode` only picks which axes gate:
+  `mode=check` → integrity + strict both gate. `mode=repair` → **integrity only** — a strict-only
+  failure (`3`) is treated as clean (for repos that don't robustify their links yet).
 - `scope=repo` → judge the whole tree (**the wall — use in CI**).
   `scope=staged` → judge only the files you're committing (**multi-session pre-commit**, so a
   teammate's in-flight plain link doesn't block your commit). It filters `darnlink check --json` by

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -1,0 +1,76 @@
+# darnlink-gate — the one generic darnlink quality-gate recipe
+
+The **`darnlink-gate`** script here (+ `.ps1` for Windows) is the **single** orchestration around
+[darnlink](https://github.com/txemi/darnlink) for every repo that uses it. darnlink itself is a pure
+link tool — it checks and reports, and deliberately knows nothing about gates, git, excludes-policy,
+or CI (its Constitution). All that orchestration used to be copy-pasted into each repo's `*_gate.sh`
+and drifted (the "strict ⊇ repair" myth, `ignore-file` vs `ignore-links`, un-pinned refs). This recipe
+is that orchestration in one place; a consumer carries only a tiny config + a 3-line hook.
+
+## What it does (read-only — never writes)
+
+- Runs darnlink at a **pinned ref** (deterministic).
+- `mode=check` → `darnlink check` (**both** axes: integrity + strict, exit `0/2/3`).
+  `mode=repair` → `darnlink .` (integrity only — for repos that don't robustify their links yet).
+- `scope=repo` → judge the whole tree (**the wall — use in CI**).
+  `scope=staged` → judge only the files you're committing (**multi-session pre-commit**, so a
+  teammate's in-flight plain link doesn't block your commit). It filters `darnlink check --json` by
+  `git diff --cached` — **darnlink stays git-agnostic; the git lives here** (darnlink spec 008,
+  Option B).
+- Fails **open** on a network/uvx error (offline commits aren't bricked; CI is the backstop).
+- **Refuses `--write`** (this gate never mutates; robustify by hand).
+
+Exit: `0` clean · `2` integrity failure · `3` strict-only failure · `1` usage.
+
+## Adopt it in a repo (3 pieces)
+
+**1. Config** — `darnlink-gate.json` at the repo root (all keys optional):
+
+```json
+{
+  "ref": "git+https://github.com/txemi/darnlink@v0.4.0",
+  "excludes": ["secrets", "external_repos"],
+  "ignore_blocks": ["txmd-autogrid"],
+  "mode": "check",
+  "scope": "repo"
+}
+```
+
+**2. Pre-commit** — a 3-line `conf.d` fragment (staged scope, so parallel sessions don't block each
+other; the repo-wide wall stays in CI):
+
+```bash
+#!/usr/bin/env bash
+# hooks/pre-commit.d/NN-darnlink
+exec env DARNLINK_GATE_SCOPE=staged darnlink-gate
+```
+
+**3. CI** (GitHub Actions / Jenkins) — the wall, whole-repo:
+
+```yaml
+- uses: astral-sh/setup-uv@v5
+- run: darnlink-gate            # scope=repo from config
+```
+
+**Getting the script.** It lives here — `recipes/darnlink-gate` in the **public** darnlink repo — so
+any CI can fetch it **without a token** (no private checkout, no cred):
+
+```bash
+curl -sSL https://raw.githubusercontent.com/txemi/darnlink/v0.4.0/recipes/darnlink-gate -o darnlink-gate
+chmod +x darnlink-gate
+```
+
+Pin the tag (`v0.4.0`) so the gate is deterministic. Windows agents fetch `darnlink-gate.ps1` the same
+way. Locally, drop it on your `PATH` (e.g. `~/.local/bin`).
+
+## Notes
+
+- **Generated files** are handled by the `<!-- darnlink-ignore-links -->` marker (emitted by the
+  generator), **not** by this recipe — the recipe never lists files. See darnlink `FORMAT.md §5`.
+- Per-repo differences (ref, excludes, mode, scope) live entirely in `darnlink-gate.json`; the logic
+  is identical everywhere. When darnlink changes a recommendation, fix it **here**, not in N repos.
+- Supersedes the old per-repo `tools/darnlink_gate.sh` / `scripts/darnlink_gate.ps1` /
+  `darnlink_robustness_check.py` wrappers each repo used to carry.
+- **This is a reference recipe, not part of the darnlink CLI/package.** The tool itself stays "links &
+  UUIDs only" (its Constitution); this script only *orchestrates* it (pinned ref, both checks, staged
+  scope, fail-open). darnlink `check`s; the recipe wires it into your gate.

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -28,7 +28,7 @@ Exit: `0` clean · `2` integrity failure · `3` strict-only failure · `1` usage
 
 ```json
 {
-  "ref": "git+https://github.com/txemi/darnlink@v0.4.0",
+  "ref": "git+https://github.com/txemi/darnlink@v0.5.0",
   "excludes": ["secrets", "external_repos"],
   "ignore_blocks": ["txmd-autogrid"],
   "mode": "check",
@@ -56,11 +56,11 @@ exec env DARNLINK_GATE_SCOPE=staged darnlink-gate
 any CI can fetch it **without a token** (no private checkout, no cred):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/txemi/darnlink/v0.4.0/recipes/darnlink-gate -o darnlink-gate
+curl -sSL https://raw.githubusercontent.com/txemi/darnlink/v0.5.0/recipes/darnlink-gate -o darnlink-gate
 chmod +x darnlink-gate
 ```
 
-Pin the tag (`v0.4.0`) so the gate is deterministic. Windows agents fetch `darnlink-gate.ps1` the same
+Pin the tag (`v0.5.0`) so the gate is deterministic. Windows agents fetch `darnlink-gate.ps1` the same
 way. Locally, drop it on your `PATH` (e.g. `~/.local/bin`).
 
 ## Notes

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# darnlink-gate — the ONE generic darnlink quality-gate recipe for every repo that uses darnlink.
+#
+# WHY THIS EXISTS. darnlink is a pure link tool (it checks/reports; it deliberately knows nothing
+# about gates, git, excludes-policy, or CI — see its Constitution). Every consumer repo needs the
+# SAME orchestration around it, and until now each repo re-implemented it in its own `*_gate.sh`,
+# so the wrappers drifted (the "strict ⊇ repair" myth, ignore-file vs ignore-links, un-pinned refs).
+# This is that orchestration in ONE place. A consumer repo carries only a tiny config + a 3-line hook.
+#
+# WHAT IT DOES (all read-only — it never writes):
+#   • bootstraps uv/uvx if missing;
+#   • runs darnlink at a PINNED ref (deterministic);
+#   • mode=check  → `darnlink check` (BOTH axes: integrity + strict, exit 0/2/3);
+#     mode=repair → `darnlink .`     (integrity only — for repos that don't robustify yet);
+#   • scope=repo  → judge the whole tree (the wall — use in CI);
+#     scope=staged→ judge only the files you're committing (use in a multi-session pre-commit, so a
+#                   teammate's in-flight plain link doesn't block your commit). The repo-wide wall
+#                   stays in CI. [Option B of darnlink spec 008: git lives HERE, not in darnlink.]
+#   • fails OPEN on a network/uvx error (offline commit isn't bricked; CI is the backstop).
+#
+# CONFIG. Reads `darnlink-gate.json` at the repo root (all keys optional):
+#   { "ref": "git+https://github.com/txemi/darnlink@v0.4.0",
+#     "excludes": ["secrets","external_repos"], "ignore_blocks": ["txmd-autogrid"],
+#     "mode": "check", "scope": "repo" }
+# Env overrides (so one config serves both surfaces): DARNLINK_REF, DARNLINK_GATE_MODE,
+# DARNLINK_GATE_SCOPE. Typical wiring: config says scope=repo; the pre-commit hook exports
+# DARNLINK_GATE_SCOPE=staged; CI leaves it repo.
+#
+# EXIT: 0 clean · 2 integrity failure · 3 strict-only failure · 1 usage · 0 (warn) on fail-open.
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cfg="$root/darnlink-gate.json"
+
+# --- read config (JSON, all optional) via python; env wins over file ---
+read_cfg() { python3 - "$cfg" "$1" "$2" <<'PY' 2>/dev/null || printf '%s' "$2"
+import json, sys
+cfg, key, default = sys.argv[1], sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else ""
+try:
+    d = json.load(open(cfg, encoding="utf-8"))
+except Exception:
+    d = {}
+v = d.get(key, default)
+print("\n".join(v) if isinstance(v, list) else (v if v is not None else default))
+PY
+}
+
+REF="${DARNLINK_REF:-$(read_cfg ref 'git+https://github.com/txemi/darnlink@v0.4.0')}"
+MODE="${DARNLINK_GATE_MODE:-$(read_cfg mode check)}"
+SCOPE="${DARNLINK_GATE_SCOPE:-$(read_cfg scope repo)}"
+mapfile -t EXCLUDES < <(read_cfg excludes "")
+mapfile -t IGNORE_BLOCKS < <(read_cfg ignore_blocks "")
+
+# --- guard: this recipe is READ-ONLY. Never let a --write slip through it. ---
+for a in "$@"; do
+  case "$a" in
+    --write) echo "darnlink-gate: refusing --write (this gate is read-only; robustify by hand: 'uvx --from $REF darnlink . --robustify --write')." >&2; exit 1;;
+  esac
+done
+
+# --- build darnlink args (excludes + ignore-blocks) ---
+DL_ARGS=()
+for e in "${EXCLUDES[@]}";      do [ -n "$e" ] && DL_ARGS+=(--exclude "$e"); done
+for b in "${IGNORE_BLOCKS[@]}"; do [ -n "$b" ] && DL_ARGS+=(--ignore-block "$b"); done
+
+# --- fail OPEN if uv/uvx unreachable (don't brick offline commits; CI covers it) ---
+if ! command -v uvx >/dev/null 2>&1; then
+  echo "darnlink-gate: uvx not found → SKIP (install uv; CI covers the wall)." >&2
+  exit 0
+fi
+
+cd "$root"
+run() { uvx --from "$REF" darnlink "$@"; }   # single source of the darnlink invocation
+
+# Pre-flight: can uvx actually BUILD+RUN darnlink at this ref? darnlink's own exit codes (0/1/2/3)
+# overlap a uvx fetch failure (bad ref / no network also exits low), so we can't tell "darnlink ran
+# and found issues" from "couldn't run darnlink" by the check's exit code alone. `--help` runs iff
+# darnlink is reachable. If it isn't → fail OPEN (don't brick a commit; CI covers the wall).
+if ! run --help >/dev/null 2>&1; then
+  echo "darnlink-gate: can't run darnlink at $REF (bad ref / no network) → SKIP; CI covers the wall." >&2
+  exit 0
+fi
+
+if [ "$SCOPE" != "staged" ]; then
+  # ---- whole-repo (the wall). darnlink's own exit code is the gate. ----
+  # set +e around the run: darnlink exits 0/1/2/3 (findings ARE non-zero) — set -e must not kill us
+  # before we read rc and run the rc>3 fail-open.
+  set +e
+  if [ "$MODE" = "repair" ]; then run . "${DL_ARGS[@]}"; else run check . "${DL_ARGS[@]}"; fi
+  rc=$?
+  set -e
+  # rc>3 (e.g. 127 network) → fail open + warn; darnlink's own 0/1/2/3 pass through.
+  if [ "$rc" -gt 3 ]; then echo "darnlink-gate: darnlink unreachable (rc=$rc) → SKIP; CI covers it." >&2; exit 0; fi
+  exit "$rc"
+fi
+
+# ---- staged scope (Option B): darnlink judges the whole tree; WE filter findings to staged files.
+#      darnlink stays git-agnostic; the git lives here. Only fail on findings in files you're committing.
+# python3 does the filtering — fail OPEN if it's missing (don't brick a commit; CI covers the wall).
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "darnlink-gate (staged): python3 not found → SKIP; CI covers the wall." >&2; exit 0
+fi
+mapfile -t STAGED < <(git diff --cached --name-only --diff-filter=ACMR -- '*.md' 2>/dev/null || true)
+[ "${#STAGED[@]}" -eq 0 ] && { echo "darnlink-gate (staged): no staged .md — nothing to judge."; exit 0; }
+
+# darnlink check exits 0/2/3 on findings (expected — we still get JSON); only rc>3 (e.g. 127) is
+# "unreachable". Don't let set -e or a findings-exit trip the fail-open path.
+set +e
+DL_JSON="$(run check . --json "${DL_ARGS[@]}" 2>/dev/null)"; rc=$?
+set -e
+if [ "$rc" -gt 3 ] || [ -z "$DL_JSON" ]; then
+  echo "darnlink-gate (staged): darnlink unreachable (rc=$rc) → SKIP; CI covers the wall." >&2; exit 0
+fi
+export DL_JSON DL_ROOT="$root" DL_REF="$REF"
+export DL_STAGED="$(printf '%s\n' "${STAGED[@]}")"
+
+# Pass everything via env (no interpolation into the script → no injection from finding text).
+python3 <<'PY'
+import json, os, sys
+root = os.environ["DL_ROOT"]
+staged = {os.path.normpath(os.path.join(root, p)) for p in os.environ["DL_STAGED"].split("\n") if p.strip()}
+data = json.loads(os.environ["DL_JSON"])
+def hits(axis):
+    return [f for f in data.get(axis, {}).get("findings", []) if os.path.normpath(f["file"]) in staged]
+integ, strict = hits("integrity"), hits("strict")
+for f in integ:  print(f"  [integrity/{f['kind']}] {f['file']}: {f['detail']}")
+for f in strict: print(f"  [strict/{f['kind']}] {f['file']}: {f['detail']}")
+if integ:  print("darnlink-gate (staged): integrity failure in a file you're committing."); sys.exit(2)
+if strict: print("darnlink-gate (staged): un-anchored plain link in a file you're committing "
+                 f"(anchor it: uvx --from {os.environ['DL_REF']} darnlink . --robustify --write)."); sys.exit(3)
+print("darnlink-gate (staged): clean."); sys.exit(0)
+PY

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -8,10 +8,11 @@
 # This is that orchestration in ONE place. A consumer repo carries only a tiny config + a 3-line hook.
 #
 # WHAT IT DOES (all read-only — it never writes):
-#   • bootstraps uv/uvx if missing;
-#   • runs darnlink at a PINNED ref (deterministic);
-#   • mode=check  → `darnlink check` (BOTH axes: integrity + strict, exit 0/2/3);
-#     mode=repair → `darnlink .`     (integrity only — for repos that don't robustify yet);
+#   • runs darnlink at a PINNED ref (deterministic); fails OPEN if uv/uvx is missing (never bootstraps);
+#   • ALWAYS runs `darnlink check` (stable 0/2/3 contract); MODE only picks which axes gate:
+#     mode=check  → integrity + strict both gate (exit 0/2/3);
+#     mode=repair → integrity only — a strict-only failure (3) is treated as clean (for repos that
+#                   don't robustify their links yet);
 #   • scope=repo  → judge the whole tree (the wall — use in CI);
 #     scope=staged→ judge only the files you're committing (use in a multi-session pre-commit, so a
 #                   teammate's in-flight plain link doesn't block your commit). The repo-wide wall
@@ -86,11 +87,13 @@ if [ "$SCOPE" != "staged" ]; then
   # set +e around the run: darnlink exits 0/1/2/3 (findings ARE non-zero) — set -e must not kill us
   # before we read rc and run the rc>3 fail-open.
   set +e
-  if [ "$MODE" = "repair" ]; then run . "${DL_ARGS[@]}"; else run check . "${DL_ARGS[@]}"; fi
+  run check . "${DL_ARGS[@]}"        # always `check` → stable 0/2/3 contract, regardless of MODE
   rc=$?
   set -e
-  # rc>3 (e.g. 127 network) → fail open + warn; darnlink's own 0/1/2/3 pass through.
+  # rc>3 (e.g. 127 network) → fail open + warn; darnlink's own 0/2/3 pass through.
   if [ "$rc" -gt 3 ]; then echo "darnlink-gate: darnlink unreachable (rc=$rc) → SKIP; CI covers it." >&2; exit 0; fi
+  # mode=repair gates on integrity only: a strict-only failure (3) is clean.
+  if [ "$MODE" = "repair" ] && [ "$rc" -eq 3 ]; then exit 0; fi
   exit "$rc"
 fi
 
@@ -111,18 +114,21 @@ set -e
 if [ "$rc" -gt 3 ] || [ -z "$DL_JSON" ]; then
   echo "darnlink-gate (staged): darnlink unreachable (rc=$rc) → SKIP; CI covers the wall." >&2; exit 0
 fi
-export DL_JSON DL_ROOT="$root" DL_REF="$REF"
+export DL_JSON DL_ROOT="$root" DL_REF="$REF" DL_MODE="$MODE"
 export DL_STAGED="$(printf '%s\n' "${STAGED[@]}")"
 
 # Pass everything via env (no interpolation into the script → no injection from finding text).
 python3 <<'PY'
 import json, os, sys
 root = os.environ["DL_ROOT"]
-staged = {os.path.normpath(os.path.join(root, p)) for p in os.environ["DL_STAGED"].split("\n") if p.strip()}
+mode = os.environ.get("DL_MODE", "check")
+# realpath both sides: darnlink emits resolved absolute paths, so resolve symlinks here too to match.
+staged = {os.path.realpath(os.path.join(root, p)) for p in os.environ["DL_STAGED"].split("\n") if p.strip()}
 data = json.loads(os.environ["DL_JSON"])
 def hits(axis):
-    return [f for f in data.get(axis, {}).get("findings", []) if os.path.normpath(f["file"]) in staged]
-integ, strict = hits("integrity"), hits("strict")
+    return [f for f in data.get(axis, {}).get("findings", []) if os.path.realpath(f["file"]) in staged]
+integ = hits("integrity")
+strict = [] if mode == "repair" else hits("strict")   # mode=repair gates on integrity only
 for f in integ:  print(f"  [integrity/{f['kind']}] {f['file']}: {f['detail']}")
 for f in strict: print(f"  [strict/{f['kind']}] {f['file']}: {f['detail']}")
 if integ:  print("darnlink-gate (staged): integrity failure in a file you're committing."); sys.exit(2)

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -19,7 +19,7 @@
 #   • fails OPEN on a network/uvx error (offline commit isn't bricked; CI is the backstop).
 #
 # CONFIG. Reads `darnlink-gate.json` at the repo root (all keys optional):
-#   { "ref": "git+https://github.com/txemi/darnlink@v0.4.0",
+#   { "ref": "git+https://github.com/txemi/darnlink@v0.5.0",
 #     "excludes": ["secrets","external_repos"], "ignore_blocks": ["txmd-autogrid"],
 #     "mode": "check", "scope": "repo" }
 # Env overrides (so one config serves both surfaces): DARNLINK_REF, DARNLINK_GATE_MODE,
@@ -45,7 +45,7 @@ print("\n".join(v) if isinstance(v, list) else (v if v is not None else default)
 PY
 }
 
-REF="${DARNLINK_REF:-$(read_cfg ref 'git+https://github.com/txemi/darnlink@v0.4.0')}"
+REF="${DARNLINK_REF:-$(read_cfg ref 'git+https://github.com/txemi/darnlink@v0.5.0')}"
 MODE="${DARNLINK_GATE_MODE:-$(read_cfg mode check)}"
 SCOPE="${DARNLINK_GATE_SCOPE:-$(read_cfg scope repo)}"
 mapfile -t EXCLUDES < <(read_cfg excludes "")

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -18,7 +18,7 @@ $cfgPath = Join-Path $root "darnlink-gate.json"
 if (Test-Path $cfgPath) { try { $cfg = Get-Content $cfgPath -Raw | ConvertFrom-Json } catch { $cfg = @{} } }
 function CfgOr($key, $default) { if ($cfg.$key) { return $cfg.$key } else { return $default } }
 
-$ref   = if ($env:DARNLINK_REF)        { $env:DARNLINK_REF }        else { CfgOr 'ref' 'git+https://github.com/txemi/darnlink@v0.4.0' }
+$ref   = if ($env:DARNLINK_REF)        { $env:DARNLINK_REF }        else { CfgOr 'ref' 'git+https://github.com/txemi/darnlink@v0.5.0' }
 $mode  = if ($env:DARNLINK_GATE_MODE)  { $env:DARNLINK_GATE_MODE }  else { CfgOr 'mode' 'check' }
 $scope = if ($env:DARNLINK_GATE_SCOPE) { $env:DARNLINK_GATE_SCOPE } else { CfgOr 'scope' 'repo' }
 $excludes     = @(CfgOr 'excludes' @())

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -2,9 +2,10 @@
 #
 # See the bash version for the full rationale. Same contract: read-only; config in darnlink-gate.json
 # (ref/excludes/ignore_blocks/mode/scope) with env overrides (DARNLINK_REF, DARNLINK_GATE_MODE,
-# DARNLINK_GATE_SCOPE); mode=check → `darnlink check` (both axes, 0/2/3), mode=repair → integrity only;
-# scope=staged filters `darnlink check --json` by `git diff --cached` (Option B — darnlink stays
-# git-agnostic); fail-open on network; refuses --write. Exit 0/2/3/1.
+# DARNLINK_GATE_SCOPE). It ALWAYS runs `darnlink check` (stable 0/2/3 contract); MODE only picks which
+# axes gate: mode=check → integrity + strict both gate; mode=repair → integrity only (a strict-only
+# failure, 3, is treated as clean). scope=staged filters `darnlink check --json` by `git diff --cached`
+# (Option B — darnlink stays git-agnostic); fail-open on network; refuses --write. Exit 0/2/3/1.
 $ErrorActionPreference = "Stop"
 
 $root = (git rev-parse --show-toplevel 2>$null)
@@ -48,10 +49,11 @@ if ($LASTEXITCODE -ne 0) { Write-Warning "darnlink-gate: can't run darnlink at $
 
 if ($scope -ne 'staged') {
   # ---- whole-repo (the wall): darnlink's own exit code is the gate ----
-  if ($mode -eq 'repair') { & uvx --from $ref darnlink . @dlArgs @args }
-  else                    { & uvx --from $ref darnlink check . @dlArgs @args }
+  & uvx --from $ref darnlink check . @dlArgs @args   # always `check` → stable 0/2/3, regardless of MODE
   $rc = $LASTEXITCODE
   if ($rc -gt 3) { Write-Warning "darnlink-gate: darnlink unreachable (rc=$rc) -> SKIP; CI covers it."; exit 0 }
+  # mode=repair gates on integrity only: a strict-only failure (3) is clean.
+  if ($mode -eq 'repair' -and $rc -eq 3) { exit 0 }
   exit $rc
 }
 
@@ -68,7 +70,7 @@ $stagedSet = [System.Collections.Generic.HashSet[string]]::new()
 foreach ($p in $staged) { [void]$stagedSet.Add(([IO.Path]::GetFullPath((Join-Path $root $p)))) }
 function Hits($axis) { @($data.$axis.findings | Where-Object { $stagedSet.Contains(([IO.Path]::GetFullPath($_.file))) }) }
 $integ  = Hits 'integrity'
-$strict = Hits 'strict'
+$strict = if ($mode -eq 'repair') { @() } else { Hits 'strict' }   # mode=repair gates on integrity only
 foreach ($f in $integ)  { Write-Output "  [integrity/$($f.kind)] $($f.file): $($f.detail)" }
 foreach ($f in $strict) { Write-Output "  [strict/$($f.kind)] $($f.file): $($f.detail)" }
 if ($integ)  { Write-Output "darnlink-gate (staged): integrity failure in a file you're committing."; exit 2 }

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -1,0 +1,76 @@
+# darnlink-gate.ps1 — Windows sibling of scripts/darnlink-gate (same generic darnlink quality-gate).
+#
+# See the bash version for the full rationale. Same contract: read-only; config in darnlink-gate.json
+# (ref/excludes/ignore_blocks/mode/scope) with env overrides (DARNLINK_REF, DARNLINK_GATE_MODE,
+# DARNLINK_GATE_SCOPE); mode=check → `darnlink check` (both axes, 0/2/3), mode=repair → integrity only;
+# scope=staged filters `darnlink check --json` by `git diff --cached` (Option B — darnlink stays
+# git-agnostic); fail-open on network; refuses --write. Exit 0/2/3/1.
+$ErrorActionPreference = "Stop"
+
+$root = (git rev-parse --show-toplevel 2>$null)
+if (-not $root) { $root = (Get-Location).Path }
+$root = $root.Trim()
+Set-Location $root
+
+# --- config (JSON, all optional); env wins over file ---
+$cfg = @{}
+$cfgPath = Join-Path $root "darnlink-gate.json"
+if (Test-Path $cfgPath) { try { $cfg = Get-Content $cfgPath -Raw | ConvertFrom-Json } catch { $cfg = @{} } }
+function CfgOr($key, $default) { if ($cfg.$key) { return $cfg.$key } else { return $default } }
+
+$ref   = if ($env:DARNLINK_REF)        { $env:DARNLINK_REF }        else { CfgOr 'ref' 'git+https://github.com/txemi/darnlink@v0.4.0' }
+$mode  = if ($env:DARNLINK_GATE_MODE)  { $env:DARNLINK_GATE_MODE }  else { CfgOr 'mode' 'check' }
+$scope = if ($env:DARNLINK_GATE_SCOPE) { $env:DARNLINK_GATE_SCOPE } else { CfgOr 'scope' 'repo' }
+$excludes     = @(CfgOr 'excludes' @())
+$ignoreBlocks = @(CfgOr 'ignore_blocks' @())
+
+# --- guard: read-only. Never pass --write through. ---
+if ($args -contains '--write') {
+  Write-Error "darnlink-gate: refusing --write (read-only gate; robustify by hand: uvx --from $ref darnlink . --robustify --write)."
+  exit 1
+}
+
+# --- ensure uvx (installer leaves it in ~\.local\bin); fail OPEN if absent ---
+if (-not (Get-Command uvx -ErrorAction SilentlyContinue)) {
+  $uvBin = Join-Path $env:USERPROFILE ".local\bin"
+  if (Test-Path (Join-Path $uvBin "uvx.exe")) { $env:Path = "$uvBin;$env:Path" }
+  else { Write-Warning "darnlink-gate: uvx not found -> SKIP (install uv; CI covers the wall)."; exit 0 }
+}
+
+$dlArgs = @()
+foreach ($e in $excludes)     { if ($e) { $dlArgs += @('--exclude', $e) } }
+foreach ($b in $ignoreBlocks) { if ($b) { $dlArgs += @('--ignore-block', $b) } }
+
+# Pre-flight: can uvx BUILD+RUN darnlink at this ref? darnlink's exit codes (0/1/2/3) overlap a uvx
+# fetch failure, so confirm reachability first; if not -> fail OPEN (don't brick a commit; CI covers it).
+& uvx --from $ref darnlink --help *> $null
+if ($LASTEXITCODE -ne 0) { Write-Warning "darnlink-gate: can't run darnlink at $ref (bad ref / no network) -> SKIP; CI covers the wall."; exit 0 }
+
+if ($scope -ne 'staged') {
+  # ---- whole-repo (the wall): darnlink's own exit code is the gate ----
+  if ($mode -eq 'repair') { & uvx --from $ref darnlink . @dlArgs @args }
+  else                    { & uvx --from $ref darnlink check . @dlArgs @args }
+  $rc = $LASTEXITCODE
+  if ($rc -gt 3) { Write-Warning "darnlink-gate: darnlink unreachable (rc=$rc) -> SKIP; CI covers it."; exit 0 }
+  exit $rc
+}
+
+# ---- staged scope (Option B): darnlink judges the whole tree; WE filter findings to staged files ----
+$staged = @(git diff --cached --name-only --diff-filter=ACMR -- '*.md' 2>$null)
+if (-not $staged) { Write-Output "darnlink-gate (staged): no staged .md — nothing to judge."; exit 0 }
+
+$json = (& uvx --from $ref darnlink check . --json @dlArgs 2>$null | Out-String)
+$rc = $LASTEXITCODE
+if ($rc -gt 3 -or -not $json.Trim()) { Write-Warning "darnlink-gate (staged): darnlink unreachable (rc=$rc) -> SKIP; CI covers the wall."; exit 0 }
+
+$data = $json | ConvertFrom-Json
+$stagedSet = [System.Collections.Generic.HashSet[string]]::new()
+foreach ($p in $staged) { [void]$stagedSet.Add(([IO.Path]::GetFullPath((Join-Path $root $p)))) }
+function Hits($axis) { @($data.$axis.findings | Where-Object { $stagedSet.Contains(([IO.Path]::GetFullPath($_.file))) }) }
+$integ  = Hits 'integrity'
+$strict = Hits 'strict'
+foreach ($f in $integ)  { Write-Output "  [integrity/$($f.kind)] $($f.file): $($f.detail)" }
+foreach ($f in $strict) { Write-Output "  [strict/$($f.kind)] $($f.file): $($f.detail)" }
+if ($integ)  { Write-Output "darnlink-gate (staged): integrity failure in a file you're committing."; exit 2 }
+if ($strict) { Write-Output "darnlink-gate (staged): un-anchored plain link in a file you're committing (anchor it: uvx --from $ref darnlink . --robustify --write)."; exit 3 }
+Write-Output "darnlink-gate (staged): clean."; exit 0


### PR DESCRIPTION
Promotes the generic `darnlink-gate` wrapper (bash + `.ps1`) from the **private** toolbelt into `recipes/` in the **public** darnlink repo, so any consumer CI can fetch it **without a token** (fresh CI runners can't reach a private repo; immich is public and can't use a cred).

## Why public / why here
- The recipe is the recommended way to wire darnlink into a repo's gate. Consumers already use the public darnlink; shipping the recipe alongside it makes darnlink **self-contained/self-explanatory**.
- **Constitution:** this is a **reference recipe, NOT part of the CLI/package** — the tool stays "links & UUIDs only"; the script only *orchestrates* darnlink. (Reopens the earlier "orchestration→toolbelt" call; txemi's decision as the tool owner. @pma flagging for your constitution view — is `recipes/` an acceptable reference artifact, core untouched?)

## What
- `recipes/darnlink-gate` (+ `.ps1`) — self-contained (no toolbelt deps), default ref `@v0.4.0`.
- `recipes/README.md` — adoption + the credless CI fetch (`curl .../darnlink/v0.4.0/recipes/darnlink-gate`).
- README pointer + CHANGELOG.

## Test plan
- [x] dogfood `darnlink .` + `--robustify` clean with `recipes/` present
- [x] recipe self-contained (no `source` of toolbelt; only uvx/git/python3)

Follow-ups (separate PRs): toolbelt keeps a **pointer** here + drops its copy; consumers migrate to fetch from here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)