### PR TITLE
feat(recipe): opt-in web + create_readme keys in darnlink-gate.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **Recipe `darnlink-gate` gains two opt-in `darnlink-gate.json` keys** (both `mode=max` only), so a
+  fleet can turn them on by config instead of hand-wiring each repo:
+  - **`"web": true`** — adds a `web-check --online` pass: cross-repo Markdown links to other GitHub
+    repos must resolve to the destination file's `uuid`. Public targets are tokenless; private ones
+    send `$GITHUB_TOKEN` if set, else report `web_unverifiable` (a warning, never a failure). Fail-closed
+    on a broken public web link. The recipe exits web-check's code directly (its `4` is a real broken
+    link, not the core's `rc>3` "unreachable" — which would otherwise swallow it and go green).
+  - **`"create_readme": true`** — the `max` robustify pass also runs `--create-readme`, so a directory
+    link whose target folder has no README (no `uuid` to anchor) fails the gate (dry-run detects it).
+  Both wired in the bash and PowerShell recipes. `DARNLINK_GATE_WEB` / `DARNLINK_GATE_CREATE_README`
+  env overrides mirror the existing ones.
+
 ## [0.10.0] — 2026-07-23
 
 ### Changed

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -35,8 +35,15 @@
 # CONFIG. Reads `darnlink-gate.json` at the repo root (all keys optional):
 #   { "ref": "git+https://github.com/txemi/darnlink@v0.7.0",
 #     "excludes": ["secrets","external_repos"], "ignore_blocks": ["txmd-autogrid"],
-#     "mode": "check", "scope": "repo", "fail_closed": true }
+#     "mode": "check", "scope": "repo", "fail_closed": true,
+#     "web": true, "create_readme": true }
 #   mode ∈ { repair | check | max } — see WHAT IT DOES. Raising it is a one-way ratchet: only up.
+#   web (mode=max only): add a `web-check --online` pass — cross-repo links to OTHER GitHub repos must
+#     resolve to the destination's uuid (read online). Public targets need no token; private ones send
+#     $GITHUB_TOKEN if set, else `web_unverifiable` (a warning, never a failure). Fail-closed on a broken
+#     public web link.
+#   create_readme (mode=max only): also run `--create-readme` — a directory link whose target folder has
+#     no README (no uuid to anchor to) FAILS the gate (dry-run detects it; fix with `--create-readme --write`).
 # ⚠️ In CI prefer the ENV VAR over the json key: reading the json needs python3, so if python3 is
 #    missing the key is silently lost — and "python3 missing" is one of the very cases fail-closed
 #    exists to catch. `DARNLINK_GATE_FAIL_CLOSED=1` is read by the shell and always applies.
@@ -76,6 +83,18 @@ SCOPE="${DARNLINK_GATE_SCOPE:-$(read_cfg scope repo)}"
 # turn it OFF. Accept the obvious spellings on both sides.
 FAIL_CLOSED="${DARNLINK_GATE_FAIL_CLOSED:-$(read_cfg fail_closed "")}"
 case "${FAIL_CLOSED,,}" in ""|0|false|no|off) FAIL_CLOSED="" ;; *) FAIL_CLOSED=1 ;; esac
+# WEB (opt-in): when on, mode=max adds a 3rd whole-repo pass — `web-check --online` — that verifies
+# cross-repo Markdown links to OTHER GitHub repos still resolve to the destination file's uuid (read
+# online, anchored with `<!-- web-uuid: X -->`). Public destinations need NO token; private ones send
+# $GITHUB_TOKEN if set, else are reported `web_unverifiable` (a warning, NOT a failure — never a crash).
+# Fail-closed only on a genuinely broken/moved public web link. Same normalise-the-string dance as above.
+WEB="${DARNLINK_GATE_WEB:-$(read_cfg web "")}"
+case "${WEB,,}" in ""|0|false|no|off) WEB="" ;; *) WEB=1 ;; esac
+# CREATE_README (opt-in): when on, mode=max also runs `--create-readme` — a directory link whose target
+# folder has no README (so no uuid to anchor to) FAILS the gate (dry-run: it's DETECTED, not written).
+# Robustify it by hand with `--create-readme --write`. Raises the max ceiling from "files" to "folders".
+CREATE_README="${DARNLINK_GATE_CREATE_README:-$(read_cfg create_readme "")}"
+case "${CREATE_README,,}" in ""|0|false|no|off) CREATE_README="" ;; *) CREATE_README=1 ;; esac
 mapfile -t EXCLUDES < <(read_cfg excludes "")
 mapfile -t IGNORE_BLOCKS < <(read_cfg ignore_blocks "")
 
@@ -125,8 +144,26 @@ if [ "$SCOPE" != "staged" ]; then
     # the bare `--robustify --create-frontmatter` ADDS create-frontmatter but DROPS integrity (it never
     # runs plan_repairs — a broken/moved robust link sails through). So run BOTH dry-run passes and
     # fail if either does. This makes max a TRUE superset of check (the ratchet holds). Both read-only.
+    # create_readme raises the ceiling: directory targets must have a README too (dry-run = detect it).
+    MAX_ROBUSTIFY=(--robustify --create-frontmatter)
+    [ -n "$CREATE_README" ] && MAX_ROBUSTIFY+=(--create-readme)
     run check . "${DL_ARGS[@]}"; rc=$?
-    if [ "$rc" -eq 0 ]; then run . --robustify --create-frontmatter "${DL_ARGS[@]}"; rc=$?; fi
+    if [ "$rc" -eq 0 ]; then run . "${MAX_ROBUSTIFY[@]}" "${DL_ARGS[@]}"; rc=$?; fi
+    # WEB pass (opt-in, mode=max only): cross-repo web-link robustness, only if the core passed (so a
+    # core failure surfaces first). web-check has no --exclude (it only walks web hrefs) but takes
+    # --ignore-block. Fail-closed on a broken public web link; web_unverifiable (private w/o token, or
+    # offline) is exit 0. Needs a ref with the web-check subcommand (v0.9.0+) — the fleet pins >= that.
+    if [ "$rc" -eq 0 ] && [ -n "$WEB" ]; then
+      WEB_ARGS=(); for b in "${IGNORE_BLOCKS[@]}"; do [ -n "$b" ] && WEB_ARGS+=(--ignore-block "$b"); done
+      run web-check . --online "${WEB_ARGS[@]}"; rc=$?
+      set -e
+      # web-check's contract differs from core: 0 = clean (a network/token failure is reported
+      # web_unverifiable, still exit 0 — it NEVER exits high for unreachability), and 4 = a REAL broken/
+      # moved/mismatched public web link. So its non-zero is fail-closed, NOT the core's rc>3
+      # "unreachable" case — exit it DIRECTLY, bypassing the bail heuristic below (which would swallow
+      # a genuine broken link as "network hiccup" and go green).
+      exit "$rc"
+    fi
   else
     run check . "${DL_ARGS[@]}"; rc=$?   # `darnlink check` → stable 0/2/3 contract (mode=check|repair)
   fi

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -157,11 +157,12 @@ if [ "$SCOPE" != "staged" ]; then
       WEB_ARGS=(); for b in "${IGNORE_BLOCKS[@]}"; do [ -n "$b" ] && WEB_ARGS+=(--ignore-block "$b"); done
       run web-check . --online "${WEB_ARGS[@]}"; rc=$?
       set -e
-      # web-check's contract differs from core: 0 = clean (a network/token failure is reported
-      # web_unverifiable, still exit 0 — it NEVER exits high for unreachability), and 4 = a REAL broken/
-      # moved/mismatched public web link. So its non-zero is fail-closed, NOT the core's rc>3
-      # "unreachable" case — exit it DIRECTLY, bypassing the bail heuristic below (which would swallow
-      # a genuine broken link as "network hiccup" and go green).
+      # web-check's contract (all in 0..4, none of them "unreachable"): 0 = clean (a network/token
+      # failure is reported web_unverifiable, still exit 0 — it NEVER exits high); 3 = a plain web link
+      # not yet anchored (dry-run: it COULD be robustified) — a real gate failure, which is the point
+      # (detect un-robustified web links); 4 = a broken/moved/mismatched public web link. So EVERY
+      # non-zero is fail-closed, NOT the core's rc>3 "unreachable" case — exit it DIRECTLY, bypassing the
+      # bail heuristic below (which would swallow a genuine 4 as "network hiccup" and go green).
       exit "$rc"
     fi
   else

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -103,9 +103,10 @@ if ($scope -ne 'staged') {
       & uvx --from $ref darnlink . @maxArgs @dlArgs @args
       $rc = $LASTEXITCODE
     }
-    # WEB pass (opt-in, max only): web-check's non-zero is fail-closed (0 = clean incl web_unverifiable/
-    # offline; 4 = real broken public web link) — NOT the core's rc>3 "unreachable", so exit it directly,
-    # bypassing the bail below. web-check has no --exclude but takes --ignore-block.
+    # WEB pass (opt-in, max only): EVERY web-check non-zero is fail-closed (0 = clean incl web_unverifiable/
+    # offline; 3 = a plain web link not yet anchored — dry-run, could be robustified; 4 = broken public web
+    # link) — none is the core's rc>3 "unreachable", so exit it directly, bypassing the bail below.
+    # web-check has no --exclude but takes --ignore-block.
     if ($rc -eq 0 -and $web) {
       $webArgs = @(); foreach ($b in $ignoreBlocks) { if ($b) { $webArgs += @('--ignore-block', $b) } }
       & uvx --from $ref darnlink web-check . --online @webArgs

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -54,6 +54,17 @@ function Invoke-Bail([string]$reason) {
 }
 $excludes     = @(CfgOr 'excludes' @())
 $ignoreBlocks = @(CfgOr 'ignore_blocks' @())
+# WEB (opt-in, mode=max): add a `web-check --online` pass — cross-repo links to OTHER GitHub repos must
+# resolve to the destination's uuid (read online). Public needs no token; private sends $GITHUB_TOKEN if
+# set, else web_unverifiable (a warning). Fail-closed on a broken public web link. Same normalise dance.
+$rawWeb = if ($null -ne $env:DARNLINK_GATE_WEB) { $env:DARNLINK_GATE_WEB } else { CfgOr 'web' '' }
+$web = -not ([string]::IsNullOrWhiteSpace([string]$rawWeb) -or
+             ([string]$rawWeb).Trim().ToLower() -in @('0','false','no','off'))
+# CREATE_README (opt-in, mode=max): also run --create-readme — a directory link whose target folder has
+# no README (no uuid) FAILS the gate (dry-run detects it; fix with --create-readme --write).
+$rawCR = if ($null -ne $env:DARNLINK_GATE_CREATE_README) { $env:DARNLINK_GATE_CREATE_README } else { CfgOr 'create_readme' '' }
+$createReadme = -not ([string]::IsNullOrWhiteSpace([string]$rawCR) -or
+                      ([string]$rawCR).Trim().ToLower() -in @('0','false','no','off'))
 
 # --- guard: read-only. Never pass --write through. ---
 if ($args -contains '--write') {
@@ -87,8 +98,18 @@ if ($scope -ne 'staged') {
     & uvx --from $ref darnlink check . @dlArgs @args
     $rc = $LASTEXITCODE
     if ($rc -eq 0) {
-      & uvx --from $ref darnlink . --robustify --create-frontmatter @dlArgs @args
+      $maxArgs = @('--robustify','--create-frontmatter')
+      if ($createReadme) { $maxArgs += '--create-readme' }   # directory targets need a README too
+      & uvx --from $ref darnlink . @maxArgs @dlArgs @args
       $rc = $LASTEXITCODE
+    }
+    # WEB pass (opt-in, max only): web-check's non-zero is fail-closed (0 = clean incl web_unverifiable/
+    # offline; 4 = real broken public web link) — NOT the core's rc>3 "unreachable", so exit it directly,
+    # bypassing the bail below. web-check has no --exclude but takes --ignore-block.
+    if ($rc -eq 0 -and $web) {
+      $webArgs = @(); foreach ($b in $ignoreBlocks) { if ($b) { $webArgs += @('--ignore-block', $b) } }
+      & uvx --from $ref darnlink web-check . --online @webArgs
+      exit $LASTEXITCODE
     }
   } else {
     & uvx --from $ref darnlink check . @dlArgs @args   # `darnlink check` → 0/2/3 (mode=check|repair)


### PR DESCRIPTION
## What

Adds two opt-in keys to `darnlink-gate.json` (both only under `mode=max`), so a fleet can turn web / create-readme on **by config** instead of wiring each repo by hand:

- **`"web": true`** → a 3rd `web-check --online` pass (robustness of cross-repo links by GitHub URL, anchored with `<!-- web-uuid: X -->`). Public = tokenless; private = `$GITHUB_TOKEN` if present, otherwise `web_unverifiable` (a warning, does not break). **Fail-closed** on a broken public link.
- **`"create_readme": true`** → the `max` pass additionally runs `--create-readme` (directory-link targets need a README with a uuid).

Wired in **both** the bash and the PowerShell recipe. Overrides: `DARNLINK_GATE_WEB` / `DARNLINK_GATE_CREATE_README`.

## Integration bug caught and fixed

`web-check` exits with **code 4** on a broken link (`web_mismatch`), which collided with the recipe's `rc>3 = "darnlink unreachable"` heuristic → **bail fail-open** (green with a broken link). Fix: the web pass **exits with its own code directly**, without going through the bail.

## Test (clean fixture)

| Case | Expected | Actual |
|---|---|---|
| correct web-uuid | 0 | ✅ 0 |
| broken web-uuid | 4 (fail-closed) | ✅ 4 |
| `web:false` (broken link) | 0 (ignored) | ✅ 0 |
| `create_readme:true` with no hubs | 0 | ✅ 0 |

## Why

The consuming fleet's goal: **every repo with the web option on and maximum robustness**, kept in sync by one shared recipe. This is the piece of darnlink that enables it. After merge → release (v0.11.0) → consumers pin it and add `"web": true` to each json.

<sub>Translated from the original Spanish on 2026-08-11 — this repo is English-only on every surface, PR titles and descriptions included.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
