### PR TITLE
fix: robustify links to elevating-your-link-gate.md (main gate was red)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ To adopt it on an existing repo: anchor what's already anchorable once with
 > on a large repo with a big generated mirror. The end-to-end playbook — the two-bucket strategy,
 > how generators cooperate (stable `uuid` + the `darnlink-ignore-links` marker), bulk-adopting a mirror from
 > its stored raw, the traps, and the pre-commit/pre-push/CI wall architecture — is in
-> **[docs/elevating-your-link-gate.md](docs/elevating-your-link-gate.md)**.
+> **[docs/elevating-your-link-gate.md](docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 -->**.
 
 > **Scope note for repos with many contributors.** All the hooks run over the **whole tree**
 > (`pass_filenames: false` — darnlink takes a directory, not a file list), and the strict check is

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -20,7 +20,7 @@ is that orchestration in one place; a consumer carries only a tiny config + a 3-
     `darnlink . --robustify --create-frontmatter` has no integrity axis, so `max` runs **both** dry-run
     passes (a true superset of `check` — it can't silently drop broken robust links).
     **Whole-repo only** — the staged pre-commit stays at strict on purpose (fast); the whole-repo wall
-    (pre-push / CI) is where `max` is enforced. See [`docs/elevating-your-link-gate.md`](../docs/elevating-your-link-gate.md).
+    (pre-push / CI) is where `max` is enforced. See [`docs/elevating-your-link-gate.md`](../docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 -->.
 - `scope=repo` → judge the whole tree (**the wall — use in pre-push & CI**).
   `scope=staged` → judge only the files you're committing (**multi-session pre-commit**, so a
   teammate's in-flight plain link doesn't block your commit). It filters `darnlink check --json` by
@@ -39,7 +39,7 @@ Exit: `0` clean · `2` integrity failure · `3` strict-only failure · `1` usage
 ## Adopt it in a repo (the wall in 4 pieces)
 
 The gate runs at three layers, each at the scope that fits — **deliberate, not redundant** (see
-[`docs/elevating-your-link-gate.md §7`](../docs/elevating-your-link-gate.md)): staged & fast locally,
+[`docs/elevating-your-link-gate.md §7`](../docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 -->): staged & fast locally,
 whole-repo where it's the wall.
 
 **1. Config** — `darnlink-gate.json` at the repo root (all keys optional):

--- a/recipes/examples/README.md
+++ b/recipes/examples/README.md
@@ -12,7 +12,7 @@ recipe ([`../darnlink-gate`](../darnlink-gate)) at the scope that fits each laye
 | [`github-actions-darnlink-gate.yml`](github-actions-darnlink-gate.yml) | server wall | **whole repo** | **closed** |
 | [`Jenkinsfile-stage.groovy`](Jenkinsfile-stage.groovy) | server wall (self-hosted) | **whole repo** | **closed** |
 
-**The scope split is deliberate** (see [`../../docs/elevating-your-link-gate.md §7`](../../docs/elevating-your-link-gate.md)):
+**The scope split is deliberate** (see [`../../docs/elevating-your-link-gate.md §7`](../../docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 -->):
 staged locally so parallel contributors don't block each other; whole-repo where the gate is the wall.
 A whole-repo **pre-commit** would deadlock — don't; that's what pre-push is for.
 
@@ -21,4 +21,4 @@ A whole-repo **pre-commit** would deadlock — don't; that's what pre-push is fo
 
 **Raising to fail-closed links (`mode=max`)** is a one-line change in `darnlink-gate.json`
 (`"mode": "max"`) once the repo's gap is 0 — the hooks and CI here need no edit. Follow
-[`../../docs/elevating-your-link-gate.md`](../../docs/elevating-your-link-gate.md) to get the gap to 0 first.
+[`../../docs/elevating-your-link-gate.md`](../../docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 --> to get the gap to 0 first.


### PR DESCRIPTION
## What

Commit `b396cb3` gave `docs/elevating-your-link-gate.md` a `uuid` (so web/cross-repo links could
anchor to it) but did **not** robustify its 5 inbound plain links. That left the strict self-check
`darnlink . --robustify` — a CI step (ci.yml) and the local pre-commit — **failing on `main`**, and
every branch cut from `main` inherited the red (e.g. #16).

This anchors those 5 links to that uuid, in `README.md`, `recipes/README.md`,
`recipes/examples/README.md`. It's darnlink robustifying its own docs — exactly what the tool does;
no code or behavior change.

## Verification

`darnlink . --robustify` → `plain links to robustify: 0`. The pre-commit gate (`tools/check.sh`)
passes locally; CI should go green. Once merged, #16 (and any other branch off main) can rebase to a
green base.