### PR TITLE
feat(recipe): web pass reads GITHUB_TOKEN from a PAT file when unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **Recipe `darnlink-gate`: the `web` pass reads `$GITHUB_TOKEN` from a read-only PAT file** when it is
+  not already in the environment (default `~/.config/github_token_ro`, override `DARNLINK_GATE_TOKEN_FILE`).
+  A git hook's environment usually lacks `GITHUB_TOKEN`, so without this, turning `web` on in a repo with
+  **private** cross-repo destinations would 404 them and read them as broken. Missing file → private
+  destinations stay `web_unverifiable` (non-fatal), exactly as before. Bash + PowerShell.
+
 ## [0.13.0] — 2026-07-23
 
 Recipe & docs only — **the CLI/package is byte-for-byte identical to 0.12.0**.

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -155,6 +155,14 @@ if [ "$SCOPE" != "staged" ]; then
     # web links INSIDE someone else's checkout. Fail-closed on a broken public web link; web_unverifiable
     # (private w/o token, or offline) is exit 0. Needs a ref with web-check + its --exclude (v0.12.0+).
     if [ "$rc" -eq 0 ] && [ -n "$WEB" ]; then
+      # web-check needs $GITHUB_TOKEN for PRIVATE destinations (public are tokenless). If it's not
+      # already exported, read it from a read-only PAT FILE (default ~/.config/github_token_ro; override
+      # with DARNLINK_GATE_TOKEN_FILE) — a git hook's env usually lacks it. Without a token a private
+      # destination 404s and reads as broken; with it, it verifies. Missing file → stays unverifiable.
+      if [ -z "${GITHUB_TOKEN:-}" ]; then
+        _tf="${DARNLINK_GATE_TOKEN_FILE:-$HOME/.config/github_token_ro}"
+        [ -r "$_tf" ] && { GITHUB_TOKEN="$(tr -d '\r\n' < "$_tf")"; export GITHUB_TOKEN; }
+      fi
       WEB_ARGS=()
       for e in "${EXCLUDES[@]}";      do [ -n "$e" ] && WEB_ARGS+=(--exclude "$e"); done
       for b in "${IGNORE_BLOCKS[@]}"; do [ -n "$b" ] && WEB_ARGS+=(--ignore-block "$b"); done

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -161,7 +161,8 @@ if [ "$SCOPE" != "staged" ]; then
       # destination 404s and reads as broken; with it, it verifies. Missing file → stays unverifiable.
       if [ -z "${GITHUB_TOKEN:-}" ]; then
         _tf="${DARNLINK_GATE_TOKEN_FILE:-$HOME/.config/github_token_ro}"
-        [ -r "$_tf" ] && { GITHUB_TOKEN="$(tr -d '\r\n' < "$_tf")"; export GITHUB_TOKEN; }
+        # -f: a REGULAR file (not a directory — `-r` alone passes on a dir, then `< dir` fails).
+        [ -f "$_tf" ] && [ -r "$_tf" ] && { GITHUB_TOKEN="$(tr -d '\r\n' < "$_tf")"; export GITHUB_TOKEN; }
       fi
       WEB_ARGS=()
       for e in "${EXCLUDES[@]}";      do [ -n "$e" ] && WEB_ARGS+=(--exclude "$e"); done

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -109,6 +109,12 @@ if ($scope -ne 'staged') {
     # web-check takes the SAME --exclude + --ignore-block as the core (since 0.12.0) -> pass both so it
     # skips vendored clones / mirrors instead of fetching+anchoring web links inside them.
     if ($rc -eq 0 -and $web) {
+      # web-check needs $GITHUB_TOKEN for PRIVATE destinations; if not already set, read it from a
+      # read-only PAT file (default ~/.config/github_token_ro; override DARNLINK_GATE_TOKEN_FILE).
+      if ([string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
+        $tf = if ($env:DARNLINK_GATE_TOKEN_FILE) { $env:DARNLINK_GATE_TOKEN_FILE } else { Join-Path $env:USERPROFILE ".config/github_token_ro" }
+        if (Test-Path $tf) { $env:GITHUB_TOKEN = (Get-Content $tf -Raw).Trim() }
+      }
       $webArgs = @()
       foreach ($e in $excludes)     { if ($e) { $webArgs += @('--exclude', $e) } }
       foreach ($b in $ignoreBlocks) { if ($b) { $webArgs += @('--ignore-block', $b) } }

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -113,7 +113,11 @@ if ($scope -ne 'staged') {
       # read-only PAT file (default ~/.config/github_token_ro; override DARNLINK_GATE_TOKEN_FILE).
       if ([string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
         $tf = if ($env:DARNLINK_GATE_TOKEN_FILE) { $env:DARNLINK_GATE_TOKEN_FILE } else { Join-Path $env:USERPROFILE ".config/github_token_ro" }
-        if (Test-Path $tf) { $env:GITHUB_TOKEN = (Get-Content $tf -Raw).Trim() }
+        # PathType Leaf = a file, not a dir. try/catch so a read error can't terminate the gate under
+        # $ErrorActionPreference='Stop' (missing token just leaves private destinations web_unverifiable).
+        if (Test-Path $tf -PathType Leaf) {
+          try { $env:GITHUB_TOKEN = (Get-Content $tf -Raw -ErrorAction Stop).Trim() } catch { }
+        }
       }
       $webArgs = @()
       foreach ($e in $excludes)     { if ($e) { $webArgs += @('--exclude', $e) } }


### PR DESCRIPTION
## What
The recipe's `web` pass reads `$GITHUB_TOKEN` from a read-only PAT file (default `~/.config/github_token_ro`, override `DARNLINK_GATE_TOKEN_FILE`) when it is not already in the environment.

## Why
A git hook's environment usually has no `GITHUB_TOKEN`, so turning `web` on in a repo with **private** cross-repo targets would report them as broken (404). With the file, the gate reads it by itself. File absent → private targets stay `web_unverifiable` (does not break), exactly as before.

## Test
Recipe with `GITHUB_TOKEN` unset → reads the file → web-check reads a private target → anchor pending (exit 3). Without the file → not-found. Bash + PowerShell.

<sub>Translated from the original Spanish on 2026-08-11 — this repo is English-only on every surface, PR titles and descriptions included.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
