### PR TITLE
feat(scope): --only — scope writes to specific files (spec 010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **`--only FILE` / `--only-from FILE` — scope writes to specific files** (feature 010). darnlink now
+  separates the two scopes the positional `path` used to fuse: the **index** scope (which files are
+  read — still the whole tree, so a link's target resolves wherever it lives) and the **write** scope
+  (which files are modified). `--only` narrows the latter; `--only-from` reads the list from a file or
+  stdin (`-`), so a caller can pipe `git diff --cached --name-only` in without darnlink learning about
+  git. This makes the common "anchor the links in the file I'm committing, touch nothing else" case
+  possible — previously you either scanned your subtree (and the tool couldn't see out-of-subtree
+  targets, so it anchored nothing) or ran repo-wide (and rewrote everyone's links).
+- **`--no-target-writes`** — with `--only`, refuse the one write that otherwise lands outside the
+  scope (adding a `uuid` to a *target* so a link can be anchored). Links that would need it stay plain
+  and are reported; the guarantee becomes absolute: **no** file outside `--only` is touched.
+- **New finding kinds** in human and `--json` output: `out_of_scope`, `target_uuid_write`,
+  `target_write_refused`. `--json` gains `write_scope` and `suppressed_outside_write_scope`.
+
+### Fixed
+- **`out_of_scope` no longer misreported as `no_frontmatter`.** A plain link whose target exists but
+  was never scanned (outside `path`, or excluded) used to be reported as "target has no frontmatter"
+  — stating as fact something the run never checked. It now has its own kind and an honest message.
+  This is the confusion that motivated feature 010.
+
 ## [0.6.0] — 2026-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -108,11 +108,14 @@ The sections above introduce these in context; this is the full list (same as `d
 
 | Option | What it does |
 |---|---|
-| `path` *(positional)* | Root directory to scan. Default: `.` — darnlink takes a **directory**, not a file list. |
+| `path` *(positional)* | Root directory to scan. Default: `.` — darnlink takes a **directory**, not a file list. (To write to specific files while still scanning the whole tree, use `--only`, below.) |
 | `--write` | Apply the changes. Without it darnlink only **reports** — it never modifies a file. |
 | `--robustify` | Upgrade plain links to robust. Without it the operation is *repair* (fix robust links whose target moved). |
 | `--create-frontmatter` | *(robustify)* Allow creating frontmatter on a target that has none, so it can take a `uuid`. Opt-in on purpose. |
 | `--no-create-frontmatter-for GLOB` | *(robustify)* Basename glob whose targets **never** get a `uuid` — no block created, no line inserted — regardless of `--create-frontmatter`. Reusing a `uuid` the target already has is unaffected. Repeatable. |
+| `--only FILE` | Restrict **writes** to these `.md` files. The tree is still scanned and indexed in full — so a link's target can live anywhere — but only these files are modified. Repeatable. See [Scoping writes to specific files](#scoping-writes-to-specific-files---only). |
+| `--only-from FILE` | Read `--only` paths from `FILE`, one per line (`-` = stdin). Combines with `--only`. Lets you pipe a generated list (e.g. staged files) without darnlink knowing about git. |
+| `--no-target-writes` | *(with `--only`)* Never write a `uuid` into a target **outside** the write scope: such links are left plain and reported. Guarantees **no** file outside `--only` is touched. |
 | `--exclude PATTERN` | Skip any directory whose name matches `PATTERN` (glob / `fnmatch`, case-sensitive; a plain name matches exactly). Repeatable — e.g. `--exclude old --exclude 'old_*' --exclude '*_old'` skips the whole `old` family. |
 | `--ignore-block NAME` | Leave links inside `<!-- NAME-start --> … <!-- NAME-end -->` blocks alone. Repeatable. |
 | `--json` | Machine-readable output (see below). |
@@ -129,6 +132,8 @@ Stable shape, meant for gates and scripts:
 {
   "wrote": 0,
   "applied": false,
+  "write_scope": null,
+  "suppressed_outside_write_scope": 0,
   "ignored_files": ["path/to/opted-out.md"],
   "link_ignored_files": ["path/to/generated/INDEX.md"],
   "invalid_frontmatter_files": [],
@@ -137,9 +142,53 @@ Stable shape, meant for gates and scripts:
 ```
 
 `kind` is one of: `repair`, `conflict`, `robustify`, `unresolvable`, `ambiguous`, `no_frontmatter`,
-`deny_listed`, `ignored_links`, `invalid_frontmatter`. A gate that wants "is anything left to do?"
-should count the kinds it cares about (e.g. `robustify`) rather than the length of `findings` — the
-non-actionable kinds are reported precisely so nothing is skipped silently.
+`out_of_scope`, `deny_listed`, `ignored_links`, `invalid_frontmatter`, `target_uuid_write`,
+`target_write_refused`. A gate that wants "is anything left to do?" should count the kinds it cares
+about (e.g. `robustify`) rather than the length of `findings` — the non-actionable kinds are
+reported precisely so nothing is skipped silently.
+
+`write_scope` is `null` unless `--only` is in effect, when it lists the files that may be written;
+`suppressed_outside_write_scope` counts actionable findings in files outside that scope — not shown,
+but surfaced so a narrowed run never reads as a clean tree.
+
+`out_of_scope` is worth calling out: it means a plain link's target **exists but was never scanned**
+(it lives outside `path`, or an `--exclude` skipped it), so its `uuid` is unknown and the link is
+left plain. That is a different fact from `no_frontmatter` (target scanned, but it has none) — the
+two used to collapse into one, which reported a scope miss as if the target were malformed.
+
+### Scoping writes to specific files (`--only`)
+
+By default darnlink writes to every file it scans. `--only` narrows the **write** scope to named
+files while still building the target graph from the whole tree — the two are separate axes:
+
+```bash
+# Scan the whole repo (so targets resolve wherever they live), but only rewrite ONE file:
+darnlink . --robustify --write --only tasks/56/README.md
+```
+
+Why the split matters: the link you want to anchor lives in your file, but its **target** usually
+lives elsewhere in the repo. Scanning only your subtree (`darnlink tasks/56`) can't see the target,
+so it reports `out_of_scope` and anchors nothing; scanning the whole repo without `--only` would
+rewrite every robustifiable link in the tree, including other people's work in flight. `--only` is
+"read everything, write here".
+
+- The **one** write that may land outside `--only` is adding a `uuid` to a *target* so the link can
+  be anchored at all — it is reported (kind `target_uuid_write`) before it happens. Pass
+  `--no-target-writes` to refuse even that: the link stays plain, and **nothing** outside `--only`
+  is touched.
+- A **repair** run under `--only` only ever inspects the links *inside* the scoped files. A moved
+  target's *inbound* links live in files you didn't name — a clean scoped result is **not** proof the
+  tree is clean. Keep a full-tree run in CI for that.
+- darnlink never touches git. To scope to your staged files, pipe them in — this is the whole
+  `--only-from -` use case:
+
+```bash
+git diff --cached --diff-filter=ACMR --name-only -- '*.md' \
+  | darnlink . --robustify --write --only-from -
+```
+
+  (darnlink edits the files but does **not** re-stage them; your hook re-runs `git add` if it wants
+  the fixes in the same commit.)
 
 ## For language models / agents
 

--- a/specs/010-write-scope/spec.md
+++ b/specs/010-write-scope/spec.md
@@ -1,0 +1,158 @@
+# Feature Specification: write scope — `--only`
+
+**Feature Branch**: `010-write-scope`
+
+**Created**: 2026-07-21
+
+**Status**: Draft
+
+**Input**: A contributor can run darnlink over the whole repo, or over a subtree — and neither serves
+the commonest case: *"anchor the links in the file I am committing, and touch nothing else."*
+Repo-wide `--robustify --write` rewrites every robustifiable link in the tree (in a consumer repo,
+679 of them, most belonging to other people's work in flight); scoping the scan to a subtree instead
+silently fails to anchor anything whose **target** lives outside that subtree. There is no way to say
+*"read everything, write here"*.
+
+## The two scopes (and why they are fused today)
+
+Feature 006 split the two **axes** a file sits on (source / target). This feature splits the two
+**scopes** an invocation has, which the positional `path` currently fuses into one:
+
+| Scope | Question | Today |
+|---|---|---|
+| **Index scope** | Which files may be *read* — as link sources, and as targets whose `uuid` resolves? | `path` |
+| **Write scope** | Which files may be *modified*? | `path` |
+
+One knob answers both, so the two useful configurations are unreachable: narrowing the write scope
+also blinds the index, and keeping the index whole also opens the write scope to the whole tree. The
+first is not a theoretical loss — it is the failure below.
+
+## Evidence this gap is real (not hypothetical)
+
+The consumer repo `project_map` (~8.000 `.md`, ~15.000 Markdown links) runs a fail-closed pre-commit
+gate: a commit is refused when a **staged** file carries a robustifiable plain link. Its advice to the
+contributor is `darnlink <your/path> --robustify --write`, and on 2026-07-21 that advice could not be
+followed:
+
+- **Scoped to the author's directory**, the link's target lived in another subtree, so it was never
+  indexed. The finding came back as `no frontmatter; target skipped` — while the target *did* have
+  frontmatter and a `uuid`. The diagnosis was not merely unhelpful, it was **wrong** (see FR-009).
+- **Repo-wide**, the run would have rewritten 679 links across other sessions' files and generated
+  documents. The gate's own comment records that this already dirtied the repo three times
+  (2026-06-11, 07-16, 07-17).
+
+The link was anchored **by hand**, pasting `<!-- uuid: … -->` into the file. A tool whose entire job
+is to write that comment lost to a text editor, because it could not be told *where it may write*.
+
+## Why `--only`, and not "let `path` accept files"
+
+The obvious shape is to let the positional accept `.md` files. It is rejected:
+
+- **It says something false.** `darnlink some/file.md` reads as *"look at this file"*. darnlink cannot
+  work that way: it must still walk the tree to build the `uuid → path` index (repair) and to read the
+  targets' frontmatter (robustify). Nothing is skipped — a scoped run reads exactly as much as a full
+  one. The saving is in *blast radius*, not in work, and the interface should not pretend otherwise.
+- **It drags in `--root`.** Once the positional is a file, the index needs its own root — which means a
+  new flag, or auto-detecting the git root, i.e. **git knowledge inside a tool that today knows only
+  `.md` files, links and frontmatter** (Principle I/III).
+- **It complicates a working contract.** `path` stays a directory, `not a directory` stays an error,
+  every existing invocation and the pre-commit hook's `pass_filenames: false` stay literally true.
+
+`--only` is a filter on the write scope and nothing else. It composes with the scan flags rather than
+competing with them, and it reads as what it does: *scan from here, write only there*.
+
+## Constitution Check
+
+- **P-I (Links & UUIDs Only, NON-NEGOTIABLE):** refines *which files may be written*, the same class
+  of knob as `--exclude` (which files are scanned) and the in-file markers (which axes a file joins).
+  No document semantics, no external state, no VCS. In-bounds; no amendment needed. ✅
+- **P-II (Safe by Default — Dry-Run First):** strictly *narrowing*. The default (no `--only`) is
+  unchanged, and the flag can only ever reduce the set of files written. ✅
+- **P-III (Self-Contained, Tool-Agnostic):** a CLI argument; nothing is stored, no config file, no git.
+  A list produced by any means can be piped in (FR-002). ✅
+- **P-IV (Deterministic):** output stays a pure function of (tree, flags). No heuristics, no inference
+  of "what the user probably meant". ✅
+- **P-V (Test-First):** the guarantee that makes the feature worth having — *nothing outside the write
+  scope changes* — is an acceptance test, not a claim (Acceptance 3).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `--only PATH` (repeatable) MUST restrict **writes** to the named `.md` files. It MUST NOT
+  affect which files are scanned, indexed, or reported on.
+- **FR-002**: `--only-from FILE` MUST read newline-separated paths from FILE, where `-` means stdin, so
+  a list produced elsewhere composes without darnlink learning where it came from. `--only` and
+  `--only-from` MUST be combinable (union).
+- **FR-003**: Every path given MUST exist, be a `.md` file, and resolve **inside** the scanned root; any
+  other path is a usage error (exit 1) naming the offending path. Silently ignoring an unmatched path
+  would turn a typo — or a stale entry in a generated list — into a green run that wrote nothing.
+- **FR-004**: With `--robustify --write`, a plain link in a file in the write scope MUST be annotated
+  exactly as it would be in a full-tree run, **including when its target lives outside the scope** —
+  the target's `uuid` is read from the index, which `--only` does not narrow (FR-001). This is the
+  motivating failure and the feature's reason to exist.
+- **FR-005**: With `--write` (repair), a robust link in a file in the write scope whose target moved
+  MUST be repaired exactly as in a full-tree run.
+- **FR-006**: Writing a `uuid` into a **target's** frontmatter is the one write allowed outside the
+  scope, because a link cannot be anchored to a target that has no `uuid`. It MUST be announced by
+  path in the report, in human and `--json` output, before it happens (dry-run) and when it happens.
+  `--no-target-writes` MUST suppress it: the link is then left plain and reported with the existing
+  "target has no uuid" kind, so a caller that needs the hard guarantee can have it.
+- **FR-007**: No file outside `--only` ∪ (targets receiving a `uuid` per FR-006) may be modified. This
+  is the guarantee the feature exists to provide; it MUST hold for every operation and flag combination.
+- **FR-008**: A repair run narrowed by `--only` MUST state, in its report, that only **outbound** links
+  were considered and that a moved target still requires a full-tree run to fix its **inbound** links.
+  A narrowed run can only ever see the links written *inside* the scoped files; a clean result is not
+  evidence of a clean tree, and must not read like one.
+- **FR-009** *(adjacent fix, same confusion)*: A link whose target is **outside the scanned root** MUST
+  be reported with its own kind — distinct from the target having no frontmatter. Today both collapse
+  into `no frontmatter`, which states as fact something the run never checked and cannot know.
+- **FR-010**: `darnlink check` MUST accept `--only` and restrict its **findings** to links whose source
+  file is in the set (it writes nothing, so there is no write scope to narrow). Exit-code semantics are
+  unchanged. This is what a pre-commit gate needs: *is what I am committing clean?*
+- **FR-011**: Without `--only`/`--only-from`, behaviour MUST be byte-identical to today, for every
+  operation (regression: the positional keeps meaning "root directory to scan").
+- **FR-012**: Runs MUST stay idempotent: a second run with the same `--only` set changes nothing.
+
+### Key Entities
+
+- **Write scope**: the set of files an invocation may modify. Defaults to the index scope (today's
+  behaviour); `--only` narrows it. Not persisted anywhere — an argument, alive for one run.
+
+## Acceptance
+
+1. **The motivating case.** `A.md` (in `x/`) holds a plain link to `B.md` (in `y/`), which has a `uuid`.
+   `darnlink . --robustify --write --only x/A.md` anchors the link in `A.md` and leaves the rest of the
+   tree byte-identical. (Today's alternatives: `darnlink x/` skips it as "no frontmatter"; `darnlink .`
+   rewrites the whole tree.)
+2. **Several files at once.** Two files, each with links into unrelated subtrees, are both anchored in
+   one run; nothing else changes.
+3. **The guarantee.** In a tree with many robustifiable links, a `--only` run modifies exactly the
+   scoped files (plus any target receiving a `uuid`, each named in the report) and no other file —
+   verified by hashing the tree before and after.
+4. **Target writes are visible and refusable.** A target with frontmatter but no `uuid` is named in the
+   dry-run report; with `--no-target-writes` it is not written, and the link is left plain and reported.
+5. **Repair, narrowed.** A file whose robust link went stale is repaired via `--only`; the report says
+   inbound links elsewhere were not considered.
+6. **Guard rails.** `--only` with a non-existent path, a non-`.md` path, or a path outside the root
+   exits 1 naming it.
+7. **Piped list.** The same set passed via `--only-from -` behaves identically to repeated `--only`.
+8. **Regression.** Every existing invocation without `--only` produces identical output and identical
+   writes; `darnlink some/file.md` still fails with `not a directory`.
+
+## Out of scope
+
+- **A `--staged` flag.** darnlink must not learn about git (P-I/P-III). Once `--only-from -` exists it
+  is one line in a consumer's hook or in `recipes/`:
+  `git diff --cached --diff-filter=ACMR --name-only -- '*.md' | darnlink . --robustify --write --only-from -`.
+  A recipe is the right home: it is where the VCS knowledge already lives.
+- **Auto-staging what was written.** A tool that edits files must not touch the git index; the caller
+  re-adds. (A hook that fixes files must also decide whether to re-run — that is the hook's policy.)
+- **Reading staged blobs instead of the worktree.** darnlink reads the worktree, as it always has. A
+  file with unstaged modifications is anchored as it exists on disk; the caller owns that trade-off.
+- **Inbound links.** No index of "who links to this file" is added — it would be an external index
+  (P-III). Full-tree runs remain the way to repair a moved target's inbound links, which is what the
+  consumer gate and CI already enforce.
+- **Allowlists of files never to write** (globs a consumer wants darnlink to leave alone). That need is
+  already served on the file's own terms by `<!-- darnlink-ignore-links -->` (006); `--only` is a
+  per-invocation narrowing, not a repo policy.

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -5,6 +5,8 @@
     darnlink [PATH] --robustify [--write] [--create-frontmatter]
     darnlink [PATH] --robustify --create-frontmatter --no-create-frontmatter-for content.md
     darnlink [PATH] --exclude external_repos --json
+    darnlink [PATH] --robustify --write --only sub/dir/A.md   # scan PATH, write only A.md
+    git diff --cached --name-only -- '*.md' | darnlink . --robustify --write --only-from -
     darnlink check [PATH]                        # report-only gate: BOTH checks, exit 0/2/3 (1 on usage)
 """
 from __future__ import annotations
@@ -19,6 +21,12 @@ from .frontmatter_index import DEFAULT_EXCLUDES, build_index
 from .repair import apply_repairs, plan_repairs
 from .report import Finding, Kind
 from .robustify import apply_robustify, plan_robustify
+from .scope import ScopeError, read_paths_from, resolve_write_scope
+
+
+def _scope_note(suppressed: int) -> str:
+    return (f"  NOTE: {suppressed} finding(s) in files outside --only were neither written nor "
+            f"listed (drop --only to see them).")
 
 
 def _findings_json(
@@ -28,11 +36,15 @@ def _findings_json(
     ignored: Optional[List[Path]] = None,
     invalid: Optional[List[Path]] = None,
     link_ignored: Optional[List[Path]] = None,
+    suppressed: int = 0,
+    only: Optional[set] = None,
 ) -> str:
     return json.dumps(
         {
             "wrote": wrote,
             "applied": write,
+            "write_scope": sorted(str(p) for p in only) if only is not None else None,
+            "suppressed_outside_write_scope": suppressed,
             "ignored_files": [str(p) for p in (ignored or [])],
             # feature 006: opted out as a SOURCE only — still indexed as a target
             "link_ignored_files": [str(p) for p in (link_ignored or [])],
@@ -43,9 +55,10 @@ def _findings_json(
     )
 
 
-def _run_repair(root: Path, write: bool, excludes: set, as_json: bool, block_markers: tuple) -> int:
+def _run_repair(root: Path, write: bool, excludes: set, as_json: bool, block_markers: tuple,
+                only: Optional[set] = None) -> int:
     index = build_index(root, excludes)
-    result = plan_repairs(root, index, excludes, block_markers)
+    result = plan_repairs(root, index, excludes, block_markers, only=only)
     repairs = [f for f in result.findings if f.kind is Kind.REPAIR]
     conflicts = [f for f in result.findings if f.kind is Kind.CONFLICT]
     unresolved = [f for f in result.findings if f.kind in (Kind.UNRESOLVABLE, Kind.AMBIGUOUS)]
@@ -53,9 +66,11 @@ def _run_repair(root: Path, write: bool, excludes: set, as_json: bool, block_mar
 
     if as_json:
         print(_findings_json(result.findings, wrote, write, result.ignored, index.invalid,
-                             result.link_ignored))
+                             result.link_ignored, result.suppressed, only))
     else:
         print(f"darnlink repair — root: {root}")
+        if only is not None:
+            print(f"  write scope: {len(only)} file(s) (--only)")
         print(f"  indexed uuids: {len(index.by_uuid)} | duplicate uuids: {len(index.duplicates)}")
         print(f"  links to repair: {len(repairs)} | conflicts: {len(conflicts)} | unresolved: {len(unresolved)} | ignored files: {len(result.ignored)} | link-ignored: {len(result.link_ignored)} | invalid frontmatter: {len(index.invalid)}")
         for f in repairs:
@@ -68,6 +83,14 @@ def _run_repair(root: Path, write: bool, excludes: set, as_json: bool, block_mar
             print(f"  [link-ignored] {f.file}: {f.detail}")
         for p in index.invalid:
             print(f"  [invalid-frontmatter] {p}: not valid YAML; not indexed (fix the file)")
+        if only is not None:
+            # FR-008: a narrowed run only ever sees the links written INSIDE the scoped files. A moved
+            # target's inbound links live in files the caller did not name — a clean result here is
+            # not evidence of a clean tree, and must not read like one.
+            print("  NOTE: --only checks outbound links of the scoped files; a moved target's "
+                  "inbound links still need a full-tree run.")
+            if result.suppressed:
+                print(_scope_note(result.suppressed))
         if write:
             print(f"  WROTE {wrote} file(s).")
         elif repairs:
@@ -76,29 +99,42 @@ def _run_repair(root: Path, write: bool, excludes: set, as_json: bool, block_mar
     return 1 if conflicts or unresolved or index.invalid or (repairs and not write) else 0
 
 
-def _run_robustify(root: Path, write: bool, create_frontmatter: bool, excludes: set, as_json: bool, block_markers: tuple, no_create_globs: tuple) -> int:
-    result = plan_robustify(root, create_frontmatter=create_frontmatter, excludes=excludes, block_markers=block_markers, no_create_globs=no_create_globs)
+def _run_robustify(root: Path, write: bool, create_frontmatter: bool, excludes: set, as_json: bool, block_markers: tuple, no_create_globs: tuple, only: Optional[set] = None, allow_target_writes: bool = True) -> int:
+    result = plan_robustify(root, create_frontmatter=create_frontmatter, excludes=excludes, block_markers=block_markers, no_create_globs=no_create_globs, only=only, allow_target_writes=allow_target_writes)
     upgrades = [f for f in result.findings if f.kind is Kind.ROBUSTIFY]
     skipped = [f for f in result.findings if f.kind is Kind.NO_FRONTMATTER]
     denied = [f for f in result.findings if f.kind is Kind.DENY_LISTED]
+    out_of_scope = [f for f in result.findings if f.kind is Kind.OUT_OF_SCOPE]
+    target_writes = [f for f in result.findings if f.kind is Kind.TARGET_UUID_WRITE]
+    refused = [f for f in result.findings if f.kind is Kind.TARGET_WRITE_REFUSED]
     wrote = len(apply_robustify(result)) if write else 0
 
     if as_json:
         print(_findings_json(result.findings, wrote, write, result.ignored, result.invalid,
-                             result.link_ignored))
+                             result.link_ignored, result.suppressed, only))
     else:
         print(f"darnlink robustify — root: {root}")
-        print(f"  plain links to robustify: {len(upgrades)} | skipped (no frontmatter): {len(skipped)} | deny-listed: {len(denied)} | ignored files: {len(result.ignored)} | link-ignored: {len(result.link_ignored)} | invalid frontmatter: {len(result.invalid)}")
+        if only is not None:
+            print(f"  write scope: {len(only)} file(s) (--only)")
+        print(f"  plain links to robustify: {len(upgrades)} | skipped (no frontmatter): {len(skipped)} | out of scanned root: {len(out_of_scope)} | deny-listed: {len(denied)} | ignored files: {len(result.ignored)} | link-ignored: {len(result.link_ignored)} | invalid frontmatter: {len(result.invalid)}")
         for f in upgrades:
             print(f"  [robustify] {f.file}: {f.detail}")
         for f in skipped:
             print(f"  [no-frontmatter] {f.file}: {f.detail} (use --create-frontmatter to allow)")
+        for f in out_of_scope:
+            print(f"  [out-of-scope] {f.file}: {f.detail}")
+        for f in target_writes:
+            print(f"  [target-uuid-write] {f.file}: {f.detail}")
+        for f in refused:
+            print(f"  [target-write-refused] {f.file}: {f.detail}")
         for f in denied:
             print(f"  [deny-listed] {f.file}: {f.detail}")
         for f in [x for x in result.findings if x.kind is Kind.IGNORED_LINKS]:
             print(f"  [link-ignored] {f.file}: {f.detail}")
         for p in result.invalid:
             print(f"  [invalid-frontmatter] {p}: not valid YAML; left untouched (fix the file)")
+        if only is not None and result.suppressed:
+            print(_scope_note(result.suppressed))
         if write:
             print(f"  WROTE {wrote} file(s).")
         elif upgrades:
@@ -107,7 +143,8 @@ def _run_robustify(root: Path, write: bool, create_frontmatter: bool, excludes: 
     return 1 if result.invalid or (upgrades and not write) else 0
 
 
-def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple) -> int:
+def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple,
+               only: Optional[set] = None) -> int:
     """Feature 007: report-only gate. Run BOTH checks (integrity + strict) in one invocation and
     return a distinguishable exit code. Never writes. `--robustify` alone does not catch a broken
     robust link, and plain `darnlink .` does not catch an un-anchored plain link — a gate that runs
@@ -118,17 +155,23 @@ def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple) -
     strict when both fail (a broken link is more urgent than an un-anchored one).
     """
     # Integrity axis (repair, dry-run): robust links whose path is stale/unresolvable, plus invalid YAML.
+    # FR-010: `--only` restricts FINDINGS to links whose source file is in the set (check writes
+    # nothing, so there is no write scope — just a report filter). The index is still whole.
     index = build_index(root, excludes)
-    rep = plan_repairs(root, index, excludes, block_markers)
+    rep = plan_repairs(root, index, excludes, block_markers, only=only)
     repairs = [f for f in rep.findings if f.kind is Kind.REPAIR]
     conflicts = [f for f in rep.findings if f.kind is Kind.CONFLICT]
     unresolved = [f for f in rep.findings if f.kind in (Kind.UNRESOLVABLE, Kind.AMBIGUOUS)]
-    integrity_fail = bool(repairs or conflicts or unresolved or index.invalid)
+    # Invalid frontmatter is a file-level integrity fault; when scoped, only the caller's own files
+    # count — a gate must not fail my commit over someone else's un-staged invalid YAML.
+    invalid = [p for p in index.invalid if only is None or p.resolve() in only]
+    integrity_fail = bool(repairs or conflicts or unresolved or invalid)
 
     # Strict axis (robustify, dry-run): plain links to an anchorable target left un-anchored.
-    rob = plan_robustify(root, create_frontmatter=False, excludes=excludes, block_markers=block_markers)
+    rob = plan_robustify(root, create_frontmatter=False, excludes=excludes, block_markers=block_markers, only=only)
     upgrades = [f for f in rob.findings if f.kind is Kind.ROBUSTIFY]
-    strict_fail = bool(upgrades or rob.invalid)
+    rob_invalid = [p for p in rob.invalid if only is None or p.resolve() in only]
+    strict_fail = bool(upgrades or rob_invalid)
 
     code = 2 if integrity_fail else (3 if strict_fail else 0)
 
@@ -136,43 +179,46 @@ def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple) -
         print(json.dumps({
             "check": True,
             "exit_code": code,
+            "write_scope": sorted(str(p) for p in only) if only is not None else None,
             "integrity": {
                 "failed": integrity_fail,
                 "repairs": len(repairs), "conflicts": len(conflicts),
-                "unresolved": len(unresolved), "invalid_frontmatter": len(index.invalid),
-                "invalid_frontmatter_files": [str(p) for p in index.invalid],
+                "unresolved": len(unresolved), "invalid_frontmatter": len(invalid),
+                "invalid_frontmatter_files": [str(p) for p in invalid],
                 "findings": [{"kind": f.kind.value, "file": str(f.file), "detail": f.detail}
                              for f in (repairs + conflicts + unresolved)]
                 + [{"kind": Kind.INVALID_FRONTMATTER.value, "file": str(p),
                     "detail": "frontmatter present but not valid YAML; not indexed"}
-                   for p in index.invalid],
+                   for p in invalid],
             },
             "strict": {
                 "failed": strict_fail,
-                "robustify": len(upgrades), "invalid_frontmatter": len(rob.invalid),
-                "invalid_frontmatter_files": [str(p) for p in rob.invalid],
+                "robustify": len(upgrades), "invalid_frontmatter": len(rob_invalid),
+                "invalid_frontmatter_files": [str(p) for p in rob_invalid],
                 "findings": [{"kind": f.kind.value, "file": str(f.file), "detail": f.detail}
                              for f in upgrades]
                 + [{"kind": Kind.INVALID_FRONTMATTER.value, "file": str(p),
                     "detail": "frontmatter present but not valid YAML; left untouched (fix the file)"}
-                   for p in rob.invalid],
+                   for p in rob_invalid],
             },
         }, indent=2))
     else:
         outcome = {0: "clean", 2: "integrity failure", 3: "strict failure"}[code]
         print(f"darnlink check — root: {root}")
+        if only is not None:
+            print(f"  scope: {len(only)} file(s) (--only) — findings limited to their own links")
         print(f"  [integrity] repair: {len(repairs)} | conflicts: {len(conflicts)} | "
-              f"unresolved: {len(unresolved)} | invalid frontmatter: {len(index.invalid)} "
+              f"unresolved: {len(unresolved)} | invalid frontmatter: {len(invalid)} "
               f"→ {'FAIL' if integrity_fail else 'ok'}")
-        print(f"  [strict]    to robustify: {len(upgrades)} | invalid frontmatter: {len(rob.invalid)} "
+        print(f"  [strict]    to robustify: {len(upgrades)} | invalid frontmatter: {len(rob_invalid)} "
               f"→ {'FAIL' if strict_fail else 'ok'}")
         for f in repairs + conflicts + unresolved:
             print(f"  [integrity/{f.kind.value}] {f.file}: {f.detail}")
-        for p in index.invalid:
+        for p in invalid:
             print(f"  [integrity/invalid-frontmatter] {p}: not valid YAML; not indexed (fix the file)")
         for f in upgrades:
             print(f"  [strict/robustify] {f.file}: {f.detail}")
-        for p in rob.invalid:
+        for p in rob_invalid:
             print(f"  [strict/invalid-frontmatter] {p}: not valid YAML; left untouched (fix the file)")
         print(f"  → exit {code} ({outcome})")
 
@@ -197,14 +243,32 @@ def _run_check_cli(argv: List[str]) -> int:
     parser.add_argument("--exclude", action="append", default=[], metavar="PATTERN", help="directory-name glob to skip (fnmatch, case-sensitive; a plain name matches exactly) (repeatable)")
     parser.add_argument("--ignore-block", action="append", default=[], metavar="NAME",
                         help="ignore links inside <!-- NAME-start --> … <!-- NAME-end --> blocks (repeatable)")
+    parser.add_argument("--only", action="append", default=[], metavar="FILE",
+                        help="(feature 010) limit findings to links whose SOURCE file is one of these .md "
+                        "files (repeatable). The tree is still scanned in full; this is a report filter. "
+                        "What a pre-commit gate needs: 'is what I am committing clean?'")
+    parser.add_argument("--only-from", metavar="FILE",
+                        help="read --only paths from FILE, one per line ('-' = stdin). Combines with --only.")
     parser.add_argument("--json", action="store_true", help="machine-readable output")
     args = parser.parse_args(argv)
     root = Path(args.path).resolve()
     if not root.is_dir():
         print(f"error: not a directory: {root}", file=sys.stderr)
         return 1
+    only_paths = list(args.only)
+    if args.only_from:
+        try:
+            only_paths += read_paths_from(args.only_from)
+        except ScopeError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+    try:
+        only = resolve_write_scope(only_paths, root)
+    except ScopeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     excludes = set(DEFAULT_EXCLUDES) | set(args.exclude)
-    return _run_check(root, excludes, args.json, tuple(args.ignore_block))
+    return _run_check(root, excludes, args.json, tuple(args.ignore_block), only=only)
 
 
 def main(argv: Optional[List[str]] = None) -> int:
@@ -240,6 +304,28 @@ def main(argv: Optional[List[str]] = None) -> int:
         help="ignore links inside generated blocks <!-- NAME-start --> ... <!-- NAME-end --> "
         "(repeatable; e.g. --ignore-block autogrid)",
     )
+    parser.add_argument(
+        "--only",
+        action="append",
+        default=[],
+        metavar="FILE",
+        help="(feature 010) restrict WRITES to these .md files — the tree is still scanned and indexed "
+        "in full, only these are modified (repeatable). A target outside the set may still receive a "
+        "uuid so a link can be anchored (see --no-target-writes).",
+    )
+    parser.add_argument(
+        "--only-from",
+        metavar="FILE",
+        help="read --only paths from FILE, one per line ('-' = stdin). Combines with --only. Lets a "
+        "caller pipe a generated list (e.g. `git diff --cached --name-only`) without darnlink knowing "
+        "about git.",
+    )
+    parser.add_argument(
+        "--no-target-writes",
+        action="store_true",
+        help="(with --only) never write a uuid into a target outside the write scope: such links are "
+        "left plain and reported, guaranteeing NO file outside --only is modified.",
+    )
     parser.add_argument("--json", action="store_true", help="machine-readable output")
     args = parser.parse_args(argv)
 
@@ -248,14 +334,31 @@ def main(argv: Optional[List[str]] = None) -> int:
         print(f"error: not a directory: {root}", file=sys.stderr)
         return 2
 
+    only_paths = list(args.only)
+    if args.only_from:
+        try:
+            only_paths += read_paths_from(args.only_from)
+        except ScopeError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+    if args.no_target_writes and not only_paths:
+        print("error: --no-target-writes has no effect without --only/--only-from", file=sys.stderr)
+        return 1
+    try:
+        only = resolve_write_scope(only_paths, root)
+    except ScopeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
     excludes = set(DEFAULT_EXCLUDES) | set(args.exclude)
     block_markers = tuple(args.ignore_block)
     if args.robustify:
         return _run_robustify(
             root, args.write, args.create_frontmatter, excludes, args.json, block_markers,
-            tuple(args.no_create_frontmatter_for),
+            tuple(args.no_create_frontmatter_for), only=only,
+            allow_target_writes=not args.no_target_writes,
         )
-    return _run_repair(root, args.write, excludes, args.json, block_markers)
+    return _run_repair(root, args.write, excludes, args.json, block_markers, only=only)
 
 
 if __name__ == "__main__":

--- a/src/darnlink/repair.py
+++ b/src/darnlink/repair.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional, Set
 
 from .frontmatter_index import DEFAULT_EXCLUDES, FrontmatterIndex, iter_markdown_files
 from .links import (code_spans, emit_robust_link, file_ignores_links, file_is_ignored,
@@ -22,6 +22,7 @@ from .links import (code_spans, emit_robust_link, file_ignores_links, file_is_ig
 from .paths import relative_link, resolve_href, split_fragment
 from .frontmatter_edit import read_text_keep_newlines, write_text_keep_newlines
 from .report import Finding, Kind
+from .scope import in_scope
 
 
 @dataclass
@@ -30,6 +31,7 @@ class RepairResult:
     new_content: Dict[Path, str] = field(default_factory=dict)  # files that would change
     ignored: List[Path] = field(default_factory=list)  # files skipped via the ignore-file marker
     link_ignored: List[Path] = field(default_factory=list)  # sources via the ignore-links marker (006)
+    suppressed: int = 0  # findings in files outside the write scope (feature 010): counted, never hidden
 
 
 def plan_repairs(
@@ -37,8 +39,16 @@ def plan_repairs(
     index: FrontmatterIndex,
     excludes: set = DEFAULT_EXCLUDES,
     block_markers: tuple = (),
+    only: Optional[Set[Path]] = None,
 ) -> RepairResult:
-    """Compute repairs for every robust link under `root` (no writes)."""
+    """Compute repairs for every robust link under `root` (no writes).
+
+    `only` (feature 010) narrows the **write** scope: files outside it are still scanned and still
+    resolve as targets — the index is built from the whole tree — but their own links are neither
+    rewritten nor reported as actionable; they are counted in `suppressed`. A narrowed run therefore
+    sees only **outbound** links of the scoped files: a moved target's *inbound* links live in files
+    the caller did not name, and still need a full-tree run.
+    """
     result = RepairResult()
     for f in iter_markdown_files(root, excludes):
         try:
@@ -51,29 +61,32 @@ def plan_repairs(
         # Feature 006: its links are never rewritten — not even to fix a stale path. The generator
         # re-emits the correct path on its next run; darnlink must not fight it. Unlike ignore-file
         # this does NOT touch the target axis: the index still resolves this file's uuid (FR-034).
+        scoped = in_scope(f, only)  # feature 010: may this file be written / reported on?
         if file_ignores_links(content):
             result.link_ignored.append(f)
-            result.findings.append(Finding(
-                Kind.IGNORED_LINKS, f,
-                "file carries darnlink-ignore-links; its links are left as-is (still a target)"))
+            if scoped:
+                result.findings.append(Finding(
+                    Kind.IGNORED_LINKS, f,
+                    "file carries darnlink-ignore-links; its links are left as-is (still a target)"))
             continue
         ignore = ignored_spans(content, block_markers) + code_spans(content)
         links = find_robust_links(content, ignore)
         if not links:
             continue
         # rebuild content applying edits left-to-right; collect findings
+        local: List[Finding] = []  # this file's findings; kept only if it is in the write scope
         pieces: List[str] = []
         cursor = 0
         changed = False
         for link in links:
             if index.is_ambiguous(link.uuid):
-                result.findings.append(
+                local.append(
                     Finding(Kind.AMBIGUOUS, f, f"uuid {link.uuid} in multiple files; left untouched")
                 )
                 continue
             target = index.get(link.uuid)
             if target is None:
-                result.findings.append(
+                local.append(
                     Finding(Kind.UNRESOLVABLE, f, f"uuid {link.uuid} not found; left untouched")
                 )
                 continue
@@ -84,7 +97,7 @@ def plan_repairs(
                 # The written path still points to a real file, but the uuid lives elsewhere:
                 # the two halves of the robust link disagree (typically a mis-pasted uuid). This
                 # is NOT a moved target, so don't guess which side is right — flag it for review.
-                result.findings.append(
+                local.append(
                     Finding(
                         Kind.CONFLICT,
                         f,
@@ -95,12 +108,18 @@ def plan_repairs(
                 continue
             _, frag = split_fragment(link.href)
             new_href = relative_link(target, f, frag)
-            result.findings.append(Finding(Kind.REPAIR, f, f"{link.href} -> {new_href}"))
+            local.append(Finding(Kind.REPAIR, f, f"{link.href} -> {new_href}"))
             # splice the rewritten robust link in place of the old span
             pieces.append(content[cursor:link.start])
             pieces.append(emit_robust_link(link.text, new_href, link.uuid))
             cursor = link.end
             changed = True
+        if not scoped:
+            # Outside the write scope: nothing is written and nothing is reported as actionable —
+            # but the count is surfaced, so a narrowed run never reads as "the tree is clean".
+            result.suppressed += len(local)
+            continue
+        result.findings.extend(local)
         if changed:
             pieces.append(content[cursor:])
             result.new_content[f] = "".join(pieces)

--- a/src/darnlink/report.py
+++ b/src/darnlink/report.py
@@ -16,6 +16,9 @@ class Kind(str, Enum):
     DENY_LISTED = "deny_listed"        # robustify target matches --no-create-frontmatter-for: never given a uuid
     IGNORED_LINKS = "ignored_links"    # source carries <!-- darnlink-ignore-links -->: its own links are left alone (it stays a target)
     INVALID_FRONTMATTER = "invalid_frontmatter"  # frontmatter present but not valid YAML; reported, never touched
+    OUT_OF_SCOPE = "out_of_scope"      # robustify target exists but was never scanned (outside the root, or excluded): its uuid is unknown, so the link is left plain — NOT the same as having no frontmatter (FR-009)
+    TARGET_UUID_WRITE = "target_uuid_write"      # (--only) a uuid was written into a target outside the write scope, so the link could be anchored (FR-006)
+    TARGET_WRITE_REFUSED = "target_write_refused"  # (--only --no-target-writes) target outside the write scope needs a uuid; refused, link left plain (FR-006)
 
 
 @dataclass(frozen=True)

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -160,6 +160,17 @@ def plan_robustify(
     # whose target ALREADY has a uuid are counted; deciding the rest would mean minting uuids for
     # files this run has no mandate to touch.
     if only is not None:
+        has_uuid: Dict[Path, bool] = {}  # target -> already has a uuid; parse each target once (Copilot)
+
+        def _target_has_uuid(tr: Path) -> bool:
+            cached = has_uuid.get(tr)
+            if cached is None:
+                c = contents.get(tr)
+                status, existing = read_frontmatter_uuid(c) if c is not None else ("none", None)
+                cached = status == "valid" and bool(existing)
+                has_uuid[tr] = cached
+            return cached
+
         for f in files:
             if in_scope(f, only) or f.resolve() in link_ignored:
                 continue
@@ -168,13 +179,9 @@ def plan_robustify(
                 if t is None or t.resolve() == f.resolve():
                     continue
                 tr = t.resolve()
-                if tr in ignored_targets:
+                if tr in ignored_targets or tr not in contents:
                     continue
-                c = contents.get(tr)
-                if c is None:
-                    continue
-                status, existing = read_frontmatter_uuid(c)
-                if status == "valid" and existing:
+                if _target_has_uuid(tr):
                     result.suppressed += 1
 
     # --- Phase B: per file, annotate plain links, then add its own uuid if it is a target ---
@@ -210,8 +217,9 @@ def plan_robustify(
             if tr in skip_out_of_scope:
                 result.findings.append(
                     Finding(Kind.OUT_OF_SCOPE, f,
-                            f"{link.href}: target is outside the scanned root (or excluded); "
-                            f"its uuid was never read — widen PATH to anchor this link")
+                            f"{link.href}: target is outside the scanned root (or skipped by "
+                            f"--exclude); its uuid was never read — scan the target (widen PATH "
+                            f"or drop the --exclude that hides it) to anchor this link")
                 )
                 continue
             if tr in skip_target_write:

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from fnmatch import fnmatch
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from .frontmatter_edit import (
     add_uuid_to_content,
@@ -25,6 +25,7 @@ from .links import (code_spans, emit_robust_link, file_ignores_links, file_is_ig
                     find_plain_links, ignored_spans)
 from .paths import is_local_md, resolve_href
 from .report import Finding, Kind
+from .scope import in_scope
 
 
 @dataclass
@@ -34,6 +35,7 @@ class RobustifyResult:
     ignored: List[Path] = field(default_factory=list)  # files skipped via the ignore-file marker
     link_ignored: List[Path] = field(default_factory=list)  # sources via the ignore-links marker (006)
     invalid: List[Path] = field(default_factory=list)  # files with non-YAML frontmatter (reported)
+    suppressed: int = 0  # anchorable links in files outside the write scope (010): counted, never hidden
 
 
 def _md_target(href: str, linking_file: Path) -> Path | None:
@@ -56,7 +58,20 @@ def plan_robustify(
     excludes: set = DEFAULT_EXCLUDES,
     block_markers: tuple = (),
     no_create_globs: Tuple[str, ...] = (),
+    only: Optional[Set[Path]] = None,
+    allow_target_writes: bool = True,
 ) -> RobustifyResult:
+    """Plan the robustify pass over `root` (no writes).
+
+    `only` (feature 010) narrows the **write** scope, never the scan: the whole tree is still read,
+    because a link's target — whose `uuid` this pass needs — usually lives outside the caller's own
+    subtree. Only links inside the named files are annotated; anchorable links elsewhere are counted
+    in `suppressed`.
+
+    `allow_target_writes=False` refuses the one write that legitimately lands outside `only`: adding
+    a `uuid` to a *target* so the link can be anchored at all (FR-006). Such links stay plain and are
+    reported.
+    """
     result = RobustifyResult()
     link_ignored: Set[Path] = set()   # feature 006: sources that opt their own links out
     contents: Dict[Path, str] = {}
@@ -88,14 +103,20 @@ def plan_robustify(
     skip_no_fm: Set[Path] = set()       # targets with no frontmatter and create disabled
     skip_denied: Set[Path] = set()      # targets matched by --no-create-frontmatter-for (never a uuid)
     invalid_fm: Set[Path] = set()       # targets whose frontmatter is not valid YAML (reported)
+    skip_out_of_scope: Set[Path] = set()   # targets that exist but were never scanned (FR-009)
+    skip_target_write: Set[Path] = set()   # targets needing a uuid, refused by --no-target-writes (FR-006)
 
     def decide(target: Path) -> None:
         target = target.resolve()
-        if target in target_uuid or target in skip_no_fm or target in skip_denied or target in invalid_fm:
+        if (target in target_uuid or target in skip_no_fm or target in skip_denied
+                or target in invalid_fm or target in skip_out_of_scope or target in skip_target_write):
             return
         c = contents.get(target)
         if c is None:
-            skip_no_fm.add(target)  # outside scanned scope; don't touch
+            # FR-009: the target exists on disk but is outside the scanned root (or excluded), so its
+            # frontmatter was never read. Reporting this as "no frontmatter" states as fact something
+            # this run never checked — it is a *scope* result, and gets its own kind.
+            skip_out_of_scope.add(target)
             return
         status, existing = read_frontmatter_uuid(c)  # canonical YAML reader (FR-023)
         if status == "invalid":
@@ -110,6 +131,11 @@ def plan_robustify(
             # skip_no_fm so the report is accurate (it is not a "needs --create-frontmatter" case).
             skip_denied.add(target)
             return
+        if not in_scope(target, only) and not allow_target_writes:
+            # FR-006: anchoring this link would write a uuid into a file the caller did not name.
+            # The caller asked for the hard guarantee, so the link stays plain and is reported.
+            skip_target_write.add(target)
+            return
         u = new_uuid()
         if add_uuid_to_content(c, u, create_frontmatter) is None:
             skip_no_fm.add(target)  # no frontmatter, creation not allowed
@@ -120,6 +146,8 @@ def plan_robustify(
     for f in files:
         if f.resolve() in link_ignored:
             continue  # FR-033: its links are never rewritten -> they must not drive uuid creation
+        if not in_scope(f, only):
+            continue  # 010: its links are never rewritten either -> they must not create uuids
         for link in find_plain_links(contents.get(f, ""), spans.get(f, [])):
             t = _md_target(link.href, f)
             # Skip self-links (a file linking to itself, e.g. autogrid `path` rows): robustifying
@@ -127,20 +155,46 @@ def plan_robustify(
             if t is not None and t.resolve() != f.resolve():
                 decide(t)
 
+    # --- Phase A′ (only when narrowed): count what a full run would have anchored elsewhere ---
+    # Constitution II — no silent caps: a narrowed run must not read like a clean tree. Only links
+    # whose target ALREADY has a uuid are counted; deciding the rest would mean minting uuids for
+    # files this run has no mandate to touch.
+    if only is not None:
+        for f in files:
+            if in_scope(f, only) or f.resolve() in link_ignored:
+                continue
+            for link in find_plain_links(contents.get(f, ""), spans.get(f, [])):
+                t = _md_target(link.href, f)
+                if t is None or t.resolve() == f.resolve():
+                    continue
+                tr = t.resolve()
+                if tr in ignored_targets:
+                    continue
+                c = contents.get(tr)
+                if c is None:
+                    continue
+                status, existing = read_frontmatter_uuid(c)
+                if status == "valid" and existing:
+                    result.suppressed += 1
+
     # --- Phase B: per file, annotate plain links, then add its own uuid if it is a target ---
     for f in files:
         original = contents.get(f, "")
         pieces: List[str] = []
         cursor = 0
         changed = False
+        scoped = in_scope(f, only)  # 010: may this file's own links be rewritten?
         if f.resolve() in link_ignored:
             # FR-033: leave every link in it alone. We still fall through to the uuid write below,
             # because opting out as a SOURCE says nothing about being a target (FR-034/FR-035).
             result.link_ignored.append(f)
-            result.findings.append(Finding(
-                Kind.IGNORED_LINKS, f,
-                "file carries darnlink-ignore-links; its links are left as-is (still a target)"))
-        links = () if f.resolve() in link_ignored else find_plain_links(original, spans.get(f, []))
+            if scoped:
+                result.findings.append(Finding(
+                    Kind.IGNORED_LINKS, f,
+                    "file carries darnlink-ignore-links; its links are left as-is (still a target)"))
+        # Out of the write scope: its links are left alone here too, but it may still RECEIVE its own
+        # uuid below — being a target is not a write the caller has to name (FR-006).
+        links = () if (f.resolve() in link_ignored or not scoped) else find_plain_links(original, spans.get(f, []))
         for link in links:
             t = _md_target(link.href, f)
             if t is None or t.resolve() == f.resolve():
@@ -151,6 +205,20 @@ def plan_robustify(
             if tr in skip_denied:
                 result.findings.append(
                     Finding(Kind.DENY_LISTED, f, f"{link.href}: target deny-listed (--no-create-frontmatter-for); link left plain")
+                )
+                continue
+            if tr in skip_out_of_scope:
+                result.findings.append(
+                    Finding(Kind.OUT_OF_SCOPE, f,
+                            f"{link.href}: target is outside the scanned root (or excluded); "
+                            f"its uuid was never read — widen PATH to anchor this link")
+                )
+                continue
+            if tr in skip_target_write:
+                result.findings.append(
+                    Finding(Kind.TARGET_WRITE_REFUSED, f,
+                            f"{link.href}: target needs a uuid but is outside --only and "
+                            f"--no-target-writes is set; link left plain")
                 )
                 continue
             if tr in skip_no_fm:
@@ -175,6 +243,15 @@ def plan_robustify(
 
         if content != original:
             result.new_content[f] = content
+
+    # FR-006: name every uuid write that lands OUTSIDE the write scope — in the dry-run report too,
+    # so the caller sees it before it happens and can refuse it with --no-target-writes.
+    if only is not None:
+        for t in sorted(needs_uuid_write):
+            if not in_scope(t, only):
+                result.findings.append(Finding(
+                    Kind.TARGET_UUID_WRITE, t,
+                    "uuid added to this target (outside --only) so an inbound link could be anchored"))
 
     # report invalid-frontmatter targets once each (never read, never written) — FR-024/FR-026
     for p in sorted(invalid_fm):

--- a/src/darnlink/scope.py
+++ b/src/darnlink/scope.py
@@ -1,0 +1,60 @@
+"""Write scope (feature 010): which files an invocation may modify.
+
+`--only` narrows the **write** scope without touching the **index** scope. The tree is still walked
+and indexed in full — a link's target usually lives outside the caller's own subtree, and narrowing
+the *scan* is exactly what makes anchoring fail — but only the named files are rewritten.
+
+A scope of `None` means "no narrowing": every scanned file may be written, which is the historical
+behaviour and stays the default.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Iterable, List, Optional, Set
+
+
+class ScopeError(ValueError):
+    """A `--only` path that cannot be part of a write scope (FR-003)."""
+
+
+def read_paths_from(source: str) -> List[str]:
+    """Newline-separated paths from `source`; `-` reads stdin.
+
+    This is how a caller passes a *generated* list (e.g. staged files) without darnlink learning
+    where the list came from — it knows nothing about git (Constitution I/III).
+    """
+    try:
+        text = sys.stdin.read() if source == "-" else Path(source).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ScopeError(f"--only-from: cannot read {source}: {exc}") from exc
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def resolve_write_scope(paths: Iterable[str], root: Path) -> Optional[Set[Path]]:
+    """Resolve `--only` paths against the CWD and validate them (FR-003). Empty input -> `None`.
+
+    Every path must exist, be a `.md` file, and live inside `root`. An unmatched path is an error
+    rather than a no-op on purpose: silently ignoring it would turn a typo — or a stale entry in a
+    generated list — into a green run that wrote nothing.
+    """
+    paths = list(paths)
+    if not paths:
+        return None
+    root = root.resolve()
+    scope: Set[Path] = set()
+    for raw in paths:
+        p = Path(raw).resolve()
+        if not p.exists():
+            raise ScopeError(f"--only: no such file: {raw}")
+        if not p.is_file() or p.suffix.lower() != ".md":
+            raise ScopeError(f"--only: not a Markdown file: {raw}")
+        if not p.is_relative_to(root):
+            raise ScopeError(f"--only: outside the scanned root ({root}): {raw}")
+        scope.add(p)
+    return scope
+
+
+def in_scope(path: Path, scope: Optional[Set[Path]]) -> bool:
+    """True if `path` may be written (always true when there is no narrowing)."""
+    return scope is None or path.resolve() in scope

--- a/tests/test_write_scope.py
+++ b/tests/test_write_scope.py
@@ -1,0 +1,246 @@
+"""Feature 010: write scope — `--only` / `--only-from` / `--no-target-writes`.
+
+Acceptance (from specs/010-write-scope/spec.md):
+1. motivating case — a file whose target lives in another subtree is anchored (dir-scan skips it)
+2. several files at once
+3. the guarantee — nothing outside the write scope changes (hash the tree)
+4. target writes are visible (reported) and refusable (--no-target-writes)
+5. repair, narrowed — outbound repaired; report says inbound elsewhere not considered
+6. guard rails — bad --only path exits 1
+7. piped list — --only-from - == repeated --only
+8. regression — no --only is byte-identical; `darnlink some/file.md` still errors
+"""
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from darnlink.cli import main
+from darnlink.frontmatter_edit import read_uuid_from_content
+from darnlink.links import find_robust_links
+from darnlink.report import Kind
+from darnlink.robustify import plan_robustify
+from darnlink.scope import ScopeError, resolve_write_scope
+
+U = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+V = "11111111-2222-3333-4444-555555555555"
+
+
+def _w(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _tree_hashes(root: Path):
+    return {p.relative_to(root).as_posix(): hashlib.sha1(p.read_bytes()).hexdigest()
+            for p in sorted(root.rglob("*.md"))}
+
+
+# --- 1. the motivating case: target in another subtree, only the source is written ---------------
+
+def test_only_anchors_link_whose_target_is_in_another_subtree(tmp_path):
+    _w(tmp_path / "y" / "B.md", f"---\nuuid: {U}\n---\n# B\n")   # target already has a uuid
+    _w(tmp_path / "x" / "A.md", "See [B](../y/B.md) plain.\n")
+    a = tmp_path / "x" / "A.md"
+
+    rc = main([str(tmp_path), "--robustify", "--write", "--only", str(a)])
+    assert rc == 0
+    links = find_robust_links(a.read_text())
+    assert len(links) == 1 and links[0].uuid == U          # anchored, reusing the target's uuid
+    # target byte-identical (it already had a uuid — no write needed)
+    assert (tmp_path / "y" / "B.md").read_text() == f"---\nuuid: {U}\n---\n# B\n"
+
+
+def test_dir_scan_of_the_subtree_alone_cannot_anchor_it(tmp_path):
+    # Contrast: scanning only x/ (today's advice) never indexes y/B.md, so the target is unknown.
+    _w(tmp_path / "y" / "B.md", f"---\nuuid: {U}\n---\n# B\n")
+    _w(tmp_path / "x" / "A.md", "See [B](../y/B.md) plain.\n")
+    result = plan_robustify(tmp_path / "x")
+    assert result.new_content == {}                        # nothing anchored
+    assert any(f.kind is Kind.OUT_OF_SCOPE for f in result.findings)   # FR-009: honest kind
+    assert not any(f.kind is Kind.NO_FRONTMATTER for f in result.findings)  # NOT the wrong one
+
+
+# --- 2. several files at once --------------------------------------------------------------------
+
+def test_only_multiple_files(tmp_path):
+    _w(tmp_path / "t1" / "B.md", f"---\nuuid: {U}\n---\n# B\n")
+    _w(tmp_path / "t2" / "C.md", f"---\nuuid: {V}\n---\n# C\n")
+    _w(tmp_path / "A.md", "[B](t1/B.md) and [C](t2/C.md)\n")
+    _w(tmp_path / "D.md", "[C](t2/C.md)\n")                 # NOT in scope — must stay plain
+    a = tmp_path / "A.md"
+
+    rc = main([str(tmp_path), "--robustify", "--write", "--only", str(a)])
+    assert rc == 0
+    assert len(find_robust_links(a.read_text())) == 2
+    assert find_robust_links((tmp_path / "D.md").read_text()) == []   # untouched
+
+
+# --- 3. the guarantee: nothing outside the write scope changes ------------------------------------
+
+def test_nothing_outside_scope_is_written(tmp_path):
+    _w(tmp_path / "B.md", f"---\nuuid: {U}\n---\n# B\n")
+    _w(tmp_path / "keep" / "A.md", "[B](../B.md)\n")
+    # many other robustifiable links elsewhere — a repo-wide run would rewrite them all
+    for i in range(5):
+        _w(tmp_path / "other" / f"O{i}.md", "[B](../B.md)\n")
+    before = _tree_hashes(tmp_path)
+    a = tmp_path / "keep" / "A.md"
+
+    main([str(tmp_path), "--robustify", "--write", "--only", str(a)])
+    after = _tree_hashes(tmp_path)
+
+    changed = {k for k in before if before[k] != after[k]}
+    assert changed == {"keep/A.md"}                         # exactly the scoped file, nothing else
+
+
+def test_idempotent_under_only(tmp_path):
+    _w(tmp_path / "B.md", f"---\nuuid: {U}\n---\n# B\n")
+    _w(tmp_path / "A.md", "[B](B.md)\n")
+    a = tmp_path / "A.md"
+    main([str(tmp_path), "--robustify", "--write", "--only", str(a)])
+    second = plan_robustify(tmp_path, only={a.resolve()})
+    assert second.new_content == {}
+
+
+# --- 4. target writes are visible and refusable --------------------------------------------------
+
+def test_target_write_is_reported_and_happens_by_default(tmp_path):
+    _w(tmp_path / "y" / "B.md", "---\ntitle: B\n---\n# B\n")  # frontmatter, but NO uuid
+    _w(tmp_path / "x" / "A.md", "[B](../y/B.md)\n")
+    a = tmp_path / "x" / "A.md"
+    b = tmp_path / "y" / "B.md"
+
+    # dry-run: the out-of-scope write is announced before it happens (FR-006)
+    dry = plan_robustify(tmp_path, only={a.resolve()})
+    assert any(f.kind is Kind.TARGET_UUID_WRITE and f.file.resolve() == b.resolve()
+               for f in dry.findings)
+
+    # apply: the uuid lands in B (the one write allowed outside --only) and A is anchored to it
+    main([str(tmp_path), "--robustify", "--write", "--only", str(a)])
+    u = read_uuid_from_content(b.read_text())
+    assert u is not None
+    assert find_robust_links(a.read_text())[0].uuid == u
+
+
+def test_no_target_writes_refuses_and_leaves_link_plain(tmp_path):
+    _w(tmp_path / "y" / "B.md", "---\ntitle: B\n---\n# B\n")  # no uuid
+    _w(tmp_path / "x" / "A.md", "[B](../y/B.md)\n")
+    a = tmp_path / "x" / "A.md"
+    b = tmp_path / "y" / "B.md"
+    before = _tree_hashes(tmp_path)
+
+    rc = main([str(tmp_path), "--robustify", "--write", "--only", str(a), "--no-target-writes"])
+    assert rc == 0
+    assert _tree_hashes(tmp_path) == before                # NOTHING changed — the hard guarantee
+    result = plan_robustify(tmp_path, only={a.resolve()}, allow_target_writes=False)
+    assert any(f.kind is Kind.TARGET_WRITE_REFUSED for f in result.findings)
+    assert read_uuid_from_content(b.read_text()) is None   # B never got a uuid
+
+
+def test_no_target_writes_without_only_is_a_usage_error(tmp_path):
+    _w(tmp_path / "A.md", "hi\n")
+    assert main([str(tmp_path), "--robustify", "--no-target-writes"]) == 1
+
+
+# --- 5. repair, narrowed -------------------------------------------------------------------------
+
+def test_repair_under_only_fixes_outbound(tmp_path, capsys):
+    _w(tmp_path / "new" / "B.md", f"---\nuuid: {U}\n---\n# B\n")
+    _w(tmp_path / "A.md", f"[B](old/B.md) <!-- uuid: {U} -->\n")   # stale path — B moved to new/
+    a = tmp_path / "A.md"
+    rc = main([str(tmp_path), "--write", "--only", str(a)])
+    assert rc == 0
+    assert find_robust_links(a.read_text())[0].href.endswith("new/B.md")
+    out = capsys.readouterr().out
+    assert "inbound" in out.lower()                         # FR-008: warns it did not see inbound links
+
+
+def test_repair_under_only_does_not_touch_inbound_in_other_files(tmp_path):
+    # C points at A by uuid; A moves. A scoped repair on A must NOT fix C (that is a full-tree job).
+    _w(tmp_path / "moved" / "A.md", f"---\nuuid: {V}\n---\n# A\n")
+    _w(tmp_path / "C.md", f"[A](A.md) <!-- uuid: {V} -->\n")       # stale: A now under moved/
+    before = (tmp_path / "C.md").read_text()
+    main([str(tmp_path), "--write", "--only", str(tmp_path / "moved" / "A.md")])
+    assert (tmp_path / "C.md").read_text() == before               # inbound untouched
+
+
+# --- 6. guard rails ------------------------------------------------------------------------------
+
+def test_only_nonexistent_path_errors(tmp_path):
+    _w(tmp_path / "A.md", "hi\n")
+    assert main([str(tmp_path), "--robustify", "--only", str(tmp_path / "nope.md")]) == 1
+
+
+def test_only_non_md_path_errors(tmp_path):
+    _w(tmp_path / "A.md", "hi\n")
+    _w(tmp_path / "note.txt", "x\n")
+    assert main([str(tmp_path), "--robustify", "--only", str(tmp_path / "note.txt")]) == 1
+
+
+def test_only_outside_root_errors(tmp_path):
+    root = tmp_path / "repo"
+    _w(root / "A.md", "hi\n")
+    outside = tmp_path / "elsewhere.md"
+    _w(outside, "---\nuuid: x\n---\n")
+    assert main([str(root), "--robustify", "--only", str(outside)]) == 1
+
+
+def test_resolve_write_scope_unit(tmp_path):
+    _w(tmp_path / "A.md", "hi\n")
+    assert resolve_write_scope([], tmp_path) is None                # no narrowing
+    scope = resolve_write_scope([str(tmp_path / "A.md")], tmp_path)
+    assert scope == {(tmp_path / "A.md").resolve()}
+    with pytest.raises(ScopeError):
+        resolve_write_scope([str(tmp_path / "ghost.md")], tmp_path)
+
+
+# --- 7. piped list (--only-from -) ---------------------------------------------------------------
+
+def test_only_from_stdin_matches_repeated_only(tmp_path, monkeypatch):
+    import io
+    _w(tmp_path / "B.md", f"---\nuuid: {U}\n---\n# B\n")
+    _w(tmp_path / "A.md", "[B](B.md)\n")
+    a = tmp_path / "A.md"
+    monkeypatch.setattr("sys.stdin", io.StringIO(f"{a}\n"))
+    rc = main([str(tmp_path), "--robustify", "--write", "--only-from", "-"])
+    assert rc == 0
+    assert find_robust_links(a.read_text())[0].uuid == U
+
+
+# --- 8. regression: no --only is byte-identical; a file positional still errors -------------------
+
+def test_no_only_is_unchanged_behaviour(tmp_path):
+    _w(tmp_path / "B.md", f"---\nuuid: {U}\n---\n# B\n")
+    _w(tmp_path / "A.md", "[B](B.md)\n")
+    plain = plan_robustify(tmp_path)
+    scoped_none = plan_robustify(tmp_path, only=None)
+    assert plain.new_content.keys() == scoped_none.new_content.keys()
+    assert plain.suppressed == 0
+
+
+def test_positional_file_still_errors(tmp_path):
+    f = tmp_path / "A.md"
+    _w(f, "hi\n")
+    assert main([str(f), "--robustify"]) == 2               # "not a directory" — unchanged contract
+
+
+# --- check --only (FR-010) -----------------------------------------------------------------------
+
+def test_check_only_limits_findings_to_scoped_source(tmp_path):
+    _w(tmp_path / "B.md", f"---\nuuid: {U}\n---\n# B\n")
+    _w(tmp_path / "mine.md", "[B](B.md)\n")                 # anchorable plain link — mine
+    _w(tmp_path / "theirs.md", "[B](B.md)\n")               # anchorable plain link — someone else's
+    # scoped to mine.md: strict failure is only about my file
+    assert main(["check", str(tmp_path), "--only", str(tmp_path / "mine.md")]) == 3
+    # scoped to a clean file: green, despite theirs.md being dirty
+    _w(tmp_path / "clean.md", f"[B](B.md) <!-- uuid: {U} -->\n")
+    assert main(["check", str(tmp_path), "--only", str(tmp_path / "clean.md")]) == 0
+
+
+def test_check_only_ignores_others_invalid_frontmatter(tmp_path):
+    # someone else's invalid YAML must not fail my scoped check (no deadlock)
+    _w(tmp_path / "B.md", f"---\nuuid: {U}\n---\n# B\n")
+    _w(tmp_path / "theirs.md", "---\n: : bad yaml\n---\n# broken\n")
+    _w(tmp_path / "mine.md", f"[B](B.md) <!-- uuid: {U} -->\n")   # clean
+    assert main(["check", str(tmp_path), "--only", str(tmp_path / "mine.md")]) == 0


### PR DESCRIPTION
## Why

darnlink's positional `path` fused two scopes: which files are **read** (to build the `uuid → path` target graph) and which are **written**. That makes the commonest case impossible — *"anchor the links in the file I'm committing, touch nothing else"*:

- Scan your subtree (`darnlink tasks/56`) → the link's target lives elsewhere, so it's never indexed. The link isn't anchored, and it was **misreported as `no_frontmatter`** when the target actually has one.
- Scan repo-wide → rewrites every robustifiable link in the tree, including other people's work in flight.

Real trigger (2026-07-21, consumer repo `project_map`): a pre-commit gate advised `darnlink <your/path> --robustify --write` and neither scope could follow the advice. The link was anchored by hand.

## What

Split the two axes.

- **`--only FILE`** (repeatable) narrows the **write** scope; the whole tree is still scanned so targets resolve wherever they live. "Read everything, write here."
- **`--only-from FILE`** reads the path list from a file or stdin (`-`), so a caller pipes `git diff --cached --name-only` in **without darnlink learning about git** (Constitution I/III — VCS knowledge stays in a recipe/hook, not the CLI). This replaces the need for a bespoke `--staged` flag.
- **`--no-target-writes`** — the one write allowed outside the scope is adding a `uuid` to a *target* so a link can be anchored; it's reported (`target_uuid_write`) before it happens. This flag refuses even that: absolute guarantee that **nothing** outside `--only` is touched.
- **Repair under `--only`** inspects only outbound links, and warns that a moved target's *inbound* links still need a full-tree run (a scoped clean result is not proof the tree is clean).
- **`check --only`** filters findings to the scoped sources (what a gate needs), and scopes invalid-frontmatter to the caller's own files so someone else's broken YAML can't fail your commit.

### Adjacent fix

A plain link whose target **exists but was never scanned** (outside `path`, or excluded) now reports the honest **`out_of_scope`** kind instead of `no_frontmatter` — the exact confusion that motivated this feature.

## Scope / constitution

Refines *which files may be written* — same class of knob as `--exclude` (which are scanned) and the in-file markers (which axes a file joins). No document semantics, no external state, no git. Principle I unchanged; strictly narrowing, so Principle II (safe-by-default) holds. Spec: `specs/010-write-scope/spec.md`.

## Tests

19 new (`tests/test_write_scope.py`) covering all 8 acceptance cases: target in another subtree, several files, the no-write-outside guarantee (tree hashed before/after), target-writes visible + refusable, repair-narrowed + inbound untouched, guard rails, stdin list, and regression (directory-scan byte-identical; a file positional still errors). Full suite 94 green; CI-mirror `tools/check.sh` clean; dogfood `darnlink check .` clean.

New `--json` fields: `write_scope`, `suppressed_outside_write_scope`. New kinds: `out_of_scope`, `target_uuid_write`, `target_write_refused`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)