### PR TITLE
feat(recipe): web pass forwards repo excludes to web-check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Changed
+- **Recipe `darnlink-gate`: the `web` pass now passes the repo's `excludes` to `web-check`** (not only
+  `ignore_blocks`). `web-check` gained `--exclude` in 0.12.0; without wiring it, turning `web` on in a repo
+  that vendors clones/mirrors made `web-check` fetch (and with `--write` anchor) web links *inside* someone
+  else's checkout. Now it skips them, exactly like the core does. Wired in the bash and PowerShell recipes.
+
 ## [0.12.0] — 2026-07-23
 
 ### Added

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -150,11 +150,14 @@ if [ "$SCOPE" != "staged" ]; then
     run check . "${DL_ARGS[@]}"; rc=$?
     if [ "$rc" -eq 0 ]; then run . "${MAX_ROBUSTIFY[@]}" "${DL_ARGS[@]}"; rc=$?; fi
     # WEB pass (opt-in, mode=max only): cross-repo web-link robustness, only if the core passed (so a
-    # core failure surfaces first). web-check has no --exclude (it only walks web hrefs) but takes
-    # --ignore-block. Fail-closed on a broken public web link; web_unverifiable (private w/o token, or
-    # offline) is exit 0. Needs a ref with the web-check subcommand (v0.9.0+) — the fleet pins >= that.
+    # core failure surfaces first). web-check takes the SAME `--exclude` and `--ignore-block` as the core
+    # (since 0.12.0) — pass both so it skips vendored clones / mirrors instead of fetching and anchoring
+    # web links INSIDE someone else's checkout. Fail-closed on a broken public web link; web_unverifiable
+    # (private w/o token, or offline) is exit 0. Needs a ref with web-check + its --exclude (v0.12.0+).
     if [ "$rc" -eq 0 ] && [ -n "$WEB" ]; then
-      WEB_ARGS=(); for b in "${IGNORE_BLOCKS[@]}"; do [ -n "$b" ] && WEB_ARGS+=(--ignore-block "$b"); done
+      WEB_ARGS=()
+      for e in "${EXCLUDES[@]}";      do [ -n "$e" ] && WEB_ARGS+=(--exclude "$e"); done
+      for b in "${IGNORE_BLOCKS[@]}"; do [ -n "$b" ] && WEB_ARGS+=(--ignore-block "$b"); done
       run web-check . --online "${WEB_ARGS[@]}"; rc=$?
       set -e
       # web-check's contract (all in 0..4, none of them "unreachable"): 0 = clean (a network/token

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -106,8 +106,8 @@ if ($scope -ne 'staged') {
     # WEB pass (opt-in, max only): EVERY web-check non-zero is fail-closed (0 = clean incl web_unverifiable/
     # offline; 3 = a plain web link not yet anchored — dry-run, could be robustified; 4 = broken public web
     # link) — none is the core's rc>3 "unreachable", so exit it directly, bypassing the bail below.
-    # web-check takes the SAME --exclude + --ignore-block as the core (since 0.12.0) -> se los pasamos para
-    # que no escanee clones vendados / mirrors.
+    # web-check takes the SAME --exclude + --ignore-block as the core (since 0.12.0) -> pass both so it
+    # skips vendored clones / mirrors instead of fetching+anchoring web links inside them.
     if ($rc -eq 0 -and $web) {
       $webArgs = @()
       foreach ($e in $excludes)     { if ($e) { $webArgs += @('--exclude', $e) } }

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -106,9 +106,12 @@ if ($scope -ne 'staged') {
     # WEB pass (opt-in, max only): EVERY web-check non-zero is fail-closed (0 = clean incl web_unverifiable/
     # offline; 3 = a plain web link not yet anchored — dry-run, could be robustified; 4 = broken public web
     # link) — none is the core's rc>3 "unreachable", so exit it directly, bypassing the bail below.
-    # web-check has no --exclude but takes --ignore-block.
+    # web-check takes the SAME --exclude + --ignore-block as the core (since 0.12.0) -> se los pasamos para
+    # que no escanee clones vendados / mirrors.
     if ($rc -eq 0 -and $web) {
-      $webArgs = @(); foreach ($b in $ignoreBlocks) { if ($b) { $webArgs += @('--ignore-block', $b) } }
+      $webArgs = @()
+      foreach ($e in $excludes)     { if ($e) { $webArgs += @('--exclude', $e) } }
+      foreach ($b in $ignoreBlocks) { if ($b) { $webArgs += @('--ignore-block', $b) } }
       & uvx --from $ref darnlink web-check . --online @webArgs
       exit $LASTEXITCODE
     }


### PR DESCRIPTION
## What
The `darnlink-gate` recipe's 3rd (`web`) pass now forwards to `web-check` the **same `--exclude`** list as the repo (previously only `--ignore-block`).

## Why
`web-check` gained `--exclude` in **0.12.0** (PR #23). Without wiring it through, turning `"web": true` on in a repo that vendors `clones/` or `mirrors/` made `web-check` **fetch (and, with `--write`, anchor) web links INSIDE somebody else's checkout**. Now it skips them just like the core does.

## Test (fixture)
| Case | Expected | Actual |
|---|---|---|
| new recipe (passes `--exclude clones`), broken web link inside `clones/` | 0 (skipped) | ✅ 0 |
| `web-check` WITHOUT `--exclude` on the same tree | 4 (sees it) | ✅ 4 |
| `web-check --exclude clones` | 0 | ✅ 0 |

Bash + PowerShell. After merge → release v0.13.0 → consumers pin it and turn `web` on without scanning vendored clones.

<sub>Translated from the original Spanish on 2026-08-11 — this repo is English-only on every surface, PR titles and descriptions included.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
