### PR TITLE
feat(self-gate): darnlink dogfoods its own MAX gate (README deny-listed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,9 @@ jobs:
         run: uv run pytest -q
       - name: darnlink self-check (links must be clean)
         run: uv run darnlink .
-      - name: darnlink strict self-check (fail-closed — every anchorable link must be robust)
-        run: uv run darnlink . --robustify
+      - name: darnlink MAX self-check (fail-closed — every link's target must carry a uuid)
+        # README.md deny-listed: it's the PyPI/GitHub landing page, kept frontmatter-free.
+        run: uv run darnlink . --robustify --create-frontmatter --no-create-frontmatter-for README.md
 
   # Exercises the commands users actually run (packaging + entry point + the literal README
   # one-liner) on Linux AND Windows — so the copy-paste one-liner is proven on both.

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ To adopt it on an existing repo: anchor what's already anchorable once with
 > on a large repo with a big generated mirror. The end-to-end playbook — the two-bucket strategy,
 > how generators cooperate (stable `uuid` + the `darnlink-ignore-links` marker), bulk-adopting a mirror from
 > its stored raw, the traps, and the pre-commit/pre-push/CI wall architecture — is in
-> **[docs/elevating-your-link-gate.md](docs/elevating-your-link-gate.md)**.
+> **[docs/elevating-your-link-gate.md](docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 -->**.
 
 > **Scope note for repos with many contributors.** All the hooks run over the **whole tree**
 > (`pass_filenames: false` — darnlink takes a directory, not a file list), and the strict check is

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -20,7 +20,7 @@ is that orchestration in one place; a consumer carries only a tiny config + a 3-
     `darnlink . --robustify --create-frontmatter` has no integrity axis, so `max` runs **both** dry-run
     passes (a true superset of `check` — it can't silently drop broken robust links).
     **Whole-repo only** — the staged pre-commit stays at strict on purpose (fast); the whole-repo wall
-    (pre-push / CI) is where `max` is enforced. See [`docs/elevating-your-link-gate.md`](../docs/elevating-your-link-gate.md).
+    (pre-push / CI) is where `max` is enforced. See [`docs/elevating-your-link-gate.md`](../docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 -->.
 - `scope=repo` → judge the whole tree (**the wall — use in pre-push & CI**).
   `scope=staged` → judge only the files you're committing (**multi-session pre-commit**, so a
   teammate's in-flight plain link doesn't block your commit). It filters `darnlink check --json` by
@@ -39,7 +39,7 @@ Exit: `0` clean · `2` integrity failure · `3` strict-only failure · `1` usage
 ## Adopt it in a repo (the wall in 4 pieces)
 
 The gate runs at three layers, each at the scope that fits — **deliberate, not redundant** (see
-[`docs/elevating-your-link-gate.md §7`](../docs/elevating-your-link-gate.md)): staged & fast locally,
+[`docs/elevating-your-link-gate.md §7`](../docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 -->): staged & fast locally,
 whole-repo where it's the wall.
 
 **1. Config** — `darnlink-gate.json` at the repo root (all keys optional):

--- a/recipes/examples/README.md
+++ b/recipes/examples/README.md
@@ -12,7 +12,7 @@ recipe ([`../darnlink-gate`](../darnlink-gate)) at the scope that fits each laye
 | [`github-actions-darnlink-gate.yml`](github-actions-darnlink-gate.yml) | server wall | **whole repo** | **closed** |
 | [`Jenkinsfile-stage.groovy`](Jenkinsfile-stage.groovy) | server wall (self-hosted) | **whole repo** | **closed** |
 
-**The scope split is deliberate** (see [`../../docs/elevating-your-link-gate.md §7`](../../docs/elevating-your-link-gate.md)):
+**The scope split is deliberate** (see [`../../docs/elevating-your-link-gate.md §7`](../../docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 -->):
 staged locally so parallel contributors don't block each other; whole-repo where the gate is the wall.
 A whole-repo **pre-commit** would deadlock — don't; that's what pre-push is for.
 
@@ -21,4 +21,4 @@ A whole-repo **pre-commit** would deadlock — don't; that's what pre-push is fo
 
 **Raising to fail-closed links (`mode=max`)** is a one-line change in `darnlink-gate.json`
 (`"mode": "max"`) once the repo's gap is 0 — the hooks and CI here need no edit. Follow
-[`../../docs/elevating-your-link-gate.md`](../../docs/elevating-your-link-gate.md) to get the gap to 0 first.
+[`../../docs/elevating-your-link-gate.md`](../../docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 --> to get the gap to 0 first.

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -11,4 +11,8 @@ cd "$(git rev-parse --show-toplevel)"
 uv sync --extra dev   # set up the environment (project + dev deps), like CI's install step
 uv run pytest -q
 uv run darnlink .              # repair check: robust links must not be broken
-uv run darnlink . --robustify  # strict check (fail-closed): every anchorable link must be robust
+# MAX self-gate (dogfood the strictest setting): every link's target must carry a uuid.
+# README.md is deny-listed — it's the PyPI/GitHub landing page, so it stays frontmatter-free
+# (its OUTBOUND links are still anchored with invisible <!-- uuid --> comments; only a frontmatter
+# uuid would show on the package page, which we don't want). See docs/elevating-your-link-gate.md.
+uv run darnlink . --robustify --create-frontmatter --no-create-frontmatter-for README.md


### PR DESCRIPTION
## What

darnlink now **dogfoods its own gate at MAXIMUM** (`--create-frontmatter`, fail-closed): every link points at a file carrying a `uuid`. Its self-check previously stopped at strict (level 2).

## How, without spoiling the PyPI landing page

- Anchored the **5 cross-links** between `README` / `docs/` / `recipes/` (`<!-- uuid -->` comments, **invisible** when rendered).
- **`README.md` DENY-LISTED** (`--no-create-frontmatter-for README.md`): it is the PyPI/GitHub landing page → it stays **without frontmatter**. Its outbound links are still anchored; only a frontmatter `uuid:` would show on the package page, and that is what we do not want.
- `tools/check.sh` and `ci.yml` raise the self-check to `--robustify --create-frontmatter --no-create-frontmatter-for README.md`.

## Verified

- max self-gate **exit 0**.
- README carries **no** `uuid:` in frontmatter (checked).

<sub>Translated from the original Spanish on 2026-08-11 — this repo is English-only on every surface, PR titles and descriptions included.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
