### PR TITLE
feat(web-check): --exclude (skip vendored clones / foreign subtrees)

### DIFF
--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -307,6 +307,9 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
     parser.add_argument("--write", action="store_true", help="apply anchors to plain web links (needs --online)")
     parser.add_argument("--ignore-block", action="append", default=[], metavar="NAME",
                         help="ignore links inside <!-- NAME-start --> … <!-- NAME-end --> blocks (repeatable)")
+    parser.add_argument("--exclude", action="append", default=[], metavar="PATTERN",
+                        help="directory-name glob to skip (fnmatch; repeatable). Exclude vendored clones "
+                             "of foreign repos so their internal web links aren't fetched/anchored.")
     parser.add_argument("--json", action="store_true", help="machine-readable output")
     args = parser.parse_args(argv)
 
@@ -319,6 +322,7 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
         return 1
 
     block_markers = tuple(args.ignore_block)
+    excludes = set(DEFAULT_EXCLUDES) | set(args.exclude)
 
     if not args.online:
         # Off-by-default: no network, no new behaviour. Just surface which web links exist so the user
@@ -329,7 +333,7 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
         from .frontmatter_edit import read_text_keep_newlines
         seen = 0
         listing = []
-        for f in iter_markdown_files(root):
+        for f in iter_markdown_files(root, excludes):
             try:
                 content = read_text_keep_newlines(f)
             except Exception:
@@ -350,7 +354,7 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
         return 0
 
     token = os.environ.get("GITHUB_TOKEN") or None
-    findings, edits = check_web_links_online(root, token, fetcher or default_fetcher, block_markers)
+    findings, edits = check_web_links_online(root, token, fetcher or default_fetcher, block_markers, excludes)
     ok = [x for x in findings if x.kind == "web_ok"]
     anchors = [x for x in findings if x.kind == "web_anchor"]
     mismatch = [x for x in findings if x.kind == "web_mismatch"]

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -308,8 +308,9 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
     parser.add_argument("--ignore-block", action="append", default=[], metavar="NAME",
                         help="ignore links inside <!-- NAME-start --> … <!-- NAME-end --> blocks (repeatable)")
     parser.add_argument("--exclude", action="append", default=[], metavar="PATTERN",
-                        help="directory-name glob to skip (fnmatch; repeatable). Exclude vendored clones "
-                             "of foreign repos so their internal web links aren't fetched/anchored.")
+                        help="directory-name glob to skip (fnmatch, case-sensitive; a plain name matches "
+                             "exactly) (repeatable). Exclude vendored clones of foreign repos so their "
+                             "internal web links aren't fetched/anchored.")
     parser.add_argument("--json", action="store_true", help="machine-readable output")
     args = parser.parse_args(argv)
 

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -169,19 +169,26 @@ def check_web_links_online(
     token: Optional[str] = None,
     fetcher: Fetcher = default_fetcher,
     block_markers: tuple = (),
+    excludes: Optional[set] = None,
 ) -> Tuple[List[WebFinding], Dict[Path, str]]:
     """Fetch each web link's destination (once, cached per URL) and classify it. Returns the findings
     and the per-file rewritten content for any `web_anchor` (the caller writes it only under --write).
-    Deterministic given (tree + fetcher responses). Network happens only inside `fetcher`."""
-    from .frontmatter_index import iter_markdown_files
+    Deterministic given (tree + fetcher responses). Network happens only inside `fetcher`.
+
+    `excludes` is a set of directory-name globs to skip (same semantics as the other commands); a
+    repo with vendored `clones/` of foreign repos MUST exclude them so their internal web links aren't
+    fetched/anchored. Defaults to the shared `DEFAULT_EXCLUDES`."""
+    from .frontmatter_index import iter_markdown_files, DEFAULT_EXCLUDES
     from .frontmatter_edit import read_text_keep_newlines
 
+    if excludes is None:
+        excludes = DEFAULT_EXCLUDES
     have_token = bool(token)
     cache: Dict[str, Tuple[int, Optional[str]]] = {}  # href -> (status, text)
     findings: List[WebFinding] = []
     edits: Dict[Path, str] = {}
 
-    for f in iter_markdown_files(root):
+    for f in iter_markdown_files(root, excludes):
         try:
             content = read_text_keep_newlines(f)
         except Exception:

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -219,3 +219,15 @@ def test_bad_flag_exits_1(tmp_path):
     with pytest.raises(SystemExit) as e:
         _run_web_check_cli([str(tmp_path), "--nonexistent"])
     assert e.value.code == 1
+
+
+def test_online_respects_excludes(tmp_path):
+    # a web link inside an --exclude'd directory (a vendored clone of a foreign repo) must not be
+    # fetched or anchored — otherwise web-check would inject uuids into someone else's checkout.
+    URL = "https://github.com/o/r/blob/main/dest.md"
+    (tmp_path / "clones" / "foreign").mkdir(parents=True)
+    (tmp_path / "clones" / "foreign" / "A.md").write_text(f"See [x]({URL})\n", encoding="utf-8")
+    fetch = _fetcher({URL: (200, "---\nuuid: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\n---\n")})
+    findings, edits = check_web_links_online(tmp_path, None, fetch, excludes={"clones"})
+    assert findings == []
+    assert edits == {}


### PR DESCRIPTION
## What

`web-check` scanned the whole tree with **no `--exclude`**, unlike every other command. In a repo that
vendors **clones of foreign repos** (`mirrors/<org>/github_*/clones/…`), that means web-check would
fetch — and with `--write` **anchor** — web links *inside* those clones, injecting `web-uuid` markers
into someone else's checkout. Adds `--exclude` (same dir-name-glob semantics as `repair`/`robustify`/
`check`), threaded to both the offline listing and `check_web_links_online`.

## Coverage

`test_online_respects_excludes` — a web link inside an `--exclude`'d `clones/` dir is neither fetched
nor anchored. Full suite: **146 passing**.

## Note (not in this PR)

On a real tree this surfaced a deeper limit for a *web gate*: links to a **private repo the token
can't read** come back **404**, which `_classify` maps to `web_not_found` (fails the gate) — but that's
indistinguishable, without a second call, from a file that genuinely moved in an *accessible* repo. A
follow-up could reclassify "repo itself inaccessible" as `web_unverifiable` (never fails), or add a
`--web-skip-owner`. Left out here to keep this focused and because it's a web-layer design call.