### PR TITLE
feat: --create-readme skips folders holding downloaded/external content (spec 014)

### DIFF
--- a/specs/014-create-readme-skip-external/spec.md
+++ b/specs/014-create-readme-skip-external/spec.md
@@ -1,0 +1,62 @@
+# Feature Specification: `--create-readme` skips folders holding downloaded/external content
+
+**Feature Branch**: `014-create-readme-skip-external`
+
+**Created**: 2026-07-22
+
+**Status**: Draft
+
+**Input**: `--create-readme` (feature 012) can be pointed at a documentation tree that also contains a
+**mirror** of external systems (captured chats, downloaded documents, exported issues). A link from an
+authored file into a capture folder would make darnlink create a `README.md` **inside that capture**,
+injecting a darnlink anchor into content we do not own. `--exclude` is too coarse — it also drops the
+folder's *authored* management files (our READMEs, `analysis.md`) from robustification.
+
+## Motivation
+
+The rule a real tree wants is by **provenance**, not location: *robustify everything we authored;
+never touch what was downloaded.* darnlink already has the per-file `<!-- darnlink-ignore-file -->`
+marker (a downloaded/generated file carries it → it is neither source nor target). This feature lets
+that same marker also answer the directory-level question `--create-readme` asks: **is this folder
+ours, or the mirror's?** A folder that holds a downloaded file is the mirror's, so no README is created
+there — while the folder's authored files are still robustified, and folders elsewhere are unaffected.
+
+This is the surgical alternative to `--exclude mirror`: it keeps our management files inside the mirror
+anchorable and only skips the actual downloaded captures.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Don't create a README inside a downloaded capture (Priority: P1)
+
+An authored note links to a captured chat folder that holds a `transcript.md` marked
+`<!-- darnlink-ignore-file -->`. With `--create-readme`, darnlink does **not** create a README there.
+
+**Acceptance Scenarios**:
+
+1. **Given** `capture/transcript.md` carries `<!-- darnlink-ignore-file -->` and `A.md` links
+   `[cap](capture/)`, **When** `--create-readme` runs, **Then** no README is created in `capture/` and
+   nothing is written.
+2. **Given** a folder `hub/` with only an authored `notes.md` (no marker) that `A.md` links to,
+   **When** `--create-readme` runs, **Then** `hub/README.md` **is** created (the folder is ours).
+3. **Given** an empty folder `hub/` (no `.md` at all) that `A.md` links to, **When** `--create-readme`
+   runs, **Then** `hub/README.md` **is** created — the signal is the *presence* of a marked file, so an
+   empty hub is not mistaken for external content.
+
+## Requirements *(mandatory)*
+
+- **FR-014a**: `--create-readme` does not create a `README.md` in a target directory that **directly**
+  contains a `.md` file carrying `<!-- darnlink-ignore-file -->`.
+- **FR-014b**: The check is a *positive* signal (a marked file must be present). A folder with no such
+  file — empty, or holding only authored `.md` — is unaffected.
+- **FR-014c**: Only the target directory's own direct children are inspected (not recursively): a
+  capture folder holds its downloaded files directly; a parent folder is judged by its own contents.
+- **FR-014d**: Composes with the existing guards (`--exclude`, `--only`, `--no-create-frontmatter-for`,
+  the root boundary) — any one of them still skips creation independently.
+
+## Out of Scope
+
+- Marking the downloaded files themselves (that is the consumer's ingest pipeline; darnlink only reads
+  the marker). A repo adopts this by ensuring its downloaded/generated `.md` carry
+  `<!-- darnlink-ignore-file -->`.
+- A recursive scan of the target subtree, or a directory-level marker file — the direct-child `.md`
+  check covers the capture-folder case without either.

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -122,7 +122,10 @@ def _holds_downloaded_content(directory: Path) -> bool:
                 if file_is_ignored(read_text_keep_newlines(p)):
                     return True
             except Exception:
-                continue
+                # An unreadable/undecodable `.md` here is itself a reason NOT to create a README: we
+                # can't confirm it isn't a downloaded/external file, and the whole point is to never
+                # write into the mirror. Treat the failure as a positive signal (skip), never a crash.
+                return True
     return False
 
 

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -103,6 +103,29 @@ def _within_excluded(directory: Path, root: Path, excludes) -> bool:
     return any(dir_excluded(part, excludes) for part in rel.parts)
 
 
+def _holds_downloaded_content(directory: Path) -> bool:
+    """True if `directory` directly contains a `.md` carrying `<!-- darnlink-ignore-file -->`.
+
+    Feature 014: that marker flags a **downloaded / external** file (a mirror capture — a transcript,
+    an extract), so the folder is external, not ours. `--create-readme` must not create a README there:
+    a folder is authored-by-us only if we put content in it, and a folder holding a downloaded file is
+    the mirror's, not ours. It is a *positive* signal — a folder with no such marker (an empty hub, or
+    one holding only authored `.md`) is unaffected and still gets its README.
+    """
+    try:
+        entries = list(directory.iterdir())
+    except OSError:
+        return False
+    for p in entries:
+        if p.is_file() and p.suffix.lower() == ".md":
+            try:
+                if file_is_ignored(read_text_keep_newlines(p)):
+                    return True
+            except Exception:
+                continue
+    return False
+
+
 def plan_robustify(
     root: Path,
     create_frontmatter: bool = False,
@@ -186,6 +209,8 @@ def plan_robustify(
                     continue  # a `../`-escaping link must never make us write outside the scanned root
                 if _within_excluded(d, root_resolved, excludes):
                     continue  # never create inside an --exclude'd subtree (a mirror, a vendored clone)
+                if _holds_downloaded_content(d):
+                    continue  # a folder holding a darnlink-ignore-file'd file is external/downloaded
                 if not in_scope(readme, only):
                     continue  # respect --only: never create outside the write scope
                 if _basename_denied(readme, no_create_globs):

--- a/tests/test_create_readme.py
+++ b/tests/test_create_readme.py
@@ -123,6 +123,27 @@ def test_create_readme_ignores_a_directory_named_readme(tmp_path):
     assert result.new_content == {}
 
 
+def test_create_readme_skips_folder_holding_downloaded_content(tmp_path):
+    # feature 014: a folder that holds a downloaded/external file (marked <!-- darnlink-ignore-file -->)
+    # is the mirror's, not ours — --create-readme must not create a README there, even though we link
+    # to it. This is the surgical alternative to --exclude'ing a whole mirror tree.
+    (tmp_path / "capture").mkdir()
+    _w(tmp_path / "capture" / "transcript.md", "<!-- darnlink-ignore-file -->\n# raw capture\n")
+    _w(tmp_path / "A.md", "[cap](capture/)\n")
+    result = plan_robustify(tmp_path, create_readme=True)
+    assert result.new_content == {}
+    assert not (tmp_path / "capture" / "README.md").exists()
+
+
+def test_create_readme_still_creates_in_a_folder_with_only_authored_content(tmp_path):
+    # a folder holding only authored .md (no ignore-file marker) is ours → it still gets a README
+    (tmp_path / "hub").mkdir()
+    _w(tmp_path / "hub" / "notes.md", "# my notes\n")   # authored, no marker
+    _w(tmp_path / "A.md", "[hub](hub/)\n")
+    apply_robustify(plan_robustify(tmp_path, create_readme=True))
+    assert (tmp_path / "hub" / "README.md").is_file()
+
+
 def test_create_readme_never_writes_outside_the_scanned_root(tmp_path):
     # a `../`-escaping link must never make darnlink create a README outside the tree it was pointed at
     (tmp_path / "sub").mkdir()

--- a/tests/test_create_readme.py
+++ b/tests/test_create_readme.py
@@ -135,6 +135,16 @@ def test_create_readme_skips_folder_holding_downloaded_content(tmp_path):
     assert not (tmp_path / "capture" / "README.md").exists()
 
 
+def test_create_readme_skips_folder_with_an_unreadable_md(tmp_path):
+    # an undecodable .md in the folder is a positive signal to skip: we can't confirm it isn't
+    # downloaded/external, and must never risk writing a README into the mirror. (Copilot #20.)
+    (tmp_path / "capture").mkdir()
+    (tmp_path / "capture" / "raw.md").write_bytes(b"\xff\xfe\x80\x81 not valid utf-8 \xfa")
+    _w(tmp_path / "A.md", "[cap](capture/)\n")
+    result = plan_robustify(tmp_path, create_readme=True)
+    assert result.new_content == {}
+
+
 def test_create_readme_still_creates_in_a_folder_with_only_authored_content(tmp_path):
     # a folder holding only authored .md (no ignore-file marker) is ours → it still gets a README
     (tmp_path / "hub").mkdir()


### PR DESCRIPTION
## What

`--create-readme` (feature 012) now **skips a target folder that directly contains a `.md` carrying
`<!-- darnlink-ignore-file -->`** — the marker that flags a downloaded/external file (a mirror
capture: a transcript, an extract). Such a folder is the mirror's, not ours, so no README is created
in it.

## Why

The rule a mixed docs+mirror tree wants is by **provenance**, not location: *robustify everything we
authored; never touch what was downloaded.* `--exclude mirror` is too coarse — it also drops the
mirror's **authored** files (our management READMEs, `analysis.md`) from robustification. This reuses
the existing per-file `darnlink-ignore-file` marker to answer the folder-level question create-readme
asks — is this folder ours or the mirror's? — so our management files inside the mirror stay
anchorable and only the actual captures are skipped.

Positive signal: a folder with **no** such marker (empty hub, or only authored `.md`) is unaffected
and still gets its README.

## Coverage

`tests/test_create_readme.py` — two new: skips a folder holding a marked download; still creates in a
folder with only authored content. Full suite: **143 passing**. Spec: `specs/014-create-readme-skip-external/`.

Follow-up to #16/#19 (create-readme). Rebased on v0.9.0.