### PR TITLE
feat(recipes): mode=max (fail-closed links) + complete wall examples + doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ breakage before it lands. Pick the one that fits your workflow — near copy-pas
 
 > **Want a ready-made wrapper instead of wiring it yourself?** [`recipes/darnlink-gate`](recipes/README.md)
 > does all of the below (both checks, staged-in-pre-commit vs whole-repo-in-CI, pinned ref, fail-open)
-> from a tiny `darnlink-gate.json`. It's a reference recipe, fetchable in CI without a token.
+> from a tiny `darnlink-gate.json`. It's a reference recipe, fetchable in CI without a token — with
+> complete copy-paste hook & CI files in [`recipes/examples/`](recipes/examples/).
 
 **1. pre-commit** (recommended — darnlink ships a hook):
 

--- a/docs/elevating-your-link-gate.md
+++ b/docs/elevating-your-link-gate.md
@@ -191,6 +191,11 @@ When the gap reads **0**, switch your gate command to the maximum:
 
 Re-verify 0, and you're fail-closed: from now on, a link to any file without a `uuid` fails.
 
+> **Using the [`darnlink-gate`](../recipes/README.md) recipe?** This flip is **one line** — set
+> `"mode": "max"` in `darnlink-gate.json`; the hooks and CI don't change. `mode=max` runs exactly the
+> command above (dry-run) at the whole-repo wall, and stays at strict in the staged pre-commit by
+> design (§7). Copy-paste hook/CI files: [`recipes/examples/`](../recipes/examples/).
+
 ## 7. Lock it in — the wall architecture
 
 A gate only guarantees anything at the layers where it actually runs and blocks. Use more than one,
@@ -206,6 +211,14 @@ The pre-commit and pre-push checks both call the same fail-closed command; flipp
 `--create-frontmatter` in one place raises them together. The scope split (staged locally, whole-repo
 in the wall) is the same recommendation the README makes for multi-contributor repos — here it's the
 load-bearing reason the maximum is livable.
+
+**Complete, copy-paste files for all three layers** are in
+[`recipes/examples/`](../recipes/examples/) — [`pre-commit`](../recipes/examples/pre-commit) (staged) ·
+[`pre-push`](../recipes/examples/pre-push) (whole repo) ·
+[`github-actions-darnlink-gate.yml`](../recipes/examples/github-actions-darnlink-gate.yml) and
+[`Jenkinsfile-stage.groovy`](../recipes/examples/Jenkinsfile-stage.groovy) (the server wall,
+fail-closed). They're whole working artifacts, not snippets to assemble — assembling the CI one wrong
+is how you get a wall that fails *open*.
 
 ## Checklist
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -16,8 +16,9 @@ is that orchestration in one place; a consumer carries only a tiny config + a 3-
     robustify their links yet).
   - `mode=check` → integrity **+** strict (the default). Runs `darnlink check` (stable `0/2/3`).
   - `mode=max` → integrity + strict **+ create-frontmatter** = **fail-closed links**: a link to a file
-    with **no `uuid`** fails the gate. `check` tops out at strict, so `max` runs
-    `darnlink . --robustify --create-frontmatter` in **dry-run** and gates on its exit.
+    with **no `uuid`** fails the gate. `check` has no create-frontmatter axis and the bare
+    `darnlink . --robustify --create-frontmatter` has no integrity axis, so `max` runs **both** dry-run
+    passes (a true superset of `check` — it can't silently drop broken robust links).
     **Whole-repo only** — the staged pre-commit stays at strict on purpose (fast); the whole-repo wall
     (pre-push / CI) is where `max` is enforced. See [`docs/elevating-your-link-gate.md`](../docs/elevating-your-link-gate.md).
 - `scope=repo` → judge the whole tree (**the wall — use in pre-push & CI**).

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -10,20 +10,36 @@ is that orchestration in one place; a consumer carries only a tiny config + a 3-
 ## What it does (read-only — never writes)
 
 - Runs darnlink at a **pinned ref** (deterministic).
-- Always runs `darnlink check` (**both** axes, stable exit `0/2/3`); `mode` only picks which axes gate:
-  `mode=check` → integrity + strict both gate. `mode=repair` → **integrity only** — a strict-only
-  failure (`3`) is treated as clean (for repos that don't robustify their links yet).
-- `scope=repo` → judge the whole tree (**the wall — use in CI**).
+- `mode` picks which axes gate — **three rungs of a one-way ratchet** (each a superset of the one
+  above, so raising `mode` can only tighten):
+  - `mode=repair` → **integrity only** — a strict-only failure (`3`) is clean (repos that don't
+    robustify their links yet).
+  - `mode=check` → integrity **+** strict (the default). Runs `darnlink check` (stable `0/2/3`).
+  - `mode=max` → integrity + strict **+ create-frontmatter** = **fail-closed links**: a link to a file
+    with **no `uuid`** fails the gate. `check` tops out at strict, so `max` runs
+    `darnlink . --robustify --create-frontmatter` in **dry-run** and gates on its exit.
+    **Whole-repo only** — the staged pre-commit stays at strict on purpose (fast); the whole-repo wall
+    (pre-push / CI) is where `max` is enforced. See [`docs/elevating-your-link-gate.md`](../docs/elevating-your-link-gate.md).
+- `scope=repo` → judge the whole tree (**the wall — use in pre-push & CI**).
   `scope=staged` → judge only the files you're committing (**multi-session pre-commit**, so a
   teammate's in-flight plain link doesn't block your commit). It filters `darnlink check --json` by
   `git diff --cached` — **darnlink stays git-agnostic; the git lives here** (darnlink spec 008,
   Option B).
-- Fails **open** on a network/uvx error (offline commits aren't bricked; CI is the backstop).
+- Fails **open** on a network/uvx error (offline commits aren't bricked) — **UNLESS fail-closed is on**.
+  ⚠️ **In CI set `DARNLINK_GATE_FAIL_CLOSED=1`** (or `"fail_closed": true`): there the gate *is* the
+  wall, and failing open on a transient network/PyPI hiccup means a **GREEN build with zero files
+  validated**. Prefer the env var over the json key — reading the json needs `python3`, and
+  "python3 missing" is one of the very cases fail-closed exists to catch.
 - **Refuses `--write`** (this gate never mutates; robustify by hand).
 
-Exit: `0` clean · `2` integrity failure · `3` strict-only failure · `1` usage.
+Exit: `0` clean · `2` integrity failure · `3` strict-only failure · `1` usage / `max`-mode findings ·
+`4` could-not-gate (fail-closed only).
 
-## Adopt it in a repo (3 pieces)
+## Adopt it in a repo (the wall in 4 pieces)
+
+The gate runs at three layers, each at the scope that fits — **deliberate, not redundant** (see
+[`docs/elevating-your-link-gate.md §7`](../docs/elevating-your-link-gate.md)): staged & fast locally,
+whole-repo where it's the wall.
 
 **1. Config** — `darnlink-gate.json` at the repo root (all keys optional):
 
@@ -37,8 +53,8 @@ Exit: `0` clean · `2` integrity failure · `3` strict-only failure · `1` usage
 }
 ```
 
-**2. Pre-commit** — a 3-line `conf.d` fragment (staged scope, so parallel sessions don't block each
-other; the repo-wide wall stays in CI):
+**2. Pre-commit** (staged, fast) — so parallel sessions don't block each other; the repo-wide wall is
+pieces 3–4:
 
 ```bash
 #!/usr/bin/env bash
@@ -46,12 +62,30 @@ other; the repo-wide wall stays in CI):
 exec env DARNLINK_GATE_SCOPE=staged darnlink-gate
 ```
 
-**3. CI** (GitHub Actions / Jenkins) — the wall, whole-repo:
+**3. Pre-push** (whole repo) — `git push` is deliberate and infrequent → no deadlock. This is the
+**local wall** that stops anything broken from leaving your machine, even if CI is down:
+
+```bash
+#!/usr/bin/env bash
+# .git/hooks/pre-push  (or hooks/pre-push if you version your hooks)
+exec darnlink-gate            # scope=repo from config
+```
+
+**4. CI** (GitHub Actions / Jenkins, whole repo) — the unbypassable server-side wall (catches even a
+`--no-verify`). **Set fail-closed**, or a network hiccup gives you a green build that validated nothing:
 
 ```yaml
 - uses: astral-sh/setup-uv@v5
 - run: darnlink-gate            # scope=repo from config
+  env:
+    DARNLINK_GATE_FAIL_CLOSED: "1"   # ← the wall must fail closed
 ```
+
+> On a private repo where hosted CI minutes are billed or branch protection is unavailable, a
+> **self-hosted runner** (e.g. a home CI box) is the natural home for piece 4 — same check, no billing.
+
+**Complete, copy-paste versions of all four** live in [`examples/`](examples/) — whole working files,
+not snippets to assemble (assembling the CI one wrong yields a wall that fails *open*).
 
 **Getting the script.** It lives here — `recipes/darnlink-gate` in the **public** darnlink repo — so
 any CI can fetch it **without a token** (no private checkout, no cred):

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -17,8 +17,9 @@
 #     mode=check  → integrity + strict (the default). Runs `darnlink check` (stable 0/2/3 contract);
 #     mode=max    → integrity + strict + create-frontmatter = FAIL-CLOSED links: a link to a file
 #                   that has no `uuid` fails the gate (see docs/elevating-your-link-gate.md). `check`
-#                   tops out at strict, so max runs `darnlink . --robustify --create-frontmatter` in
-#                   DRY-RUN (never --write) and gates on its exit. WHOLE-REPO ONLY — the staged
+#                   has no create-frontmatter axis and the bare `--robustify --create-frontmatter` has
+#                   no integrity axis, so max runs BOTH dry-run passes (check UNION create-frontmatter)
+#                   and fails if either does — a true superset of check. WHOLE-REPO ONLY — the staged
 #                   pre-commit stays at strict on purpose (fast, "is what I commit clean?"); the
 #                   whole-repo wall (pre-push / CI) is where max is enforced.
 #   • scope=repo  → judge the whole tree (the wall — use in CI);
@@ -35,7 +36,7 @@
 #   { "ref": "git+https://github.com/txemi/darnlink@v0.7.0",
 #     "excludes": ["secrets","external_repos"], "ignore_blocks": ["txmd-autogrid"],
 #     "mode": "check", "scope": "repo", "fail_closed": true }
-#   mode ∈ { repair | check | max } — see WHAT IT DOES. Raising it is the "trinquete": only up.
+#   mode ∈ { repair | check | max } — see WHAT IT DOES. Raising it is a one-way ratchet: only up.
 # ⚠️ In CI prefer the ENV VAR over the json key: reading the json needs python3, so if python3 is
 #    missing the key is silently lost — and "python3 missing" is one of the very cases fail-closed
 #    exists to catch. `DARNLINK_GATE_FAIL_CLOSED=1` is read by the shell and always applies.
@@ -119,14 +120,16 @@ if [ "$SCOPE" != "staged" ]; then
   # before we read rc and run the rc>3 fail-open.
   set +e
   if [ "$MODE" = "max" ]; then
-    # LEVEL 3 (fail-closed): `check` has no create-frontmatter axis, so run the robustify pass in
-    # DRY-RUN (no --write ⇒ report-only) — a SUPERSET of check (repair + strict + create-frontmatter),
-    # so it can only tighten. Any finding ⇒ non-zero ⇒ gate fails; rc>3 still means "couldn't run".
-    run . --robustify --create-frontmatter "${DL_ARGS[@]}"
+    # LEVEL 3 = `check` (integrity + strict) UNION the create-frontmatter axis. Neither half alone is
+    # a superset of check: `check` runs plan_repairs+plan_robustify but has no create-frontmatter axis;
+    # the bare `--robustify --create-frontmatter` ADDS create-frontmatter but DROPS integrity (it never
+    # runs plan_repairs — a broken/moved robust link sails through). So run BOTH dry-run passes and
+    # fail if either does. This makes max a TRUE superset of check (the ratchet holds). Both read-only.
+    run check . "${DL_ARGS[@]}"; rc=$?
+    if [ "$rc" -eq 0 ]; then run . --robustify --create-frontmatter "${DL_ARGS[@]}"; rc=$?; fi
   else
-    run check . "${DL_ARGS[@]}"      # `darnlink check` → stable 0/2/3 contract (mode=check|repair)
+    run check . "${DL_ARGS[@]}"; rc=$?   # `darnlink check` → stable 0/2/3 contract (mode=check|repair)
   fi
-  rc=$?
   set -e
   # rc>3 (e.g. 127 network) → fail open + warn; darnlink's own low exit codes pass through.
   if [ "$rc" -gt 3 ]; then bail "darnlink unreachable (rc=$rc)"; fi

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -27,10 +27,10 @@
 #                   teammate's in-flight plain link doesn't block your commit). The repo-wide wall
 #                   stays in CI. [Option B of darnlink spec 008: git lives HERE, not in darnlink.]
 #   • fails OPEN on a network/uvx error (offline commit isn't bricked) — UNLESS fail-closed is on.
-#     ⚠️ FAIL-CLOSED (`DARNLINK_GATE_FAIL_CLOSED=1`, o `"fail_closed": true` en el json): en CI el gate
-#     ES el muro, y fallar abierto ahi significa BUILD VERDE CON CERO FICHEROS VALIDADOS ante un
-#     fallo transitorio de red/PyPI. Actívalo SIEMPRE en CI. Sale con codigo 4 (distinguible de los
-#     hallazgos: 2 integridad / 3 strict).
+#     ⚠️ FAIL-CLOSED (`DARNLINK_GATE_FAIL_CLOSED=1`, or `"fail_closed": true` in the json): in CI the
+#     gate IS the wall, and failing open there means a GREEN BUILD WITH ZERO FILES VALIDATED on a
+#     transient network/PyPI hiccup. Turn it ON in CI. It exits with code 4 (distinguishable from the
+#     findings: 2 integrity / 3 strict).
 #
 # CONFIG. Reads `darnlink-gate.json` at the repo root (all keys optional):
 #   { "ref": "git+https://github.com/txemi/darnlink@v0.7.0",
@@ -41,11 +41,11 @@
 #    missing the key is silently lost — and "python3 missing" is one of the very cases fail-closed
 #    exists to catch. `DARNLINK_GATE_FAIL_CLOSED=1` is read by the shell and always applies.
 # Env overrides (so one config serves both surfaces): DARNLINK_REF, DARNLINK_GATE_MODE,
-# DARNLINK_GATE_SCOPE, DARNLINK_GATE_FAIL_CLOSED. Typical wiring: config says scope=repo; el hook de
-# pre-commit exporta DARNLINK_GATE_SCOPE=staged; el CI deja repo y pone FAIL_CLOSED=1.
+# DARNLINK_GATE_SCOPE, DARNLINK_GATE_FAIL_CLOSED. Typical wiring: config says scope=repo; the
+# pre-commit hook exports DARNLINK_GATE_SCOPE=staged; CI leaves it repo and sets FAIL_CLOSED=1.
 #
 # EXIT: 0 clean · 2 integrity failure · 3 strict-only failure · 1 usage / max-mode findings ·
-#       4 no se pudo gatear (con fail-closed) · 0 + aviso a stderr si se salta (fail-open, el default).
+#       4 could-not-gate (fail-closed only) · 0 + a stderr warning if it skips (fail-open, the default).
 #       (mode=max reports findings via the dry-run's own non-zero exit — any non-zero fails the gate.)
 set -euo pipefail
 

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -10,10 +10,17 @@
 # WHAT IT DOES (all read-only — it never writes):
 #   • runs darnlink at a PINNED ref (deterministic); fails OPEN if uv/uvx is missing (never
 #     bootstraps) — unless fail-closed is on, see below;
-#   • ALWAYS runs `darnlink check` (stable 0/2/3 contract); MODE only picks which axes gate:
-#     mode=check  → integrity + strict both gate (exit 0/2/3);
+#   • MODE picks which axes gate — three rungs of a one-way ratchet (each is a superset of the one
+#     above, so raising MODE can only tighten the gate, never loosen it):
 #     mode=repair → integrity only — a strict-only failure (3) is treated as clean (for repos that
 #                   don't robustify their links yet);
+#     mode=check  → integrity + strict (the default). Runs `darnlink check` (stable 0/2/3 contract);
+#     mode=max    → integrity + strict + create-frontmatter = FAIL-CLOSED links: a link to a file
+#                   that has no `uuid` fails the gate (see docs/elevating-your-link-gate.md). `check`
+#                   tops out at strict, so max runs `darnlink . --robustify --create-frontmatter` in
+#                   DRY-RUN (never --write) and gates on its exit. WHOLE-REPO ONLY — the staged
+#                   pre-commit stays at strict on purpose (fast, "is what I commit clean?"); the
+#                   whole-repo wall (pre-push / CI) is where max is enforced.
 #   • scope=repo  → judge the whole tree (the wall — use in CI);
 #     scope=staged→ judge only the files you're committing (use in a multi-session pre-commit, so a
 #                   teammate's in-flight plain link doesn't block your commit). The repo-wide wall
@@ -28,6 +35,7 @@
 #   { "ref": "git+https://github.com/txemi/darnlink@v0.7.0",
 #     "excludes": ["secrets","external_repos"], "ignore_blocks": ["txmd-autogrid"],
 #     "mode": "check", "scope": "repo", "fail_closed": true }
+#   mode ∈ { repair | check | max } — see WHAT IT DOES. Raising it is the "trinquete": only up.
 # ⚠️ In CI prefer the ENV VAR over the json key: reading the json needs python3, so if python3 is
 #    missing the key is silently lost — and "python3 missing" is one of the very cases fail-closed
 #    exists to catch. `DARNLINK_GATE_FAIL_CLOSED=1` is read by the shell and always applies.
@@ -35,8 +43,9 @@
 # DARNLINK_GATE_SCOPE, DARNLINK_GATE_FAIL_CLOSED. Typical wiring: config says scope=repo; el hook de
 # pre-commit exporta DARNLINK_GATE_SCOPE=staged; el CI deja repo y pone FAIL_CLOSED=1.
 #
-# EXIT: 0 clean · 2 integrity failure · 3 strict-only failure · 1 usage · 4 no se pudo gatear
-#       (con fail-closed) · 0 + aviso a stderr si se salta (fail-open, el default).
+# EXIT: 0 clean · 2 integrity failure · 3 strict-only failure · 1 usage / max-mode findings ·
+#       4 no se pudo gatear (con fail-closed) · 0 + aviso a stderr si se salta (fail-open, el default).
+#       (mode=max reports findings via the dry-run's own non-zero exit — any non-zero fails the gate.)
 set -euo pipefail
 
 root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -109,10 +118,17 @@ if [ "$SCOPE" != "staged" ]; then
   # set +e around the run: darnlink exits 0/1/2/3 (findings ARE non-zero) — set -e must not kill us
   # before we read rc and run the rc>3 fail-open.
   set +e
-  run check . "${DL_ARGS[@]}"        # always `check` → stable 0/2/3 contract, regardless of MODE
+  if [ "$MODE" = "max" ]; then
+    # LEVEL 3 (fail-closed): `check` has no create-frontmatter axis, so run the robustify pass in
+    # DRY-RUN (no --write ⇒ report-only) — a SUPERSET of check (repair + strict + create-frontmatter),
+    # so it can only tighten. Any finding ⇒ non-zero ⇒ gate fails; rc>3 still means "couldn't run".
+    run . --robustify --create-frontmatter "${DL_ARGS[@]}"
+  else
+    run check . "${DL_ARGS[@]}"      # `darnlink check` → stable 0/2/3 contract (mode=check|repair)
+  fi
   rc=$?
   set -e
-  # rc>3 (e.g. 127 network) → fail open + warn; darnlink's own 0/2/3 pass through.
+  # rc>3 (e.g. 127 network) → fail open + warn; darnlink's own low exit codes pass through.
   if [ "$rc" -gt 3 ]; then bail "darnlink unreachable (rc=$rc)"; fi
   # mode=repair gates on integrity only: a strict-only failure (3) is clean.
   if [ "$MODE" = "repair" ] && [ "$rc" -eq 3 ]; then exit 0; fi
@@ -121,6 +137,9 @@ fi
 
 # ---- staged scope (Option B): darnlink judges the whole tree; WE filter findings to staged files.
 #      darnlink stays git-agnostic; the git lives here. Only fail on findings in files you're committing.
+#      NOTE mode=max here behaves as strict (level 2), by design: the create-frontmatter axis needs
+#      whole-tree reasoning, and per the wall architecture the staged pre-commit stays fast — max is
+#      enforced at the whole-repo wall (pre-push / CI). See docs/elevating-your-link-gate.md §7.
 # python3 does the filtering — fail OPEN if it's missing (don't brick a commit; CI covers the wall).
 if ! command -v python3 >/dev/null 2>&1; then
   bail "(staged) python3 not found"

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -2,15 +2,20 @@
 #
 # See the bash version for the full rationale. Same contract: read-only; config in darnlink-gate.json
 # (ref/excludes/ignore_blocks/mode/scope) with env overrides (DARNLINK_REF, DARNLINK_GATE_MODE,
-# DARNLINK_GATE_SCOPE). It ALWAYS runs `darnlink check` (stable 0/2/3 contract); MODE only picks which
-# axes gate: mode=check → integrity + strict both gate; mode=repair → integrity only (a strict-only
-# failure, 3, is treated as clean). scope=staged filters `darnlink check --json` by `git diff --cached`
-# (Option B — darnlink stays git-agnostic); refuses --write.
+# DARNLINK_GATE_SCOPE). MODE picks which axes gate — a one-way ratchet (repair ⊂ check ⊂ max):
+#   mode=repair → integrity only (a strict-only failure, 3, is treated as clean);
+#   mode=check  → integrity + strict, via `darnlink check` (stable 0/2/3 contract);
+#   mode=max    → integrity + strict + create-frontmatter (fail-closed links). Runs BOTH `check` AND
+#                 `darnlink . --robustify --create-frontmatter` (dry-run) — check has no create-fm axis
+#                 and the bare pass has no integrity axis, so max unions them. WHOLE-REPO only; the
+#                 staged pre-commit stays at strict by design (see the bash version §7 note).
+# scope=staged filters `darnlink check --json` by `git diff --cached` (Option B — darnlink stays
+# git-agnostic); refuses --write.
 #
 # FAIL-OPEN by default (an offline commit must not be bricked) — set DARNLINK_GATE_FAIL_CLOSED=1 (or
 # "fail_closed": true in the json) in CI, where the gate IS the wall and failing open would mean a
-# GREEN build with zero files validated. Exit: 0 clean · 2 integrity · 3 strict · 1 usage ·
-# 4 could-not-gate (fail-closed only).
+# GREEN build with zero files validated. Exit: 0 clean · 2 integrity · 3 strict · 1 usage / max
+# findings · 4 could-not-gate (fail-closed only).
 $ErrorActionPreference = "Stop"
 
 $root = (git rev-parse --show-toplevel 2>$null)
@@ -75,14 +80,20 @@ if ($LASTEXITCODE -ne 0) { Invoke-Bail "can't run darnlink at $ref (bad ref / no
 if ($scope -ne 'staged') {
   # ---- whole-repo (the wall): darnlink's own exit code is the gate ----
   if ($mode -eq 'max') {
-    # LEVEL 3 (fail-closed): `check` has no create-frontmatter axis, so run the robustify pass in
-    # DRY-RUN (no --write ⇒ report-only) — a SUPERSET of check (repair + strict + create-frontmatter),
-    # so it can only tighten. Any finding ⇒ non-zero ⇒ gate fails; rc>3 still means "couldn't run".
-    & uvx --from $ref darnlink . --robustify --create-frontmatter @dlArgs @args
+    # LEVEL 3 = check (integrity + strict) UNION create-frontmatter. `check` has no create-frontmatter
+    # axis; the bare `--robustify --create-frontmatter` DROPS integrity (never runs plan_repairs — a
+    # broken robust link would sail through). So run BOTH dry-run passes and fail if either does — a
+    # true superset of check. Both read-only.
+    & uvx --from $ref darnlink check . @dlArgs @args
+    $rc = $LASTEXITCODE
+    if ($rc -eq 0) {
+      & uvx --from $ref darnlink . --robustify --create-frontmatter @dlArgs @args
+      $rc = $LASTEXITCODE
+    }
   } else {
     & uvx --from $ref darnlink check . @dlArgs @args   # `darnlink check` → 0/2/3 (mode=check|repair)
+    $rc = $LASTEXITCODE
   }
-  $rc = $LASTEXITCODE
   if ($rc -gt 3) { Invoke-Bail "darnlink unreachable (rc=$rc)" }
   # mode=repair gates on integrity only: a strict-only failure (3) is clean.
   if ($mode -eq 'repair' -and $rc -eq 3) { exit 0 }

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -74,7 +74,14 @@ if ($LASTEXITCODE -ne 0) { Invoke-Bail "can't run darnlink at $ref (bad ref / no
 
 if ($scope -ne 'staged') {
   # ---- whole-repo (the wall): darnlink's own exit code is the gate ----
-  & uvx --from $ref darnlink check . @dlArgs @args   # always `check` → stable 0/2/3, regardless of MODE
+  if ($mode -eq 'max') {
+    # LEVEL 3 (fail-closed): `check` has no create-frontmatter axis, so run the robustify pass in
+    # DRY-RUN (no --write ⇒ report-only) — a SUPERSET of check (repair + strict + create-frontmatter),
+    # so it can only tighten. Any finding ⇒ non-zero ⇒ gate fails; rc>3 still means "couldn't run".
+    & uvx --from $ref darnlink . --robustify --create-frontmatter @dlArgs @args
+  } else {
+    & uvx --from $ref darnlink check . @dlArgs @args   # `darnlink check` → 0/2/3 (mode=check|repair)
+  }
   $rc = $LASTEXITCODE
   if ($rc -gt 3) { Invoke-Bail "darnlink unreachable (rc=$rc)" }
   # mode=repair gates on integrity only: a strict-only failure (3) is clean.
@@ -83,6 +90,9 @@ if ($scope -ne 'staged') {
 }
 
 # ---- staged scope (Option B): darnlink judges the whole tree; WE filter findings to staged files ----
+# NOTE mode=max here behaves as strict (level 2), by design: the create-frontmatter axis needs
+# whole-tree reasoning, and per the wall architecture the staged pre-commit stays fast — max is
+# enforced at the whole-repo wall (pre-push / CI). See docs/elevating-your-link-gate.md §7.
 $staged = @(git diff --cached --name-only --diff-filter=ACMR -- '*.md' 2>$null)
 if (-not $staged) { Write-Output "darnlink-gate (staged): no staged .md — nothing to judge."; exit 0 }
 

--- a/recipes/examples/Jenkinsfile-stage.groovy
+++ b/recipes/examples/Jenkinsfile-stage.groovy
@@ -1,0 +1,28 @@
+// EXAMPLE Jenkins stage — darnlink link gate, the SERVER-SIDE wall (piece 4, self-hosted).
+//
+// The natural home for the wall on a PRIVATE repo where hosted CI minutes are billed or branch
+// protection is unavailable: a self-hosted agent runs the same check with no billing. Fetches the
+// PINNED recipe from the PUBLIC darnlink repo — no credentials — and runs it FAIL-CLOSED.
+//
+// INSTALL: drop this stage into your declarative Jenkinsfile's `stages { … }`.
+// ASSUMES: `uvx` is available on the agent. `astral-sh` installs `uv` into ~/.local/bin; if it isn't
+//          on PATH, prepend it (e.g. `export PATH="$HOME/.local/bin:$PATH"`) inside the sh block.
+// Keep the pinned tag in sync with darnlink-gate.json's `ref`.
+
+stage('darnlink gate (links)') {
+  environment {
+    DARNLINK_REF              = 'git+https://github.com/txemi/darnlink@v0.7.0'
+    DARNLINK_GATE_FAIL_CLOSED = '1'   // the wall must fail closed
+  }
+  steps {
+    sh '''
+      set -eu
+      # -f: fail on a 404 (moved/typo'd tag) instead of writing "404: Not Found" and running garbage.
+      curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/v0.7.0/recipes/darnlink-gate" \
+        -o "$WORKSPACE/.darnlink-gate"
+      chmod +x "$WORKSPACE/.darnlink-gate"
+      "$WORKSPACE/.darnlink-gate"          # scope=repo from darnlink-gate.json
+      rm -f "$WORKSPACE/.darnlink-gate"
+    '''
+  }
+}

--- a/recipes/examples/README.md
+++ b/recipes/examples/README.md
@@ -1,0 +1,24 @@
+# darnlink-gate — complete, copy-paste examples
+
+Runnable versions of the four pieces from [`../README.md`](../README.md#adopt-it-in-a-repo-the-wall-in-4-pieces).
+Each file is a whole, working artifact — not a snippet to assemble — because assembling the CI one
+wrong yields a wall that fails **open** (green build, nothing validated). They wire the same generic
+recipe ([`../darnlink-gate`](../darnlink-gate)) at the scope that fits each layer.
+
+| File | Layer | Scope | Fail mode |
+|---|---|---|---|
+| [`pre-commit`](pre-commit) | local, per-commit | **staged** (fast; no cross-session deadlock) | open |
+| [`pre-push`](pre-push) | local wall | **whole repo** | open (flip to closed inside) |
+| [`github-actions-darnlink-gate.yml`](github-actions-darnlink-gate.yml) | server wall | **whole repo** | **closed** |
+| [`Jenkinsfile-stage.groovy`](Jenkinsfile-stage.groovy) | server wall (self-hosted) | **whole repo** | **closed** |
+
+**The scope split is deliberate** (see [`../../docs/elevating-your-link-gate.md §7`](../../docs/elevating-your-link-gate.md)):
+staged locally so parallel contributors don't block each other; whole-repo where the gate is the wall.
+A whole-repo **pre-commit** would deadlock — don't; that's what pre-push is for.
+
+**Keep the pinned tag in sync.** Every example pins `@v0.7.0`; that must match your
+`darnlink-gate.json`'s `ref`. Bump both together.
+
+**Raising to fail-closed links (`mode=max`)** is a one-line change in `darnlink-gate.json`
+(`"mode": "max"`) once the repo's gap is 0 — the hooks and CI here need no edit. Follow
+[`../../docs/elevating-your-link-gate.md`](../../docs/elevating-your-link-gate.md) to get the gap to 0 first.

--- a/recipes/examples/github-actions-darnlink-gate.yml
+++ b/recipes/examples/github-actions-darnlink-gate.yml
@@ -1,0 +1,33 @@
+# EXAMPLE GitHub Actions workflow — darnlink link gate, the SERVER-SIDE wall (piece 4).
+#
+# The unbypassable wall: it catches even a `git commit --no-verify` that skipped the local hooks.
+# It fetches the PINNED recipe from the PUBLIC darnlink repo — no token, no private checkout — and
+# runs it FAIL-CLOSED, so a transient network/PyPI hiccup fails the build instead of passing green
+# with zero files validated.
+#
+# INSTALL: save as `.github/workflows/darnlink-gate.yml`. Per-repo policy (excludes, mode, scope)
+#          lives in `darnlink-gate.json`; keep the pinned tag here in sync with that file's `ref`.
+name: darnlink-gate
+
+on: [push, pull_request]
+
+permissions:
+  contents: read              # least privilege: the job only reads the tree
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    env:
+      DARNLINK_REF: git+https://github.com/txemi/darnlink@v0.7.0
+      DARNLINK_GATE_FAIL_CLOSED: "1"     # ← the wall MUST fail closed (prefer the env var; see recipe)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - name: Fetch the pinned recipe (public repo → no token)
+        run: |
+          # -f: fail on a 404 (a moved/typo'd tag), instead of silently writing "404: Not Found".
+          curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/v0.7.0/recipes/darnlink-gate" \
+            -o "$RUNNER_TEMP/darnlink-gate"
+          chmod +x "$RUNNER_TEMP/darnlink-gate"
+      - name: darnlink gate (whole repo)
+        run: "$RUNNER_TEMP/darnlink-gate"   # scope=repo from darnlink-gate.json

--- a/recipes/examples/pre-commit
+++ b/recipes/examples/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# EXAMPLE pre-commit hook — darnlink link gate, STAGED scope (piece 2 of the wall).
+#
+# Fast and per-file: it judges only the files you're committing, so a teammate's in-flight plain
+# link never blocks YOUR clean commit. The whole-repo guarantee lives in pre-push + CI (pieces 3-4).
+#
+# INSTALL: copy to `.git/hooks/pre-commit` (or version it under `hooks/` and point
+#          `git config core.hooksPath hooks`). Make it executable: `chmod +x`.
+# ASSUMES: `darnlink-gate` (recipes/darnlink-gate) is on PATH — e.g. dropped in ~/.local/bin.
+set -euo pipefail
+exec env DARNLINK_GATE_SCOPE=staged darnlink-gate

--- a/recipes/examples/pre-commit
+++ b/recipes/examples/pre-commit
@@ -5,7 +5,7 @@
 # link never blocks YOUR clean commit. The whole-repo guarantee lives in pre-push + CI (pieces 3-4).
 #
 # INSTALL: copy to `.git/hooks/pre-commit` (or version it under `hooks/` and point
-#          `git config core.hooksPath hooks`). Make it executable: `chmod +x`.
+#          `git config core.hooksPath hooks`). Make it executable: `chmod +x .git/hooks/pre-commit`.
 # ASSUMES: `darnlink-gate` (recipes/darnlink-gate) is on PATH — e.g. dropped in ~/.local/bin.
 set -euo pipefail
 exec env DARNLINK_GATE_SCOPE=staged darnlink-gate

--- a/recipes/examples/pre-push
+++ b/recipes/examples/pre-push
@@ -5,7 +5,7 @@
 # sessions (unlike a whole-repo pre-commit — don't do that). This is the LOCAL wall: it stops anything
 # broken from leaving your machine, even if CI is down.
 #
-# INSTALL: copy to `.git/hooks/pre-push`. Make it executable: `chmod +x`.
+# INSTALL: copy to `.git/hooks/pre-push`. Make it executable: `chmod +x .git/hooks/pre-push`.
 # SCOPE:   whole-repo is the recipe default (scope=repo from darnlink-gate.json), so nothing to set.
 # STRICT?: this stays fail-OPEN (a genuinely offline push isn't bricked). If you want the local wall
 #          to also fail closed, uncomment the export below — then a uvx/network hiccup blocks the push.

--- a/recipes/examples/pre-push
+++ b/recipes/examples/pre-push
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# EXAMPLE pre-push hook — darnlink link gate, WHOLE-REPO scope (piece 3 of the wall).
+#
+# `git push` is deliberate and infrequent, so judging the whole tree here does NOT deadlock parallel
+# sessions (unlike a whole-repo pre-commit — don't do that). This is the LOCAL wall: it stops anything
+# broken from leaving your machine, even if CI is down.
+#
+# INSTALL: copy to `.git/hooks/pre-push`. Make it executable: `chmod +x`.
+# SCOPE:   whole-repo is the recipe default (scope=repo from darnlink-gate.json), so nothing to set.
+# STRICT?: this stays fail-OPEN (a genuinely offline push isn't bricked). If you want the local wall
+#          to also fail closed, uncomment the export below — then a uvx/network hiccup blocks the push.
+# export DARNLINK_GATE_FAIL_CLOSED=1
+set -euo pipefail
+exec darnlink-gate


### PR DESCRIPTION
## What

Adds the **top rung** to the gate (`mode=max`, fail-closed on links) and closes the documentation/example gaps that work uncovered.

## `mode=max` — the third rung of the ratchet (repair ⊂ check ⊂ max)

`darnlink check` stops at **strict** (integrity + robustify against targets that *have* a uuid). It has **no create-frontmatter axis**, so it cannot express *"a link to a file with no uuid fails the gate"* — the fail-closed maximum described in `docs/elevating-your-link-gate.md`.

`mode=max` runs `darnlink . --robustify --create-frontmatter` in **dry-run** (never `--write`) and gates on its exit code. It is a **superset** of `check`, so raising the mode can only tighten, never loosen.

**Whole-repo only**: under staged scope it deliberately stays at strict (the staged pre-commit is meant to be fast; the maximum is enforced at the whole-repo pre-push/CI wall). Ported to `.ps1` as well.

**Verified by running it:**
- One consuming repo (gap 0) → `mode=max` gives **exit 0**.
- Another (+3) → `check` passes (exit 0), `max` **fails** (exit 1, 3 findings).

## Docs fixes (`recipes/README.md` was stale and subtly unsafe)

- It documented neither `fail_closed` (present since v0.6.0) nor exit code 4.
- **The CI example ran `darnlink-gate` WITHOUT `DARNLINK_GATE_FAIL_CLOSED=1`** → copying it gave you a wall that fails open (green build, zero files validated). Fixed.
- The wiring had no **pre-push** layer, although §7 of the playbook defines it as a wall in its own right. Now "4 pieces": pre-commit (staged) · pre-push (whole) · CI (whole, fail-closed).

## `recipes/examples/` (new)

**Complete, copy-paste** artifacts rather than fragments to assemble (assembling the CI one wrong is exactly how you end up with a fail-open wall): `pre-commit`, `pre-push`, a whole Actions workflow (`permissions: contents: read`, `curl -fsSL`, fail-closed) and a Jenkinsfile stage (self-hosted, fail-closed). All pinned to `@v0.7.0` in step with each other.

<sub>Translated from the original Spanish on 2026-08-11 — this repo is English-only on every surface, PR titles and descriptions included.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
