### PR TITLE
feat(web-check): 404 in an unreachable repo is web_unverifiable, not web_not_found

### DIFF
--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -147,7 +147,7 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
             # hide it) or a deleted branch. We can't tell "moved" from "no access", so we do NOT fail the
             # gate on it — a broken link in a repo we can't even see is not ours to assert.
             return WebFinding("web_unverifiable", f, link.href,
-                              "destination repo/ref not reachable (no access, or a deleted branch) — cannot verify")
+                              "destination repo/ref not reachable (no access, or the ref no longer exists) — cannot verify")
         return WebFinding("web_not_found", f, link.href,
                           "destination URL 404s; darnlink does not search where it moved (LLM layer's job)")
     if status != 200:

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -144,7 +144,7 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
     if status == 404:
         if not repo_reachable:
             # The repo root at this ref is unreachable too: a private repo we can't read (GitHub 404s to
-            # hide it) or a deleted branch. We can't tell "moved" from "no access", so we do NOT fail the
+            # hide it) or a ref that no longer exists. We can't tell "moved" from "no access", so we do NOT fail the
             # gate on it — a broken link in a repo we can't even see is not ours to assert.
             return WebFinding("web_unverifiable", f, link.href,
                               "destination repo/ref not reachable (no access, or the ref no longer exists) — cannot verify")
@@ -216,7 +216,7 @@ def check_web_links_online(
                 cache[link.href] = fetcher(gu, token)
             status, text = cache[link.href]
             # A 404 is ambiguous: the file moved in an ACCESSIBLE repo, or the repo/ref itself is not
-            # reachable (a private repo we can't read — GitHub 404s to hide it — or a deleted branch).
+            # reachable (a private repo we can't read — GitHub 404s to hide it — or a ref that no longer exists).
             # Probe the repo root at the same ref to tell them apart: if THAT is unreachable, we cannot
             # verify (so `web_unverifiable`, a warning), rather than assert the file moved (`web_not_found`).
             reachable = True

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -135,13 +135,19 @@ class WebFinding:
 
 
 def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Optional[str],
-              have_token: bool, f: Path) -> WebFinding:
+              have_token: bool, f: Path, repo_reachable: bool = True) -> WebFinding:
     if gu is None:
         return WebFinding("web_unverifiable", f, link.href, "not a recognised GitHub blob/raw URL")
     if status in (401, 403):
         why = "private repo and no GITHUB_TOKEN in env" if not have_token else "token rejected (403/401)"
         return WebFinding("web_unverifiable", f, link.href, f"cannot read destination: {why}")
     if status == 404:
+        if not repo_reachable:
+            # The repo root at this ref is unreachable too: a private repo we can't read (GitHub 404s to
+            # hide it) or a deleted branch. We can't tell "moved" from "no access", so we do NOT fail the
+            # gate on it — a broken link in a repo we can't even see is not ours to assert.
+            return WebFinding("web_unverifiable", f, link.href,
+                              "destination repo/ref not reachable (no access, or a deleted branch) — cannot verify")
         return WebFinding("web_not_found", f, link.href,
                           "destination URL 404s; darnlink does not search where it moved (LLM layer's job)")
     if status != 200:
@@ -185,6 +191,7 @@ def check_web_links_online(
         excludes = DEFAULT_EXCLUDES
     have_token = bool(token)
     cache: Dict[str, Tuple[int, Optional[str]]] = {}  # href -> (status, text)
+    repo_reachable: Dict[Tuple[str, str, str], bool] = {}  # (owner, repo, ref) -> root fetch was 200
     findings: List[WebFinding] = []
     edits: Dict[Path, str] = {}
 
@@ -208,8 +215,18 @@ def check_web_links_online(
             if link.href not in cache:
                 cache[link.href] = fetcher(gu, token)
             status, text = cache[link.href]
+            # A 404 is ambiguous: the file moved in an ACCESSIBLE repo, or the repo/ref itself is not
+            # reachable (a private repo we can't read — GitHub 404s to hide it — or a deleted branch).
+            # Probe the repo root at the same ref to tell them apart: if THAT is unreachable, we cannot
+            # verify (so `web_unverifiable`, a warning), rather than assert the file moved (`web_not_found`).
+            reachable = True
+            if status == 404:
+                key = (gu.owner, gu.repo, gu.ref)
+                if key not in repo_reachable:
+                    repo_reachable[key] = fetcher(GithubUrl(gu.owner, gu.repo, gu.ref, ""), token)[0] == 200
+                reachable = repo_reachable[key]
             dest_uuid = read_frontmatter_uuid(text)[1] if (status == 200 and text is not None) else None
-            fnd = _classify(link, gu, status, dest_uuid, have_token, f)
+            fnd = _classify(link, gu, status, dest_uuid, have_token, f, repo_reachable=reachable)
             findings.append(fnd)
             if fnd.kind == "web_anchor" and fnd.anchored_uuid:
                 pieces.append(content[cursor:link.start])

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -236,7 +236,7 @@ def test_online_respects_excludes(tmp_path):
 
 
 def test_online_404_in_unreachable_repo_is_unverifiable(tmp_path):
-    # a 404 whose repo root is ALSO unreachable (private repo we can't read, or a deleted branch) must
+    # a 404 whose repo root is ALSO unreachable (private repo we can't read, or a ref that no longer exists) must
     # be web_unverifiable (a warning), not web_not_found (which fails a gate) — a broken link in a repo
     # we can't even see is not ours to assert.
     URL = "https://github.com/o/r/blob/main/gone.md"

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -132,7 +132,9 @@ def test_online_dest_has_no_uuid_is_mismatch(tmp_path):
 
 def test_online_404_is_web_not_found_exits_4(tmp_path):
     _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
-    fetch = _fetcher({})  # every URL -> 404
+    # file 404s but the repo ROOT is reachable (200) -> the file genuinely moved in a repo we can see
+    # -> web_not_found (exit 4). (An unreachable repo would instead be web_unverifiable — separate test.)
+    fetch = _fetcher({"https://github.com/txemi/txnet1/blob/main/": (200, "[]")})
     findings, _ = check_web_links_online(tmp_path, None, fetch)
     assert findings[0].kind == "web_not_found"
     assert _run_web_check_cli([str(tmp_path), "--online"], fetcher=fetch) == 4
@@ -231,3 +233,24 @@ def test_online_respects_excludes(tmp_path):
     findings, edits = check_web_links_online(tmp_path, None, fetch, excludes={"clones"})
     assert findings == []
     assert edits == {}
+
+
+def test_online_404_in_unreachable_repo_is_unverifiable(tmp_path):
+    # a 404 whose repo root is ALSO unreachable (private repo we can't read, or a deleted branch) must
+    # be web_unverifiable (a warning), not web_not_found (which fails a gate) — a broken link in a repo
+    # we can't even see is not ours to assert.
+    URL = "https://github.com/o/r/blob/main/gone.md"
+    (tmp_path / "A.md").write_text(f"[x]({URL})\n", encoding="utf-8")
+    fetch = _fetcher({})  # everything (file AND repo root) 404
+    findings, _ = check_web_links_online(tmp_path, "tok", fetch)
+    assert [x.kind for x in findings] == ["web_unverifiable"]
+
+
+def test_online_404_in_reachable_repo_is_not_found(tmp_path):
+    # a 404 whose repo root IS reachable means the file genuinely moved in a repo we can see -> web_not_found
+    FILE = "https://github.com/o/r/blob/main/gone.md"
+    ROOT = "https://github.com/o/r/blob/main/"
+    (tmp_path / "A.md").write_text(f"[x]({FILE})\n", encoding="utf-8")
+    fetch = _fetcher({ROOT: (200, "[]")})  # file 404 (default), repo root 200
+    findings, _ = check_web_links_online(tmp_path, "tok", fetch)
+    assert [x.kind for x in findings] == ["web_not_found"]


### PR DESCRIPTION
## What

On a **404**, `web-check` couldn't distinguish two very different cases and reported both as
`web_not_found` (which **fails** a gate):
- the file genuinely **moved** in a repo we *can* see, vs.
- the **repo/ref itself is unreachable** — a private repo we can't read (GitHub returns 404 to hide
  its existence) or a **deleted branch**.

Now, on a 404, web-check probes the **repo root at the same ref** (cached per owner/repo/ref). If that
is also unreachable, the finding is **`web_unverifiable`** (a warning, never a failure) — *a broken
link in a repo we can't even see is not ours to assert*. A genuine move in a reachable repo stays
`web_not_found`.

## Why

It makes a **web gate usable** in a real repo that references **client/private repos it can't access**
(and links to deleted feature branches): those become `web_unverifiable` instead of failing the build,
while genuine breakage in repos we *can* read still fails. Measured on one such tree: 30 → 1
`web_not_found` (29 were inaccessible client repos).

## Coverage

Two new tests (unreachable-repo → unverifiable; reachable-repo-moved-file → not_found) and the existing
`test_online_404_is_web_not_found_exits_4` updated to make the repo root reachable. Full suite: **148 passing**.