### PR TITLE
feat: directory links — anchor a link to a folder via its README.md uuid (spec 011)

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -54,9 +54,36 @@ UUID        := 36 chars matching [0-9a-fA-F-] (canonically 8-4-4-4-12 lowercase 
 - **Robustify**: a plain link `[text](path.md)` is upgraded by ensuring the target has a `uuid`
   (creating one only because a link now references it) and appending the comment.
 
-Scope: relative links to local `.md` files. URLs, non-`.md` targets and bare `#anchors` are ignored.
-Links inside **code** — fenced blocks (```` ``` ````/`~~~`) or inline code (`` ` ``) — are also
-ignored: they are examples, not navigational links, and rewriting them would corrupt the docs.
+Scope: relative links to local `.md` files and to **local directories** (§4.1). URLs, other non-`.md`
+targets and bare `#anchors` are ignored. Links inside **code** — fenced blocks (```` ``` ````/`~~~`)
+or inline code (`` ` ``) — are also ignored: they are examples, not navigational links, and rewriting
+them would corrupt the docs.
+
+### 4.1 Directory links
+
+A robust link may point at a **directory** instead of a `.md` file. A directory has no frontmatter of
+its own, so its identity is the `uuid` of its **`README.md`**:
+
+```markdown
+See the [deployment guide](ops/deploy/) <!-- uuid: 7f3a1e2c-… -->
+```
+
+where `ops/deploy/README.md` declares `uuid: 7f3a1e2c-…`.
+
+- **Disambiguation is by the path alone**: a path ending in `.md` is a *file* link (points at that
+  file); any other path is a *directory* link (points at the directory whose `README.md` holds the
+  uuid). No disk access is needed to classify a link. A trailing slash is optional on input; repair
+  emits one.
+- **Resolve**: find the `README.md` whose `uuid` matches, then the link's target is its **containing
+  directory**.
+- **Repair**: when the directory moves, rewrite the path to the directory's new location (found via
+  the README's uuid), keeping it a directory path.
+- **Robustify**: a plain link to a directory that has a `README.md` is anchored to that README's
+  `uuid` (created only with `--create-frontmatter`, and only in an existing `README.md` — darnlink
+  never creates a README). A directory without a `README.md` is not anchorable and is left plain.
+
+A directory link and a file link to the same `README.md` share its uuid; the path's shape (`…/` vs
+`…/README.md`) is what keeps them pointing where their author intended.
 
 ## 5. Opting a file out
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ A robust link stays a normal, clickable Markdown link:
 See [the design doc](docs/design.md) <!-- uuid: 7f3a1e2c-... -->
 ```
 
+Links to **directories** work too: a link to `docs/guide/` is anchored to the uuid of that folder's
+`README.md`, so it heals when the folder moves — same guarantee, for the hubs you link to by folder.
+
 Format spec: [FORMAT.md](FORMAT.md) <!-- uuid: 9052d864-2a45-4ed4-8725-d8a394e7a7ef -->.
 
 ## Excluding parts of the tree

--- a/specs/011-directory-links/spec.md
+++ b/specs/011-directory-links/spec.md
@@ -1,0 +1,94 @@
+# Feature Specification: directory links
+
+**Feature Branch**: `011-directory-links`
+
+**Created**: 2026-07-22
+
+**Status**: Draft
+
+**Input**: Robust links can only target `.md` files, so a link to a *directory* (`docs/guide/`) is
+invisible to darnlink: it is never robustified and silently breaks when the directory moves. Let a
+directory be a first-class link target, identified by the `uuid` of its `README.md`.
+
+## Motivation
+
+darnlink heals `.md`→`.md` links, but real doc trees link to **directories** too — "see the
+[deployment guide](ops/deploy/)", a hub folder, a country's report folder. Those links are outside
+the tool: move or rename the folder and they die with no warning, and no `--robustify`/gate can
+protect them. A directory already tends to carry a `README.md` hub with a `uuid`; that uuid is a
+perfectly good stable identity for the directory. This feature uses it.
+
+Measured on one real tree at adoption time: of the directories linked from a refactored subtree, a
+clear majority already had a `README.md` with a uuid — i.e. this feature would have protected them
+automatically, where nothing could before.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Repair a directory link after the directory moves (Priority: P1)
+
+A doc links to a directory as `[guide](docs/guide/)`; the link is robust (carries the uuid of
+`docs/guide/README.md`). Someone moves `docs/guide/` to `manuals/guide/`. Running darnlink rewrites
+the link's path to the directory's new location — found by the README's uuid — keeping it a
+directory link.
+
+**Independent Test**: robust directory link to `docs/guide/`; move the directory; `darnlink --write`;
+assert the path is now `manuals/guide/` and still resolves.
+
+**Acceptance Scenarios**:
+
+1. **Given** `A.md` contains `[guide](docs/guide/) <!-- uuid: U -->` and `docs/guide/README.md` has
+   `uuid: U`, **When** the directory moves to `manuals/guide/` and `darnlink --write` runs, **Then**
+   A's link path becomes `manuals/guide/` (a directory path), the uuid is unchanged, and nothing else
+   changes.
+2. **Given** a robust directory link whose path already points at the right directory, **When**
+   darnlink runs, **Then** it is a no-op — regardless of a trailing slash.
+3. **Given** a directory link written without a trailing slash, **When** it is repaired, **Then** the
+   emitted path carries a trailing slash (canonical directory form).
+
+### User Story 2 - Robustify a plain directory link (Priority: P2)
+
+A plain link `[guide](docs/guide/)` points at a directory whose `README.md` has (or, with
+`--create-frontmatter`, can be given) a uuid. darnlink upgrades it to a robust link anchored to that
+uuid.
+
+**Acceptance Scenarios**:
+
+1. **Given** `docs/guide/README.md` has `uuid: U` and `A.md` has a plain `[guide](docs/guide/)`,
+   **When** `darnlink --robustify --write` runs, **Then** the link gains ` <!-- uuid: U -->` and its
+   path is unchanged.
+2. **Given** the directory's `README.md` has no uuid, **When** `--robustify` runs without
+   `--create-frontmatter`, **Then** the link is left plain and reported (`no_frontmatter`); **with**
+   `--create-frontmatter`, a uuid is created **in the existing README** and the link is anchored.
+3. **Given** a directory with **no** `README.md`, **When** `--robustify --create-frontmatter` runs,
+   **Then** the link is left plain — darnlink never creates a README.
+
+### Edge Cases
+
+- **Path/uuid disagreement (conflict).** A directory link whose old path still resolves to a real
+  *different* directory, while the README lives elsewhere, is a conflict: left untouched, reported.
+- **Directory link anchored to a non-README uuid.** Malformed (the path names a directory but the
+  uuid is some other file): conflict, left untouched.
+- **File link to a `README.md`.** Unchanged behavior: `[x](docs/guide/README.md) <!-- uuid: U -->`
+  still repairs to the *file* path, never the directory. The `.md` suffix is the discriminator.
+
+## Requirements *(mandatory)*
+
+- **FR-011a**: A link whose path part does **not** end in `.md` and that resolves to a directory is a
+  *directory link*; its anchor file is `<dir>/README.md`.
+- **FR-011b**: Classification of file vs directory link is by the href path suffix alone — no disk
+  access — so it is deterministic and stable even when the path is stale.
+- **FR-011c**: Repair of a directory link rewrites to the README's **parent directory**, relative to
+  the linking file, emitted with a trailing slash. Text, fragment and uuid are preserved.
+- **FR-011d**: Robustify anchors a plain directory link to its README's uuid, honoring
+  `--create-frontmatter`, `--no-create-frontmatter-for`, `--only` and the ignore markers exactly as
+  for file targets. A directory without a `README.md` is not anchorable.
+- **FR-011e**: A directory link is never reported as a CONFLICT merely because its path resolves to a
+  directory; conflict applies only when path and uuid genuinely disagree (real different directory at
+  the old path, or the uuid belongs to a non-README file).
+
+## Out of Scope
+
+- Creating a `README.md` where none exists (darnlink only creates frontmatter, never files).
+- A distinct finding for "directory link, no README" — such a link is simply left plain, like any
+  other non-anchorable target. (Possible future refinement for a stricter gate.)
+- Directory identity via anything other than `README.md` (e.g. `index.md`, an `.uuid` dotfile).

--- a/src/darnlink/paths.py
+++ b/src/darnlink/paths.py
@@ -6,6 +6,11 @@ from pathlib import Path
 from typing import Tuple
 
 
+# Feature 011: a link to a directory is anchored to the uuid of this file inside it. A folder has no
+# frontmatter of its own, so its README.md carries the folder's stable identity.
+DIR_ANCHOR = "README.md"
+
+
 def split_fragment(href: str) -> Tuple[str, str]:
     """Split `path#frag` into (`path`, `frag`); frag is '' if none."""
     if "#" in href:
@@ -33,12 +38,26 @@ def relative_link(target: Path, linking_file: Path, fragment: str = "") -> str:
     return f"{rel_posix}#{fragment}" if fragment else rel_posix
 
 
-def is_local_md(href: str) -> bool:
-    """True if href is a relative link to a local .md file (not a URL, not an anchor-only link)."""
+def is_local_relative(href: str) -> bool:
+    """True if href is a relative link into the local tree (not a URL, mailto, absolute or bare
+    `#anchor`). Says nothing about what the path names — a `.md` file, a directory, anything."""
     path_part, _ = split_fragment(href)
     if not path_part:
         return False  # bare #fragment
     low = path_part.lower()
     if "://" in low or low.startswith(("http:", "https:", "mailto:", "ftp:", "/")):
         return False
-    return low.endswith(".md")
+    return True
+
+
+def is_local_md(href: str) -> bool:
+    """True if href is a relative link to a local .md file (not a URL, not an anchor-only link)."""
+    path_part, _ = split_fragment(href)
+    return is_local_relative(href) and path_part.lower().endswith(".md")
+
+
+def names_md(href: str) -> bool:
+    """True if the href's path part names a `.md` file (by suffix). Used to tell a link that points
+    at a file (`foo/README.md`) from one that points at a directory (`foo/`), independent of disk."""
+    path_part, _ = split_fragment(href)
+    return path_part.lower().endswith(".md")

--- a/src/darnlink/repair.py
+++ b/src/darnlink/repair.py
@@ -1,14 +1,19 @@
 """Repair: rewrite a robust link's path to wherever its UUID now lives.
 
-A robust link is *broken* when its written path does not resolve to the file whose frontmatter
+A robust link is *broken* when its written path does not resolve to the target whose frontmatter
 `uuid` matches the link's uuid. We then rewrite the path (relative to the linking file),
 preserving the link text, any `#fragment`, and the uuid comment. Exact-uuid match only; no guessing.
 
-Defensive rule: we only auto-repair when the written path is *stale* — i.e. it does not resolve
-to an existing file. If the path STILL resolves to a real (different) file while the uuid lives
-elsewhere, the two halves of the link disagree (typically a mis-pasted uuid). That is a CONFLICT,
-not a move: we leave it untouched and report it for a human to resolve, rather than silently
-following the uuid and hijacking a link whose path was the real intent.
+The target is usually a `.md` file. A link whose path names a *directory* (feature 011) is anchored
+to that directory's `README.md`: its uuid resolves to the README, and repair rewrites the path to the
+README's parent directory (kept a directory path, with a trailing slash).
+
+Defensive rule: we only auto-repair when the written path is *stale* — i.e. it does not resolve to an
+existing target (no file, for a file link; nothing at all — neither file nor directory — for a
+directory link). If the path STILL resolves to a real target while the uuid lives elsewhere, the two
+halves of the link disagree (typically a mis-pasted uuid). That is a CONFLICT, not a move: we leave it
+untouched and report it for a human to resolve, rather than silently following the uuid and hijacking
+a link whose path was the real intent.
 """
 from __future__ import annotations
 

--- a/src/darnlink/repair.py
+++ b/src/darnlink/repair.py
@@ -111,11 +111,14 @@ def plan_repairs(
             intended = target.parent if dir_link else target
             if current == intended.resolve():
                 continue  # already correct (cosmetic ./ or trailing-slash differences are fine)
-            # Defensive: the written path still resolves to a real thing of the SAME kind — a file for
-            # a file link, a directory for a directory link — while the uuid lives elsewhere. The two
-            # halves disagree (typically a mis-pasted uuid); it is NOT a move, so flag, don't hijack.
-            if current.is_dir() if dir_link else current.is_file():
-                kind_word = "directory" if dir_link else "file"
+            # Defensive: the written path still resolves to a real target while the uuid lives
+            # elsewhere — the two halves disagree (typically a mis-pasted uuid). It is NOT a move, so
+            # flag, don't hijack. A file link keys on a real *file* (its existing behavior); a
+            # directory link keys on the path resolving to *anything* — a real directory, or a file
+            # that shadows the folder path — so a non-`.md` link whose path is still a live file is a
+            # conflict, not a rewrite.
+            if current.exists() if dir_link else current.is_file():
+                kind_word = "file" if current.is_file() else "directory"
                 local.append(
                     Finding(
                         Kind.CONFLICT,

--- a/src/darnlink/repair.py
+++ b/src/darnlink/repair.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional, Set
 from .frontmatter_index import DEFAULT_EXCLUDES, FrontmatterIndex, iter_markdown_files
 from .links import (code_spans, emit_robust_link, file_ignores_links, file_is_ignored,
                     find_robust_links, ignored_spans)
-from .paths import relative_link, resolve_href, split_fragment
+from .paths import DIR_ANCHOR, names_md, relative_link, resolve_href, split_fragment
 from .frontmatter_edit import read_text_keep_newlines, write_text_keep_newlines
 from .report import Finding, Kind
 from .scope import in_scope
@@ -91,23 +91,44 @@ def plan_repairs(
                 )
                 continue
             current = resolve_href(link.href, f)
-            if current == target.resolve():
-                continue  # already correct (cosmetic ./ differences are fine)
-            if current.is_file():
-                # The written path still points to a real file, but the uuid lives elsewhere:
-                # the two halves of the robust link disagree (typically a mis-pasted uuid). This
-                # is NOT a moved target, so don't guess which side is right — flag it for review.
+            _, frag = split_fragment(link.href)
+            # Feature 011: a link whose path does not name a `.md` file is a *directory* link — the
+            # uuid identifies the directory via its README.md, and the link points at the directory
+            # (the README's parent), not at the README file itself.
+            dir_link = not names_md(link.href)
+            if dir_link and target.name.lower() != DIR_ANCHOR.lower():
+                # The path names a directory but the uuid lives in a non-README file: the two halves
+                # disagree. Don't guess — flag like any other path/uuid conflict.
                 local.append(
                     Finding(
                         Kind.CONFLICT,
                         f,
-                        f"{link.href} resolves to an existing file, but uuid {link.uuid} lives in "
-                        f"{target} — path and uuid disagree; left untouched",
+                        f"{link.href} is a directory link, but uuid {link.uuid} lives in {target} "
+                        f"(not a {DIR_ANCHOR}) — path and uuid disagree; left untouched",
                     )
                 )
                 continue
-            _, frag = split_fragment(link.href)
-            new_href = relative_link(target, f, frag)
+            intended = target.parent if dir_link else target
+            if current == intended.resolve():
+                continue  # already correct (cosmetic ./ or trailing-slash differences are fine)
+            # Defensive: the written path still resolves to a real thing of the SAME kind — a file for
+            # a file link, a directory for a directory link — while the uuid lives elsewhere. The two
+            # halves disagree (typically a mis-pasted uuid); it is NOT a move, so flag, don't hijack.
+            if current.is_dir() if dir_link else current.is_file():
+                kind_word = "directory" if dir_link else "file"
+                local.append(
+                    Finding(
+                        Kind.CONFLICT,
+                        f,
+                        f"{link.href} resolves to an existing {kind_word}, but uuid {link.uuid} lives "
+                        f"in {target} — path and uuid disagree; left untouched",
+                    )
+                )
+                continue
+            base = relative_link(intended, f)  # path only; fragment re-appended below
+            if dir_link and not base.endswith("/"):
+                base += "/"  # keep directory links visibly directories (and re-recognisable as such)
+            new_href = f"{base}#{frag}" if frag else base
             local.append(Finding(Kind.REPAIR, f, f"{link.href} -> {new_href}"))
             # splice the rewritten robust link in place of the old span
             pieces.append(content[cursor:link.start])

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -23,7 +23,7 @@ from .frontmatter_edit import (
 from .frontmatter_index import DEFAULT_EXCLUDES, iter_markdown_files, read_frontmatter_uuid
 from .links import (code_spans, emit_robust_link, file_ignores_links, file_is_ignored,
                     find_plain_links, ignored_spans)
-from .paths import is_local_md, resolve_href
+from .paths import DIR_ANCHOR, is_local_relative, names_md, resolve_href
 from .report import Finding, Kind
 from .scope import in_scope
 
@@ -38,12 +38,23 @@ class RobustifyResult:
     suppressed: int = 0  # anchorable links in files outside the write scope (010): counted, never hidden
 
 
-def _md_target(href: str, linking_file: Path) -> Path | None:
-    if not is_local_md(href):
+def _anchor_target(href: str, linking_file: Path) -> Path | None:
+    """The `.md` file whose `uuid` anchors this link, or None.
+
+    - A link to a `.md` file anchors to that file (the original behavior).
+    - A link to a *directory* anchors to that directory's `README.md` (feature 011): a folder's
+      identity is its README's uuid. A directory with no README is not anchorable — it returns None,
+      exactly like any other non-`.md` target, so the link is left plain.
+    """
+    if not is_local_relative(href):
         return None
     t = resolve_href(href, linking_file)
-    if t.exists() and t.suffix.lower() == ".md":
-        return t
+    if names_md(href):
+        return t if (t.exists() and t.suffix.lower() == ".md") else None
+    if t.is_dir():
+        readme = t / DIR_ANCHOR
+        if readme.exists():
+            return readme
     return None
 
 
@@ -149,7 +160,7 @@ def plan_robustify(
         if not in_scope(f, only):
             continue  # 010: its links are never rewritten either -> they must not create uuids
         for link in find_plain_links(contents.get(f, ""), spans.get(f, [])):
-            t = _md_target(link.href, f)
+            t = _anchor_target(link.href, f)
             # Skip self-links (a file linking to itself, e.g. autogrid `path` rows): robustifying
             # them is meaningless and would touch machine-generated blocks.
             if t is not None and t.resolve() != f.resolve():
@@ -175,7 +186,7 @@ def plan_robustify(
             if in_scope(f, only) or f.resolve() in link_ignored:
                 continue
             for link in find_plain_links(contents.get(f, ""), spans.get(f, [])):
-                t = _md_target(link.href, f)
+                t = _anchor_target(link.href, f)
                 if t is None or t.resolve() == f.resolve():
                     continue
                 tr = t.resolve()
@@ -203,7 +214,7 @@ def plan_robustify(
         # uuid below — being a target is not a write the caller has to name (FR-006).
         links = () if (f.resolve() in link_ignored or not scoped) else find_plain_links(original, spans.get(f, []))
         for link in links:
-            t = _md_target(link.href, f)
+            t = _anchor_target(link.href, f)
             if t is None or t.resolve() == f.resolve():
                 continue  # skip non-md/external and self-links
             tr = t.resolve()

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -52,10 +52,12 @@ def _anchor_target(href: str, linking_file: Path) -> Path | None:
         return None
     t = resolve_href(href, linking_file)
     if names_md(href):
-        return t if (t.exists() and t.suffix.lower() == ".md") else None
+        # is_file() (not exists()): a *directory* named `foo.md` exists with a `.md` suffix but is
+        # not an anchor — treating it as one would fail the later frontmatter read/write.
+        return t if (t.is_file() and t.suffix.lower() == ".md") else None
     if t.is_dir():
         readme = t / DIR_ANCHOR
-        if readme.exists():
+        if readme.is_file():  # a directory named `README.md` is not an anchor either
             return readme
     return None
 

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -1,8 +1,10 @@
 """Robustify: upgrade a plain relative link to a robust one.
 
-For each plain link that resolves to a local `.md` file, ensure that target has a `uuid` in its
-frontmatter (reuse it, or create one because a link now references it), then append the
-`<!-- uuid: … -->` annotation to the link. A UUID is created only where a link needs it.
+For each plain link that resolves to a local `.md` file — or to a *directory* (feature 011), which is
+anchored to its `README.md` — ensure that target has a `uuid` in its frontmatter (reuse it, or create
+one because a link now references it), then append the `<!-- uuid: … -->` annotation to the link. A
+UUID is created only where a link needs it. A directory with no `README.md` is not anchorable and its
+link is left plain (darnlink never creates a README).
 
 Targets without any frontmatter are skipped unless `create_frontmatter=True` (Constitution II:
 creating frontmatter is opt-in).

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -69,12 +69,14 @@ def test_genuine_move_still_repairs(tmp_path):
     assert not any(f.kind is Kind.CONFLICT for f in result.findings)
 
 
-def test_directory_link_to_readme_is_repaired_not_conflict(tmp_path):
-    # A robust link pointing at a DIRECTORY (not an existing file) whose uuid lives in its README
-    # is a normal repair (dir -> README), not a conflict.
+def test_directory_link_to_readme_is_not_a_conflict(tmp_path):
+    # A robust link pointing at a DIRECTORY whose uuid lives in its README must never be flagged as a
+    # path/uuid CONFLICT (the conflict rule keys on the path resolving to a real *file*; a directory
+    # is not one). Since feature 011 (directory links) a directory link that already points at the
+    # right directory is simply correct — a no-op — not a rewrite into the README *file* as before.
     _w(tmp_path / "issue" / "README.md", f"---\nuuid: {OTHER_UUID}\n---\n# Issue\n")
     _w(tmp_path / "A.md", f"[issue](issue/) <!-- uuid: {OTHER_UUID} -->\n")
 
     result = plan_repairs(tmp_path, build_index(tmp_path))
-    assert any(f.kind is Kind.REPAIR for f in result.findings)
+    assert result.new_content == {}                       # already correct: nothing rewritten
     assert not any(f.kind is Kind.CONFLICT for f in result.findings)

--- a/tests/test_directory_links.py
+++ b/tests/test_directory_links.py
@@ -1,0 +1,146 @@
+"""Feature 011 — directory links.
+
+A robust link may point at a *directory* instead of a `.md` file. The directory's stable identity
+is the `uuid` of its `README.md`. The link's path names the directory (it does not end in `.md`);
+the uuid comment carries the README's uuid.
+
+- Robustify: a plain link to a directory with a `README.md` is anchored to that README's uuid.
+- Repair: when the directory moves, the link's path is rewritten to the directory's new location
+  (found via the README's uuid), kept as a directory path (trailing slash).
+- Disambiguation is by the href shape alone (`.md` suffix -> file link; otherwise -> directory
+  link), so it is deterministic and needs no disk access to classify.
+"""
+from pathlib import Path
+
+import shutil
+
+from darnlink.frontmatter_edit import read_uuid_from_content
+from darnlink.frontmatter_index import build_index
+from darnlink.links import find_robust_links
+from darnlink.repair import apply_repairs, plan_repairs
+from darnlink.robustify import apply_robustify, plan_robustify
+from darnlink.report import Kind
+
+DIR_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+OTHER_UUID = "11111111-2222-3333-4444-555555555555"
+
+
+def _w(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+# --- Robustify ---------------------------------------------------------------------------------
+
+def test_robustify_directory_link_reuses_readme_uuid(tmp_path):
+    _w(tmp_path / "guide" / "README.md", f"---\nuuid: {DIR_UUID}\n---\n# Guide\n")
+    _w(tmp_path / "A.md", "See the [guide](guide/) for details.\n")
+    apply_robustify(plan_robustify(tmp_path))
+    links = find_robust_links((tmp_path / "A.md").read_text())
+    assert len(links) == 1
+    assert links[0].href == "guide/"        # path unchanged (still a directory link)
+    assert links[0].uuid == DIR_UUID        # anchored to the README's uuid
+
+
+def test_robustify_directory_link_without_trailing_slash(tmp_path):
+    _w(tmp_path / "guide" / "README.md", f"---\nuuid: {DIR_UUID}\n---\n# Guide\n")
+    _w(tmp_path / "A.md", "See the [guide](guide) for details.\n")
+    apply_robustify(plan_robustify(tmp_path))
+    links = find_robust_links((tmp_path / "A.md").read_text())
+    assert len(links) == 1
+    assert links[0].href == "guide"         # path kept verbatim on robustify
+    assert links[0].uuid == DIR_UUID
+
+
+def test_robustify_directory_link_creates_uuid_in_readme_when_opted_in(tmp_path):
+    _w(tmp_path / "guide" / "README.md", "# Guide (no frontmatter)\n")
+    _w(tmp_path / "A.md", "See the [guide](guide/).\n")
+    apply_robustify(plan_robustify(tmp_path, create_frontmatter=True))
+    readme = (tmp_path / "guide" / "README.md").read_text()
+    u = read_uuid_from_content(readme)
+    assert u is not None
+    assert find_robust_links((tmp_path / "A.md").read_text())[0].uuid == u
+
+
+def test_robustify_directory_link_without_readme_is_left_plain(tmp_path):
+    (tmp_path / "empty_dir").mkdir()
+    _w(tmp_path / "A.md", "See the [dir](empty_dir/).\n")
+    result = plan_robustify(tmp_path, create_frontmatter=True)
+    assert result.new_content == {}         # a directory with no README is not anchorable
+
+
+def test_robustify_directory_link_readme_no_uuid_reports_no_frontmatter(tmp_path):
+    _w(tmp_path / "guide" / "README.md", "# Guide (no frontmatter)\n")
+    _w(tmp_path / "A.md", "See the [guide](guide/).\n")
+    result = plan_robustify(tmp_path, create_frontmatter=False)
+    assert result.new_content == {}
+    assert any(f.kind is Kind.NO_FRONTMATTER for f in result.findings)
+
+
+# --- Repair ------------------------------------------------------------------------------------
+
+def test_repair_directory_link_after_directory_moves(tmp_path):
+    _w(tmp_path / "docs" / "guide" / "README.md", f"---\nuuid: {DIR_UUID}\n---\n# Guide\n")
+    _w(tmp_path / "A.md", f"See the [guide](docs/guide/) <!-- uuid: {DIR_UUID} -->.\n")
+    # move the directory
+    shutil.move(str(tmp_path / "docs" / "guide"), str(tmp_path / "manuals_guide"))
+
+    index = build_index(tmp_path)
+    apply_repairs(plan_repairs(tmp_path, index))
+
+    link = find_robust_links((tmp_path / "A.md").read_text())[0]
+    assert link.href == "manuals_guide/"    # rewritten to the new dir, kept as a directory path
+    assert link.uuid == DIR_UUID
+
+
+def test_repair_directory_link_noop_when_already_correct(tmp_path):
+    _w(tmp_path / "guide" / "README.md", f"---\nuuid: {DIR_UUID}\n---\n# Guide\n")
+    _w(tmp_path / "A.md", f"[guide](guide/) <!-- uuid: {DIR_UUID} -->\n")
+    index = build_index(tmp_path)
+    result = plan_repairs(tmp_path, index)
+    assert result.new_content == {}         # path already resolves to the README's directory
+
+
+def test_repair_directory_link_noop_without_trailing_slash(tmp_path):
+    # a correct directory link written WITHOUT a trailing slash must not churn
+    _w(tmp_path / "guide" / "README.md", f"---\nuuid: {DIR_UUID}\n---\n# Guide\n")
+    _w(tmp_path / "A.md", f"[guide](guide) <!-- uuid: {DIR_UUID} -->\n")
+    index = build_index(tmp_path)
+    result = plan_repairs(tmp_path, index)
+    assert result.new_content == {}
+
+
+def test_repair_directory_link_conflict_when_old_path_is_a_real_dir(tmp_path):
+    # README moved, but a *different* real directory now sits at the old path: path and uuid
+    # disagree -> conflict, leave untouched.
+    _w(tmp_path / "new_home" / "README.md", f"---\nuuid: {DIR_UUID}\n---\n# Guide\n")
+    (tmp_path / "guide").mkdir()            # an unrelated directory still exists at the old path
+    _w(tmp_path / "A.md", f"[guide](guide/) <!-- uuid: {DIR_UUID} -->\n")
+    index = build_index(tmp_path)
+    result = plan_repairs(tmp_path, index)
+    assert result.new_content == {}
+    assert any(f.kind is Kind.CONFLICT for f in result.findings)
+
+
+def test_repair_directory_link_conflict_when_uuid_is_not_a_readme(tmp_path):
+    # a directory link whose uuid lives in a non-README file is malformed: flag, don't guess.
+    _w(tmp_path / "notes.md", f"---\nuuid: {OTHER_UUID}\n---\n# Notes\n")
+    _w(tmp_path / "A.md", f"[somewhere](somewhere/) <!-- uuid: {OTHER_UUID} -->\n")
+    index = build_index(tmp_path)
+    result = plan_repairs(tmp_path, index)
+    assert result.new_content == {}
+    assert any(f.kind is Kind.CONFLICT for f in result.findings)
+
+
+# --- Regression: file links to a README.md still behave as file links --------------------------
+
+def test_file_link_to_readme_still_points_to_the_file(tmp_path):
+    _w(tmp_path / "docs" / "guide" / "README.md", f"---\nuuid: {DIR_UUID}\n---\n# Guide\n")
+    _w(tmp_path / "A.md", f"[guide](docs/guide/README.md) <!-- uuid: {DIR_UUID} -->.\n")
+    shutil.move(str(tmp_path / "docs" / "guide"), str(tmp_path / "manuals_guide"))
+
+    index = build_index(tmp_path)
+    apply_repairs(plan_repairs(tmp_path, index))
+
+    link = find_robust_links((tmp_path / "A.md").read_text())[0]
+    assert link.href == "manuals_guide/README.md"   # points at the FILE, not the directory

--- a/tests/test_directory_links.py
+++ b/tests/test_directory_links.py
@@ -122,6 +122,19 @@ def test_repair_directory_link_conflict_when_old_path_is_a_real_dir(tmp_path):
     assert any(f.kind is Kind.CONFLICT for f in result.findings)
 
 
+def test_repair_directory_link_conflict_when_old_path_is_a_real_file(tmp_path):
+    # A non-`.md` link (classified as a directory link) whose path still resolves to a real FILE while
+    # its uuid lives in a README elsewhere must NOT be hijacked — the path still resolves, so it is a
+    # conflict, not a moved directory. (Regression for the Copilot finding on the defensive check.)
+    _w(tmp_path / "new_home" / "README.md", f"---\nuuid: {DIR_UUID}\n---\n# Guide\n")
+    _w(tmp_path / "LICENSE", "MIT\n")       # a real, non-.md file sits at the written path
+    _w(tmp_path / "A.md", f"[license](LICENSE) <!-- uuid: {DIR_UUID} -->\n")
+    index = build_index(tmp_path)
+    result = plan_repairs(tmp_path, index)
+    assert result.new_content == {}
+    assert any(f.kind is Kind.CONFLICT for f in result.findings)
+
+
 def test_repair_directory_link_conflict_when_uuid_is_not_a_readme(tmp_path):
     # a directory link whose uuid lives in a non-README file is malformed: flag, don't guess.
     _w(tmp_path / "notes.md", f"---\nuuid: {OTHER_UUID}\n---\n# Notes\n")

--- a/tests/test_directory_links.py
+++ b/tests/test_directory_links.py
@@ -77,6 +77,15 @@ def test_robustify_directory_link_readme_no_uuid_reports_no_frontmatter(tmp_path
     assert any(f.kind is Kind.NO_FRONTMATTER for f in result.findings)
 
 
+def test_robustify_ignores_directory_named_like_an_md_file(tmp_path):
+    # a *directory* whose name ends in `.md` must not be mistaken for an anchor file (it would fail
+    # the later frontmatter read). Regression for the Copilot finding on _anchor_target.
+    (tmp_path / "weird.md").mkdir()
+    _w(tmp_path / "A.md", "[weird](weird.md)\n")
+    result = plan_robustify(tmp_path, create_frontmatter=True)
+    assert result.new_content == {}
+
+
 # --- Repair ------------------------------------------------------------------------------------
 
 def test_repair_directory_link_after_directory_moves(tmp_path):


### PR DESCRIPTION
## What

Lets a robust link target a **directory**, not just a `.md` file. A folder has no frontmatter, so its
identity is the `uuid` of its **`README.md`**. Disambiguation is by the href alone: a path ending in
`.md` is a *file* link; any other path is a *directory* link — deterministic, no disk access needed
to classify.

```markdown
See the [deployment guide](ops/deploy/) <!-- uuid: 7f3a1e2c-… -->
```
…where `ops/deploy/README.md` declares `uuid: 7f3a1e2c-…`.

## Why

Real doc trees link to **folders** (hubs, per-topic dirs, a country's report folder) as well as
files. Those links were invisible to darnlink: never robustified, and they broke silently when the
folder moved — no `--robustify`/gate could protect them. A folder's `README.md` already tends to
carry a uuid; this uses it. On the tree that motivated this, a clear majority of linked directories
already had a `README.md` with a uuid → this feature protects them where nothing could before.

## Behavior

- **robustify** — a plain link to a directory with a `README.md` is anchored to that README's uuid
  (honors `--create-frontmatter`, `--no-create-frontmatter-for`, `--only`, ignore markers). A dir
  **without** a README is left plain; darnlink never creates a README.
- **repair** — when the directory moves, the path is rewritten to the new directory (found by the
  README's uuid), kept a directory path (trailing slash).
- **conflict** — a dir link whose old path still resolves to a real *different* directory, or whose
  uuid lives in a non-README file, is flagged, not hijacked.

## ⚠️ Format change — needs sign-off

This extends the on-disk format, so per CONTRIBUTING it's "a bigger deal": **FORMAT.md §4.1** is new
and the scope line in §4 changed. The extension is backward-compatible (existing `.md`→`.md` links
are untouched) but please review the format wording before merge.

## Test change (intentional)

`test_conflict.py::test_directory_link_to_readme_*` updated: a directory link that already points at
the right folder is now a **no-op**, not a rewrite into the README *file* as before. The old behavior
silently turned a folder link into a file link; the new one respects the author's intent. The
conflict-rule guard it was protecting (a directory path must not be mis-flagged as a file conflict)
is preserved.

## Coverage

New `tests/test_directory_links.py` (11 scenarios): robustify reuse/create/no-README/no-uuid, repair
after move, no-op (with and without trailing slash), both conflict kinds, and a regression that a
file link to a `README.md` still points at the file. Full suite: 105 passed. `tools/check.sh` green
(the tool's own dir links to README-less-uuid folders show as informational `no_frontmatter` skips,
consistent with the pre-existing ones).

Spec: `specs/011-directory-links/spec.md`.