### PR TITLE
fix(web-check): 404 without a token is web_unverifiable, not web_not_found (v0.16.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.16.0] — 2026-07-26
+
+### Fixed
+- **`web-check --online`: a 404 without a token is now `web_unverifiable`, not `web_not_found`.**
+  GitHub returns **404** (not 403) for a **private** repo the caller can't see — indistinguishable from a
+  genuinely moved/deleted file. Classifying every 404 as a break made a **tokenless** run (a dev machine,
+  a CI job or a git hook without the PAT) **false-fail on every private cross-repo link** — the real-world
+  "false breaks" that blocked pushes across sessions. Now the 404 verdict is gated on token presence:
+  - **with a token** → `web_not_found` (a 404 is trustworthy → **fail-closed**, exit 4);
+  - **without a token** → `web_unverifiable` (ambiguous → **does not fail**, exit 0).
+  This is the "fail-closed **only when there is a token**" contract: a tokened gate (CI/Jenkins with a RO
+  PAT) catches real breaks; a tokenless clone never false-reds. Public-repo breaks are still caught by any
+  tokened surface. Pairs with the recipe reading `$GITHUB_TOKEN` from `~/.config/github_token_ro` (0.14.0).
+
 ## [0.15.0] — 2026-07-26
 
 First **code** change since 0.12.0 (0.13/0.14 were recipe-only).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.15.0"
+version = "0.16.0"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -170,7 +170,7 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
     if gu is None:
         return WebFinding("web_unverifiable", f, link.href, "not a recognised GitHub blob/raw URL")
     if status in (401, 403):
-        why = "private repo and no GITHUB_TOKEN in env" if not have_token else "token rejected (403/401)"
+        why = "private repo and no token provided" if not have_token else "token rejected (403/401)"
         return WebFinding("web_unverifiable", f, link.href, f"cannot read destination: {why}")
     if status == 404:
         if not have_token:

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -173,6 +173,16 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
         why = "private repo and no GITHUB_TOKEN in env" if not have_token else "token rejected (403/401)"
         return WebFinding("web_unverifiable", f, link.href, f"cannot read destination: {why}")
     if status == 404:
+        if not have_token:
+            # A 404 WITHOUT a token is ambiguous: GitHub returns 404 (not 403) for a PRIVATE repo we
+            # cannot see, exactly as it does for a genuinely moved/deleted file — the two are
+            # indistinguishable without credentials. So a tokenless run must NOT fail on it, or every
+            # dev machine / clone lacking the PAT would false-break on each private cross-repo link
+            # (the real-world "35 false breaks" that block pushes). Only a TOKENED read can call a 404
+            # a real break (below). This is the "fail-closed ONLY when there is a token" contract.
+            return WebFinding("web_unverifiable", f, link.href,
+                              "destination 404s but no token — ambiguous (could be a private repo we "
+                              "cannot see, not necessarily moved); a token is needed to call it broken")
         return WebFinding("web_not_found", f, link.href,
                           "destination URL 404s; darnlink does not search where it moved (LLM layer's job)")
     if status != 200:

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -130,12 +130,28 @@ def test_online_dest_has_no_uuid_is_mismatch(tmp_path):
 
 # --- failure cases: 404, private-no-token, unparseable, network error ---
 
-def test_online_404_is_web_not_found_exits_4(tmp_path):
+def test_online_404_WITH_token_is_web_not_found_exits_4(tmp_path, monkeypatch):
+    """WITH a token, a 404 is a real break: the token distinguishes 'moved/deleted' from
+    'private repo we cannot see', so a 404 can be trusted as broken -> fail-closed (exit 4)."""
     _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
     fetch = _fetcher({})  # every URL -> 404
-    findings, _ = check_web_links_online(tmp_path, None, fetch)
+    findings, _ = check_web_links_online(tmp_path, token="tok", fetcher=fetch)
     assert findings[0].kind == "web_not_found"
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
     assert _run_web_check_cli([str(tmp_path), "--online"], fetcher=fetch) == 4
+
+
+def test_online_404_WITHOUT_token_is_unverifiable_exits_0(tmp_path, monkeypatch):
+    """WITHOUT a token, a 404 is AMBIGUOUS — GitHub 404s a private repo we can't see exactly like a
+    genuinely moved file — so it must NOT fail the gate, or every tokenless clone false-reds on each
+    private cross-repo link (the real 'false breaks' that blocked pushes). -> web_unverifiable, exit 0."""
+    _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
+    fetch = _fetcher({})  # every URL -> 404
+    findings, _ = check_web_links_online(tmp_path, token=None, fetcher=fetch)
+    assert findings[0].kind == "web_unverifiable"
+    assert "no token" in findings[0].detail
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    assert _run_web_check_cli([str(tmp_path), "--online"], fetcher=fetch) == 0
 
 
 def test_online_private_no_token_is_unverifiable(tmp_path):

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -159,7 +159,7 @@ def test_online_private_no_token_is_unverifiable(tmp_path):
     fetch = _fetcher({URL: (403, None)})  # private repo, no token -> 403
     findings, _ = check_web_links_online(tmp_path, token=None, fetcher=fetch)
     assert findings[0].kind == "web_unverifiable"
-    assert "no GITHUB_TOKEN" in findings[0].detail
+    assert "no token provided" in findings[0].detail
     # unverifiable does not fail the exit (not a broken link, just unconfirmed)
     assert _run_web_check_cli([str(tmp_path), "--online"], fetcher=fetch) == 0
 


### PR DESCRIPTION
## Problem

`web-check --online` classified **every** 404 as `web_not_found` (a break → exit 4), regardless of token.
But GitHub returns **404** (not 403) for a **private** repo the caller can't see — indistinguishable from a
genuinely moved/deleted file. So a **tokenless** run (a dev machine, a CI job, or a git hook without the PAT)
**false-failed on every private cross-repo link**.

This is not hypothetical: it produced the real "35 false breaks" and **blocked pushes across parallel
sessions** (a whole-repo pre-push with `web:true` went red for everyone whenever the token wasn't in the
hook's environment).

## Fix — gate the 404 verdict on token presence

`_classify`:
- **with a token** → `web_not_found` (a 404 is trustworthy; the token distinguishes "moved" from "private,
  hidden") → **fail-closed**, exit 4.
- **without a token** → `web_unverifiable` (ambiguous) → **does not fail**, exit 0.

This is the **"fail-closed ONLY when there is a token"** contract: a tokened surface (CI/Jenkins with a RO
PAT, or a local run with `~/.config/github_token_ro`) catches real breaks; a tokenless clone never false-reds.

## Verified (empirically, on a real dead-branch private link)

`github.com/txemi/txconta/blob/feat/claude-toma-control/README.md` (deleted branch, private repo):
- **without token** → `web_unverifiable` → **exit 0** (was: false exit 4).
- **with token** → `web_not_found` → **exit 4** (real break tumbles the gate).

## Changes
- `_classify`: 404 branch split on `have_token`.
- Tests: replaced the old unconditional-404 test with two — WITH token → not_found/exit 4, WITHOUT token → unverifiable/exit 0.
- `pytest` → **150 passed**.

Pairs with the recipe reading `$GITHUB_TOKEN` from a RO PAT file (0.14.0) and the transient-retry fix (0.15.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)