### PR TITLE
fix(web-check): retry transient GitHub responses so web:true is gate-safe (v0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.15.0] — 2026-07-26
+
+First **code** change since 0.12.0 (0.13/0.14 were recipe-only).
+
+### Fixed
+- **`web-check --online`: transient GitHub responses no longer produce a false `web_not_found`.**
+  `default_fetcher` now RETRIES transient statuses with short backoff (0.5s → 1.0s → …, capped 4s,
+  3 attempts by default). The transient set includes **404** on purpose: the Contents API returns 404
+  under secondary-rate-limit and for a file requested right after its push (CDN not yet warm) — a false
+  break that would fail a **blocking** gate (pre-commit / pre-push) for a link that is actually fine.
+  429/5xx/network-error are the usual throttle/outage cases. A **genuinely** dead link still 404s on
+  every attempt, so it is reported exactly as before — retry removes only the flake, never hides a real
+  break. Tune with `DARNLINK_WEB_ATTEMPTS` (default 3; 1 disables retry). This makes `web: true` safe to
+  run in blocking local gates, not just CI/manual.
+
 ## [0.14.0] — 2026-07-23
 
 Recipe & docs only — **package byte-for-byte identical to 0.12.0**.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.14.0"
+version = "0.15.0"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -18,7 +18,9 @@ here. No new dependencies: `urllib` (stdlib). The fetcher is injected so tests n
 """
 from __future__ import annotations
 
+import os
 import re
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -104,10 +106,18 @@ def find_web_links(content: str, ignore: Sequence[Span] = ()) -> List[WebLink]:
 Fetcher = Callable[[GithubUrl, Optional[str]], Tuple[int, Optional[str]]]
 
 
-def default_fetcher(gu: GithubUrl, token: Optional[str]) -> Tuple[int, Optional[str]]:
-    """Fetch the single destination file via the GitHub Contents API (stdlib urllib). Sends the token
-    when present (needed for private repos, harmless/higher-rate for public). Never raises: maps HTTP
-    and network errors to a status code."""
+# Statuses that may be a TRANSIENT GitHub blip, not the destination's true state, so a retry can clear
+# them. Crucially this includes 404: the Contents API returns 404 under secondary-rate-limit and for a
+# file requested milliseconds after its push (CDN not yet warm) — a false `web_not_found` that would
+# fail a BLOCKING gate for a link that is actually fine. 429/5xx are the usual throttle/outage codes;
+# -1 is our network-error sentinel. A GENUINELY dead link stays 404 across every retry, so it is still
+# reported — retry only removes the flake, never hides a real break.
+_TRANSIENT_STATUSES = frozenset({404, 429, 500, 502, 503, 504, -1})
+
+
+def _fetch_once(gu: GithubUrl, token: Optional[str]) -> Tuple[int, Optional[str]]:
+    """One GitHub Contents API request (stdlib urllib). Sends the token when present (needed for private
+    repos, harmless/higher-rate for public). Never raises: maps HTTP and network errors to a status."""
     req = urllib.request.Request(gu.contents_api_url(), headers={
         "Accept": "application/vnd.github.raw",
         "User-Agent": "darnlink-web-check",
@@ -121,6 +131,27 @@ def default_fetcher(gu: GithubUrl, token: Optional[str]) -> Tuple[int, Optional[
         return (e.code, None)
     except (urllib.error.URLError, TimeoutError, OSError):
         return (-1, None)
+
+
+def default_fetcher(gu: GithubUrl, token: Optional[str], *,
+                    attempts: Optional[int] = None, sleep=time.sleep) -> Tuple[int, Optional[str]]:
+    """Fetch the destination file, RETRYING transient statuses with short backoff so a flaky GitHub
+    response (rate-limit 404, 5xx, network blip) doesn't produce a false `web_not_found` in a blocking
+    gate. A non-transient status (200/401/403, or a 404 that persists) returns immediately / after the
+    last try. `attempts` (default env DARNLINK_WEB_ATTEMPTS or 3) counts the FIRST try; `sleep` is
+    injectable so tests don't wait. Never raises."""
+    if attempts is None:
+        try:
+            attempts = max(1, int(os.environ.get("DARNLINK_WEB_ATTEMPTS", "3")))
+        except ValueError:
+            attempts = 3
+    status, text = _fetch_once(gu, token)
+    for i in range(1, attempts):
+        if status not in _TRANSIENT_STATUSES:
+            break
+        sleep(min(0.5 * (2 ** (i - 1)), 4.0))  # 0.5s, 1.0s, 2.0s, … capped at 4s
+        status, text = _fetch_once(gu, token)
+    return (status, text)
 
 
 # --- Findings (a view over the single-URL fetch; not a new core model) ---

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -231,3 +231,42 @@ def test_online_respects_excludes(tmp_path):
     findings, edits = check_web_links_online(tmp_path, None, fetch, excludes={"clones"})
     assert findings == []
     assert edits == {}
+
+
+# --- transient-retry in default_fetcher (v0.15.0): a flaky 404/5xx must not become web_not_found ---
+
+def test_default_fetcher_retries_transient_404_then_succeeds(monkeypatch):
+    """A transient 404 (rate-limit / CDN-cold-right-after-push) clears on retry -> final 200, no false
+    web_not_found. `sleep` is injected as a no-op so the test never waits."""
+    import darnlink.weblinks as wl
+    gu = wl.GithubUrl("o", "r", "main", "a.md")
+    seq = iter([(404, None), (200, "---\nuuid: x\n---\n")])
+    monkeypatch.setattr(wl, "_fetch_once", lambda g, t: next(seq))
+    status, text = wl.default_fetcher(gu, None, attempts=3, sleep=lambda _s: None)
+    assert status == 200 and text is not None
+
+
+def test_default_fetcher_persistent_404_stays_404(monkeypatch):
+    """A genuinely dead link 404s on EVERY attempt -> still reported 404 (retry hides no real break)."""
+    import darnlink.weblinks as wl
+    gu = wl.GithubUrl("o", "r", "main", "gone.md")
+    calls = {"n": 0}
+    def _once(g, t):
+        calls["n"] += 1
+        return (404, None)
+    monkeypatch.setattr(wl, "_fetch_once", _once)
+    status, _ = wl.default_fetcher(gu, None, attempts=3, sleep=lambda _s: None)
+    assert status == 404 and calls["n"] == 3  # exhausted all attempts
+
+
+def test_default_fetcher_no_retry_on_200(monkeypatch):
+    """A clean first response returns immediately — no wasted retries on the happy path."""
+    import darnlink.weblinks as wl
+    gu = wl.GithubUrl("o", "r", "main", "a.md")
+    calls = {"n": 0}
+    def _once(g, t):
+        calls["n"] += 1
+        return (200, "---\nuuid: x\n---\n")
+    monkeypatch.setattr(wl, "_fetch_once", _once)
+    status, _ = wl.default_fetcher(gu, None, attempts=3, sleep=lambda _s: None)
+    assert status == 200 and calls["n"] == 1


### PR DESCRIPTION
## What

`web-check --online` produced **false `web_not_found` (exit 4)** on transient GitHub blips, blocking local gates (pre-commit / pre-push) for links that are in fact fine. Observed live: on retry, clean.

`default_fetcher` now **retries transient states** (404 / 429 / 5xx / network error) with a short, bounded backoff (0.5s → 1.0s → 2.0s, capped at 4s; **3 attempts** by default, `DARNLINK_WEB_ATTEMPTS` to tune, 1 = no retry).

### Why 404 is included on purpose
The Contents API 404s under a secondary rate limit, and for a file requested right after its push (the CDN is still cold). A **genuinely dead** link 404s on **all 3 attempts** → it is reported exactly as before. **The retry removes the flake; it never hides a real break.**

This makes `web: true` **safe in blocking gates**, not only in CI or manual runs.

## Changes
- `default_fetcher` refactored: `_fetch_once` (single request) + a retry loop; `sleep` injectable, `attempts` configurable via env.
- `_TRANSIENT_STATUSES = {404, 429, 500, 502, 503, 504, -1}`.
- 3 new tests: transient 404 → 200, persistent 404 → still 404 (3 calls, nothing hidden), 200 → no retry.

## Verification
- `pytest` → **149 passed**.
- `max` self-gate (check + robustify) → clean.
- First **code** change since 0.12.0 (0.13/0.14 were recipe-only).

<sub>Translated from the original Spanish on 2026-08-11 — this repo is English-only on every surface, PR titles and descriptions included.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
