### PR TITLE
feat(recipes): fail-closed mode for CI — a network failure no longer gives a green build with nothing validated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **`recipes/darnlink-gate`: modo FAIL-CLOSED** (`DARNLINK_GATE_FAIL_CLOSED=1`, o `"fail_closed": true`
+  en `darnlink-gate.json`). La receta falla **abierta** por defecto —correcto en pre-commit: un commit
+  offline no debe quedar bloqueado— pero eso **en CI es peligroso**: el gate *es* el muro, y un fallo
+  transitorio de red/PyPI daba **build VERDE con cero ficheros validados**. Con el flag, esos casos
+  salen con código **4** (distinguible de los hallazgos: `2` integridad, `3` strict). Actívalo siempre
+  en CI. Detectado por una revisión adversarial de la propia receta.
+
 ## [0.5.0] — 2026-07-18
 
 ### Added

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -17,17 +17,22 @@
 #     scope=staged→ judge only the files you're committing (use in a multi-session pre-commit, so a
 #                   teammate's in-flight plain link doesn't block your commit). The repo-wide wall
 #                   stays in CI. [Option B of darnlink spec 008: git lives HERE, not in darnlink.]
-#   • fails OPEN on a network/uvx error (offline commit isn't bricked; CI is the backstop).
+#   • fails OPEN on a network/uvx error (offline commit isn't bricked) — UNLESS fail-closed is on.
+#     ⚠️ FAIL-CLOSED (`DARNLINK_GATE_FAIL_CLOSED=1`, o `"fail_closed": true` en el json): en CI el gate
+#     ES el muro, y fallar abierto ahi significa BUILD VERDE CON CERO FICHEROS VALIDADOS ante un
+#     fallo transitorio de red/PyPI. Actívalo SIEMPRE en CI. Sale con codigo 4 (distinguible de los
+#     hallazgos: 2 integridad / 3 strict).
 #
 # CONFIG. Reads `darnlink-gate.json` at the repo root (all keys optional):
 #   { "ref": "git+https://github.com/txemi/darnlink@v0.5.0",
 #     "excludes": ["secrets","external_repos"], "ignore_blocks": ["txmd-autogrid"],
 #     "mode": "check", "scope": "repo" }
 # Env overrides (so one config serves both surfaces): DARNLINK_REF, DARNLINK_GATE_MODE,
-# DARNLINK_GATE_SCOPE. Typical wiring: config says scope=repo; the pre-commit hook exports
-# DARNLINK_GATE_SCOPE=staged; CI leaves it repo.
+# DARNLINK_GATE_SCOPE, DARNLINK_GATE_FAIL_CLOSED. Typical wiring: config says scope=repo; el hook de
+# pre-commit exporta DARNLINK_GATE_SCOPE=staged; el CI deja repo y pone FAIL_CLOSED=1.
 #
-# EXIT: 0 clean · 2 integrity failure · 3 strict-only failure · 1 usage · 0 (warn) on fail-open.
+# EXIT: 0 clean · 2 integrity failure · 3 strict-only failure · 1 usage · 4 no se pudo gatear
+#       (con fail-closed) · 0 + aviso a stderr si se salta (fail-open, el default).
 set -euo pipefail
 
 root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -49,6 +54,10 @@ PY
 REF="${DARNLINK_REF:-$(read_cfg ref 'git+https://github.com/txemi/darnlink@v0.5.0')}"
 MODE="${DARNLINK_GATE_MODE:-$(read_cfg mode check)}"
 SCOPE="${DARNLINK_GATE_SCOPE:-$(read_cfg scope repo)}"
+# FAIL-CLOSED: por defecto esta receta falla ABIERTA (no brickear un commit offline; ver abajo). Eso
+# es correcto en pre-commit y PELIGROSO en CI: alli el gate ES el muro, y un fallo transitorio de red
+# o de PyPI daria build VERDE con cero ficheros validados. Ponlo a 1 en CI.
+FAIL_CLOSED="${DARNLINK_GATE_FAIL_CLOSED:-$(read_cfg fail_closed "")}"
 mapfile -t EXCLUDES < <(read_cfg excludes "")
 mapfile -t IGNORE_BLOCKS < <(read_cfg ignore_blocks "")
 
@@ -59,16 +68,24 @@ for a in "$@"; do
   esac
 done
 
+# Un unico sitio decide que hacer cuando NO se ha podido gatear: saltar (default, pre-commit) o
+# abortar en rojo (CI). Nunca "verde sin validar", que es el fallo silencioso caro.
+bail() {  # $1 = motivo
+  if [ -n "$FAIL_CLOSED" ] && [ "$FAIL_CLOSED" != "0" ]; then
+    echo "darnlink-gate: $1 -> FALLO (fail-closed activo: no se ha validado nada)." >&2
+    exit 4
+  fi
+  echo "darnlink-gate: $1 -> SKIP (fail-open; el CI cubre el muro)." >&2
+  exit 0
+}
+
 # --- build darnlink args (excludes + ignore-blocks) ---
 DL_ARGS=()
 for e in "${EXCLUDES[@]}";      do [ -n "$e" ] && DL_ARGS+=(--exclude "$e"); done
 for b in "${IGNORE_BLOCKS[@]}"; do [ -n "$b" ] && DL_ARGS+=(--ignore-block "$b"); done
 
 # --- fail OPEN if uv/uvx unreachable (don't brick offline commits; CI covers it) ---
-if ! command -v uvx >/dev/null 2>&1; then
-  echo "darnlink-gate: uvx not found → SKIP (install uv; CI covers the wall)." >&2
-  exit 0
-fi
+if ! command -v uvx >/dev/null 2>&1; then bail "uvx no esta instalado"; fi
 
 cd "$root"
 run() { uvx --from "$REF" darnlink "$@"; }   # single source of the darnlink invocation
@@ -77,10 +94,7 @@ run() { uvx --from "$REF" darnlink "$@"; }   # single source of the darnlink inv
 # overlap a uvx fetch failure (bad ref / no network also exits low), so we can't tell "darnlink ran
 # and found issues" from "couldn't run darnlink" by the check's exit code alone. `--help` runs iff
 # darnlink is reachable. If it isn't → fail OPEN (don't brick a commit; CI covers the wall).
-if ! run --help >/dev/null 2>&1; then
-  echo "darnlink-gate: can't run darnlink at $REF (bad ref / no network) → SKIP; CI covers the wall." >&2
-  exit 0
-fi
+if ! run --help >/dev/null 2>&1; then bail "no puedo construir darnlink en $REF (ref malo / sin red)"; fi
 
 if [ "$SCOPE" != "staged" ]; then
   # ---- whole-repo (the wall). darnlink's own exit code is the gate. ----
@@ -91,7 +105,7 @@ if [ "$SCOPE" != "staged" ]; then
   rc=$?
   set -e
   # rc>3 (e.g. 127 network) → fail open + warn; darnlink's own 0/2/3 pass through.
-  if [ "$rc" -gt 3 ]; then echo "darnlink-gate: darnlink unreachable (rc=$rc) → SKIP; CI covers it." >&2; exit 0; fi
+  if [ "$rc" -gt 3 ]; then bail "darnlink inalcanzable (rc=$rc)"; fi
   # mode=repair gates on integrity only: a strict-only failure (3) is clean.
   if [ "$MODE" = "repair" ] && [ "$rc" -eq 3 ]; then exit 0; fi
   exit "$rc"
@@ -101,7 +115,7 @@ fi
 #      darnlink stays git-agnostic; the git lives here. Only fail on findings in files you're committing.
 # python3 does the filtering — fail OPEN if it's missing (don't brick a commit; CI covers the wall).
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "darnlink-gate (staged): python3 not found → SKIP; CI covers the wall." >&2; exit 0
+  bail "(staged) python3 no esta instalado"
 fi
 mapfile -t STAGED < <(git diff --cached --name-only --diff-filter=ACMR -- '*.md' 2>/dev/null || true)
 [ "${#STAGED[@]}" -eq 0 ] && { echo "darnlink-gate (staged): no staged .md — nothing to judge."; exit 0; }
@@ -112,7 +126,7 @@ set +e
 DL_JSON="$(run check . --json "${DL_ARGS[@]}" 2>/dev/null)"; rc=$?
 set -e
 if [ "$rc" -gt 3 ] || [ -z "$DL_JSON" ]; then
-  echo "darnlink-gate (staged): darnlink unreachable (rc=$rc) → SKIP; CI covers the wall." >&2; exit 0
+  bail "(staged) darnlink inalcanzable (rc=$rc)"
 fi
 export DL_JSON DL_ROOT="$root" DL_REF="$REF" DL_MODE="$MODE"
 export DL_STAGED="$(printf '%s\n' "${STAGED[@]}")"

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -5,7 +5,12 @@
 # DARNLINK_GATE_SCOPE). It ALWAYS runs `darnlink check` (stable 0/2/3 contract); MODE only picks which
 # axes gate: mode=check → integrity + strict both gate; mode=repair → integrity only (a strict-only
 # failure, 3, is treated as clean). scope=staged filters `darnlink check --json` by `git diff --cached`
-# (Option B — darnlink stays git-agnostic); fail-open on network; refuses --write. Exit 0/2/3/1.
+# (Option B — darnlink stays git-agnostic); refuses --write.
+#
+# FAIL-OPEN by default (an offline commit must not be bricked) — set DARNLINK_GATE_FAIL_CLOSED=1 (or
+# "fail_closed": true in the json) in CI, where the gate IS the wall and failing open would mean a
+# GREEN build with zero files validated. Exit: 0 clean · 2 integrity · 3 strict · 1 usage ·
+# 4 could-not-gate (fail-closed only).
 $ErrorActionPreference = "Stop"
 
 $root = (git rev-parse --show-toplevel 2>$null)
@@ -22,6 +27,26 @@ function CfgOr($key, $default) { if ($cfg.$key) { return $cfg.$key } else { retu
 $ref   = if ($env:DARNLINK_REF)        { $env:DARNLINK_REF }        else { CfgOr 'ref' 'git+https://github.com/txemi/darnlink@v0.5.0' }
 $mode  = if ($env:DARNLINK_GATE_MODE)  { $env:DARNLINK_GATE_MODE }  else { CfgOr 'mode' 'check' }
 $scope = if ($env:DARNLINK_GATE_SCOPE) { $env:DARNLINK_GATE_SCOPE } else { CfgOr 'scope' 'repo' }
+# FAIL-CLOSED (parity with the bash recipe). Fails OPEN by default — right for pre-commit, DANGEROUS
+# in CI, where a transient network/PyPI hiccup would give a GREEN build with zero files validated.
+# Normalise: the json may carry a real boolean, and 'false'/'no'/'off'/0 must all mean OFF (a naive
+# truthiness test would arm it for the very consumer asking to turn it off).
+$rawFC = if ($null -ne $env:DARNLINK_GATE_FAIL_CLOSED) { $env:DARNLINK_GATE_FAIL_CLOSED } else { CfgOr 'fail_closed' '' }
+$failClosed = -not ([string]::IsNullOrWhiteSpace([string]$rawFC) -or
+                    ([string]$rawFC).Trim().ToLower() -in @('0','false','no','off'))
+
+# ONE place decides what to do when the gate could NOT run: skip (default) or abort red (CI).
+# Never "green without validating", which is the expensive silent failure.
+function Invoke-Bail([string]$reason) {
+  if ($failClosed) {
+    # NOT Write-Error: with $ErrorActionPreference = "Stop" it raises a terminating error and the
+    # script would die with exit 1 — never reaching the `exit 4` that tells CI "could not gate".
+    [Console]::Error.WriteLine("darnlink-gate: $reason -> FAILING (fail-closed is on: nothing was validated).")
+    exit 4
+  }
+  Write-Warning "darnlink-gate: $reason -> SKIP; CI covers the wall."
+  exit 0
+}
 $excludes     = @(CfgOr 'excludes' @())
 $ignoreBlocks = @(CfgOr 'ignore_blocks' @())
 
@@ -35,7 +60,7 @@ if ($args -contains '--write') {
 if (-not (Get-Command uvx -ErrorAction SilentlyContinue)) {
   $uvBin = Join-Path $env:USERPROFILE ".local\bin"
   if (Test-Path (Join-Path $uvBin "uvx.exe")) { $env:Path = "$uvBin;$env:Path" }
-  else { Write-Warning "darnlink-gate: uvx not found -> SKIP (install uv; CI covers the wall)."; exit 0 }
+  else { Invoke-Bail "uvx not found" }
 }
 
 $dlArgs = @()
@@ -45,13 +70,13 @@ foreach ($b in $ignoreBlocks) { if ($b) { $dlArgs += @('--ignore-block', $b) } }
 # Pre-flight: can uvx BUILD+RUN darnlink at this ref? darnlink's exit codes (0/1/2/3) overlap a uvx
 # fetch failure, so confirm reachability first; if not -> fail OPEN (don't brick a commit; CI covers it).
 & uvx --from $ref darnlink --help *> $null
-if ($LASTEXITCODE -ne 0) { Write-Warning "darnlink-gate: can't run darnlink at $ref (bad ref / no network) -> SKIP; CI covers the wall."; exit 0 }
+if ($LASTEXITCODE -ne 0) { Invoke-Bail "can't run darnlink at $ref (bad ref / no network)" }
 
 if ($scope -ne 'staged') {
   # ---- whole-repo (the wall): darnlink's own exit code is the gate ----
   & uvx --from $ref darnlink check . @dlArgs @args   # always `check` → stable 0/2/3, regardless of MODE
   $rc = $LASTEXITCODE
-  if ($rc -gt 3) { Write-Warning "darnlink-gate: darnlink unreachable (rc=$rc) -> SKIP; CI covers it."; exit 0 }
+  if ($rc -gt 3) { Invoke-Bail "darnlink unreachable (rc=$rc)" }
   # mode=repair gates on integrity only: a strict-only failure (3) is clean.
   if ($mode -eq 'repair' -and $rc -eq 3) { exit 0 }
   exit $rc
@@ -63,7 +88,7 @@ if (-not $staged) { Write-Output "darnlink-gate (staged): no staged .md — noth
 
 $json = (& uvx --from $ref darnlink check . --json @dlArgs 2>$null | Out-String)
 $rc = $LASTEXITCODE
-if ($rc -gt 3 -or -not $json.Trim()) { Write-Warning "darnlink-gate (staged): darnlink unreachable (rc=$rc) -> SKIP; CI covers the wall."; exit 0 }
+if ($rc -gt 3 -or -not $json.Trim()) { Invoke-Bail "(staged) darnlink unreachable (rc=$rc)" }
 
 $data = $json | ConvertFrom-Json
 $stagedSet = [System.Collections.Generic.HashSet[string]]::new()


### PR DESCRIPTION
## The problem

The recipe fails **open** by design at 5 points (`uvx` missing, ref not buildable, `rc>3`, `python3` missing on staged). That is **right for pre-commit**: blocking an offline commit would be worse than the problem it solves.

But it was dropped as-is into the **CI** of 3 consuming repos. There it is precisely the opposite of what you want: **the gate IS the wall**, and failing open means a **GREEN build with zero files validated** on a transient PyPI or network failure.

Worse: the comment written in those workflows claimed *"red build if either axis fails"* — **false** in that case.

## The fix

A single `bail()` helper centralises the 5 fail-open points and honours:

- `DARNLINK_GATE_FAIL_CLOSED=1` (env), or
- `"fail_closed": true` in `darnlink-gate.json`

With the flag on, those cases exit with **code 4** — its own, distinguishable from real findings (`2` integrity, `3` strict), so CI can tell *"there is link debt"* apart from *"the gate could not run"*.

**The default does not change**: without the flag it still fails open exactly as before (backwards compatible with current consumers).

## Verified

| Scenario | Result |
|---|---|
| non-existent ref, **without** the flag | `exit 0` (skips, as before) |
| non-existent ref, **with** the flag | `exit 4` ✅ |
| good ref, **with** the flag | `exit 0` (gates normally — the flag does not touch the happy path) |

## Provenance

Found by an **adversarial reviewing subsession**, used as a stand-in for Copilot because its job is blocked by an Actions quota on the private repos. In the same pass it found that a sibling tool's atomic write **stripped the execute bit** from hooks (git ignores them silently) — the same family of failure: *disarming the gate without anyone noticing*.

## What to look at

Above all that the **default stays fail-open** (do not break consumers) and that exit code 4 does not collide with the existing `0/1/2/3` semantics.

<sub>Translated from the original Spanish on 2026-08-11 — this repo is English-only on every surface, PR titles and descriptions included.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
