### PR TITLE
fix: --create-readme must not create a README inside an --exclude'd subtree (FR-012g)

### DIFF
--- a/specs/012-create-readme/spec.md
+++ b/specs/012-create-readme/spec.md
@@ -65,6 +65,10 @@ creates `docs/hub/README.md` — with a fresh uuid and a `# hub` heading — and
   `--write`, like every other darnlink write.
 - **FR-012f**: `--create-readme` implies `--create-frontmatter` (a run willing to create a README is
   willing to add a uuid to an existing one).
+- **FR-012g**: A README is never created inside an `--exclude`'d subtree. `--exclude` prunes those
+  directories from the scan, but a link from an *included* file can point at a directory *inside* an
+  excluded one (a mirror, a vendored clone); creation must honor the exclusion for the write target,
+  not only for the scan.
 
 ## Out of Scope
 

--- a/src/darnlink/frontmatter_index.py
+++ b/src/darnlink/frontmatter_index.py
@@ -16,7 +16,7 @@ import frontmatter
 DEFAULT_EXCLUDES = {".git", "node_modules", ".venv", "__pycache__", "_build", ".tox", "dist", "build"}
 
 
-def _dir_excluded(name: str, excludes) -> bool:
+def dir_excluded(name: str, excludes) -> bool:
     """A directory name is excluded if it matches any pattern by glob (fnmatch, case-sensitive).
     A pattern with no wildcards matches exactly, so plain names (`node_modules`) still work — the
     glob is purely additive. Lets a repo exclude a family with one line, e.g. `old`, `old_*`, `*_old`."""
@@ -40,7 +40,7 @@ def iter_markdown_files(root: Path, excludes: set[str] = DEFAULT_EXCLUDES) -> It
     """Yield all `.md` files under `root`, skipping excluded directory names."""
     root = root.resolve()
     for dirpath, dirnames, filenames in os.walk(root):
-        dirnames[:] = [d for d in dirnames if not _dir_excluded(d, excludes)]
+        dirnames[:] = [d for d in dirnames if not dir_excluded(d, excludes)]
         for fn in filenames:
             if fn.lower().endswith(".md"):
                 yield Path(dirpath) / fn

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -22,7 +22,7 @@ from .frontmatter_edit import (
     read_text_keep_newlines,
     write_text_keep_newlines,
 )
-from .frontmatter_index import DEFAULT_EXCLUDES, _dir_excluded, iter_markdown_files, read_frontmatter_uuid
+from .frontmatter_index import DEFAULT_EXCLUDES, dir_excluded, iter_markdown_files, read_frontmatter_uuid
 from .links import (code_spans, emit_robust_link, file_ignores_links, file_is_ignored,
                     find_plain_links, ignored_spans)
 from .paths import DIR_ANCHOR, is_local_relative, names_md, resolve_href
@@ -100,7 +100,7 @@ def _within_excluded(directory: Path, root: Path, excludes) -> bool:
         rel = directory.resolve().relative_to(root)
     except ValueError:
         return False  # outside root is handled by the caller's own root check
-    return any(_dir_excluded(part, excludes) for part in rel.parts)
+    return any(dir_excluded(part, excludes) for part in rel.parts)
 
 
 def plan_robustify(

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -22,7 +22,7 @@ from .frontmatter_edit import (
     read_text_keep_newlines,
     write_text_keep_newlines,
 )
-from .frontmatter_index import DEFAULT_EXCLUDES, iter_markdown_files, read_frontmatter_uuid
+from .frontmatter_index import DEFAULT_EXCLUDES, _dir_excluded, iter_markdown_files, read_frontmatter_uuid
 from .links import (code_spans, emit_robust_link, file_ignores_links, file_is_ignored,
                     find_plain_links, ignored_spans)
 from .paths import DIR_ANCHOR, is_local_relative, names_md, resolve_href
@@ -87,6 +87,20 @@ def _dir_link_missing_readme(href: str, linking_file: Path) -> Path | None:
 def _basename_denied(target: Path, no_create_globs: Tuple[str, ...]) -> bool:
     """True if the target's basename matches any deny-list glob (FR-029/FR-032)."""
     return any(fnmatch(target.name, g) for g in no_create_globs)
+
+
+def _within_excluded(directory: Path, root: Path, excludes) -> bool:
+    """True if `directory` lies inside a subtree whose directory name is excluded from the scan.
+
+    Feature 012: `--create-readme` must never write a README into a subtree darnlink was told to skip
+    (a `mirror/`, a vendored `clones/`). `--exclude` prunes those dirs from the scan, but a link from
+    an *included* file can still point at a directory *inside* an excluded one — this closes that path.
+    """
+    try:
+        rel = directory.resolve().relative_to(root)
+    except ValueError:
+        return False  # outside root is handled by the caller's own root check
+    return any(_dir_excluded(part, excludes) for part in rel.parts)
 
 
 def plan_robustify(
@@ -170,6 +184,8 @@ def plan_robustify(
                     continue  # one README per directory, however many links point at it
                 if not readme.is_relative_to(root_resolved):
                     continue  # a `../`-escaping link must never make us write outside the scanned root
+                if _within_excluded(d, root_resolved, excludes):
+                    continue  # never create inside an --exclude'd subtree (a mirror, a vendored clone)
                 if not in_scope(readme, only):
                     continue  # respect --only: never create outside the write scope
                 if _basename_denied(readme, no_create_globs):

--- a/tests/test_create_readme.py
+++ b/tests/test_create_readme.py
@@ -123,17 +123,6 @@ def test_create_readme_ignores_a_directory_named_readme(tmp_path):
     assert result.new_content == {}
 
 
-def test_create_readme_skips_excluded_directories(tmp_path):
-    # a link from an INCLUDED file to a directory inside an --exclude'd subtree (e.g. a mirror, a
-    # vendored clone) must not get a README created there — --create-readme respects --exclude for the
-    # write target, not only for the scan.
-    (tmp_path / "mirror" / "capture").mkdir(parents=True)
-    _w(tmp_path / "A.md", "[cap](mirror/capture/)\n")
-    result = plan_robustify(tmp_path, create_readme=True, excludes={"mirror"})
-    assert result.new_content == {}
-    assert not (tmp_path / "mirror" / "capture" / "README.md").exists()
-
-
 def test_create_readme_never_writes_outside_the_scanned_root(tmp_path):
     # a `../`-escaping link must never make darnlink create a README outside the tree it was pointed at
     (tmp_path / "sub").mkdir()

--- a/tests/test_create_readme.py
+++ b/tests/test_create_readme.py
@@ -123,6 +123,17 @@ def test_create_readme_ignores_a_directory_named_readme(tmp_path):
     assert result.new_content == {}
 
 
+def test_create_readme_skips_excluded_directories(tmp_path):
+    # a link from an INCLUDED file to a directory inside an --exclude'd subtree (e.g. a mirror, a
+    # vendored clone) must not get a README created there — --create-readme respects --exclude for the
+    # write target, not only for the scan.
+    (tmp_path / "mirror" / "capture").mkdir(parents=True)
+    _w(tmp_path / "A.md", "[cap](mirror/capture/)\n")
+    result = plan_robustify(tmp_path, create_readme=True, excludes={"mirror"})
+    assert result.new_content == {}
+    assert not (tmp_path / "mirror" / "capture" / "README.md").exists()
+
+
 def test_create_readme_never_writes_outside_the_scanned_root(tmp_path):
     # a `../`-escaping link must never make darnlink create a README outside the tree it was pointed at
     (tmp_path / "sub").mkdir()
@@ -131,6 +142,16 @@ def test_create_readme_never_writes_outside_the_scanned_root(tmp_path):
     result = plan_robustify(tmp_path / "sub", create_readme=True)
     assert result.new_content == {}
     assert not (tmp_path / "sibling" / "README.md").exists()
+
+
+def test_create_readme_never_writes_into_an_excluded_subtree(tmp_path):
+    # a link from an INCLUDED file to a directory INSIDE an --exclude'd subtree (e.g. a mirror) must
+    # not get a README created there — --exclude prunes the scan, and creation must respect it too.
+    (tmp_path / "mirror" / "captured_chat").mkdir(parents=True)
+    _w(tmp_path / "A.md", "[chat](mirror/captured_chat/)\n")
+    result = plan_robustify(tmp_path, create_readme=True, excludes={"mirror"})
+    assert result.new_content == {}
+    assert not (tmp_path / "mirror" / "captured_chat" / "README.md").exists()
 
 
 def test_created_readme_link_heals_after_move(tmp_path):


### PR DESCRIPTION
## What

`--create-readme` (spec 012) could write a `README.md` **into an `--exclude`'d subtree**. `--exclude`
prunes those directories from the *scan*, but a link from an *included* file can point at a directory
*inside* an excluded one — and creation didn't check the write target against `--exclude`, only the
scan did.

Real case that surfaced it: running `--create-readme --exclude mirrors` on a docs tree still planned
**172** READMEs inside `mirrors/` (external snapshots + vendored `clones/`), because tasks/notes link
into mirror folders. Injecting darnlink anchors into a mirror desyncs it from its source — exactly
what `--exclude` is meant to prevent.

## Fix

Guard the creation target with `_within_excluded()`: if any directory component of the target README's
path (relative to root) is excluded, skip creation. On that same tree, `--exclude mirrors` now drops
the in-`mirrors/` READMEs from **172 → 0** (the legitimate ~180 elsewhere are unaffected).

## Coverage

`test_create_readme_skips_excluded_directories` — a link from an included file to a dir inside an
excluded subtree creates nothing. Full suite: **120 passing**. Adds **FR-012g** to spec 012.

Follow-up to #16.