### PR TITLE
fix(web-check): 404 in an inaccessible repo is web_unverifiable, not a break (v0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.17.0] — 2026-07-27
+
+### Fixed
+- **`web-check --online`: a 404 in a repo the token CANNOT access is now `web_unverifiable`, not
+  `web_not_found`.** With a token, 0.16.0 called every 404 a real break — but a link to a **private
+  cross-org repo** (e.g. a client org our read-only PAT has no access to) 404s because we cannot see it,
+  not because the file moved. Now, on a 404 with a token, `default_fetcher` does one extra probe — `GET
+  /repos/{owner}/{repo}` — and only calls the 404 a break if the destination **repo is readable**;
+  otherwise it returns the sentinel `-2` → `web_unverifiable`. The repo probe is cached per
+  `(owner, repo, token)` (a repo linked N times is checked once) and falls back to the plain
+  404-is-broken behaviour on a network blip. This lets `web: true` run on repos that link to
+  client/third-party orgs (project_map's ~1383 `mapfre-tech` links, etc.) without a wall of false breaks.
+  Pairs with the token-gated 404 (0.16.0) and the transient-retry (0.15.0).
+
+
 ## [0.16.0] — 2026-07-26
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.16.0"
+version = "0.17.0"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -151,8 +151,10 @@ def _repo_accessible(owner: str, repo: str, token: Optional[str]) -> bool:
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
             return resp.status == 200
-    except urllib.error.HTTPError:
-        return False  # 404/403 on the repo itself -> not readable with this token
+    except urllib.error.HTTPError as e:
+        if e.code in (403, 404):
+            return False  # genuinely not readable with this token (private cross-org repo)
+        return True       # 5xx/429/other: an outage/throttle, NOT inaccessible -> fall back to 404-is-broken
     except (urllib.error.URLError, TimeoutError, OSError):
         return True   # network blip: don't downgrade a persistent 404 to unverifiable on a transient error
 

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -24,6 +24,7 @@ import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -102,7 +103,8 @@ def find_web_links(content: str, ignore: Sequence[Span] = ()) -> List[WebLink]:
 # --- Fetch layer (network ONLY here; injected in tests) ---
 
 # A fetcher maps (GithubUrl, token) -> (http_status, text_or_None).
-# status: 200 ok · 404 not found · 401/403 auth-required · -1 network error · other = error.
+# status: 200 ok · 404 not found · 401/403 auth-required · -1 network error · -2 repo-not-readable
+# (v0.17.0: 404 whose destination repo the token cannot access -> unverifiable) · other = error.
 Fetcher = Callable[[GithubUrl, Optional[str]], Tuple[int, Optional[str]]]
 
 
@@ -133,13 +135,41 @@ def _fetch_once(gu: GithubUrl, token: Optional[str]) -> Tuple[int, Optional[str]
         return (-1, None)
 
 
+@lru_cache(maxsize=4096)
+def _repo_accessible(owner: str, repo: str, token: Optional[str]) -> bool:
+    """Is the destination REPO readable with this token? A GET on /repos/{owner}/{repo}: 200 = we can see
+    it (so a 404 on a FILE inside it is a REAL break), 404/403 = we can't (a private cross-org repo, e.g.
+    a client org our RO PAT has no access to) — there a file 404 is ambiguous, not a break. Cached per
+    (owner, repo, token) so a repo linked N times is probed once. On a network blip, returns True
+    (fall back to the plain 404=broken behaviour rather than hide a real break). Never raises."""
+    req = urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}", headers={
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "darnlink-web-check",
+    })
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return resp.status == 200
+    except urllib.error.HTTPError:
+        return False  # 404/403 on the repo itself -> not readable with this token
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return True   # network blip: don't downgrade a persistent 404 to unverifiable on a transient error
+
+
 def default_fetcher(gu: GithubUrl, token: Optional[str], *,
                     attempts: Optional[int] = None, sleep=time.sleep) -> Tuple[int, Optional[str]]:
     """Fetch the destination file, RETRYING transient statuses with short backoff so a flaky GitHub
     response (rate-limit 404, 5xx, network blip) doesn't produce a false `web_not_found` in a blocking
     gate. A non-transient status (200/401/403, or a 404 that persists) returns immediately / after the
     last try. `attempts` (default env DARNLINK_WEB_ATTEMPTS or 3) counts the FIRST try; `sleep` is
-    injectable so tests don't wait. Never raises."""
+    injectable so tests don't wait. Never raises.
+
+    A 404 WITH a token gets one more refinement (v0.17.0): if the destination REPO is not readable with
+    the token (a private cross-org repo — a client org our PAT can't see), the 404 is ambiguous, not a
+    real break, so it returns the sentinel `-2` (-> `web_unverifiable`). Only a 404 in a repo we CAN read
+    is called broken. This lets `web:true` run on repos that link to client/third-party orgs without a
+    wall of false breaks."""
     if attempts is None:
         try:
             attempts = max(1, int(os.environ.get("DARNLINK_WEB_ATTEMPTS", "3")))
@@ -151,6 +181,8 @@ def default_fetcher(gu: GithubUrl, token: Optional[str], *,
             break
         sleep(min(0.5 * (2 ** (i - 1)), 4.0))  # 0.5s, 1.0s, 2.0s, … capped at 4s
         status, text = _fetch_once(gu, token)
+    if status == 404 and token and not _repo_accessible(gu.owner, gu.repo, token):
+        return (-2, None)  # 404 in a repo we cannot read -> ambiguous, let _classify mark unverifiable
     return (status, text)
 
 
@@ -172,6 +204,13 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
     if status in (401, 403):
         why = "private repo and no token provided" if not have_token else "token rejected (403/401)"
         return WebFinding("web_unverifiable", f, link.href, f"cannot read destination: {why}")
+    if status == -2:
+        # v0.17.0: the file 404s AND the destination repo is not readable with this token (a private
+        # cross-org repo — a client org our PAT can't see). A 404 there is ambiguous (could be moved, or
+        # just invisible to us), so it is NOT a break. Lets web:true run on repos linking to client orgs.
+        return WebFinding("web_unverifiable", f, link.href,
+                          "destination repo not readable with this token (private cross-org repo?) — its "
+                          "404 is ambiguous, not necessarily moved")
     if status == 404:
         if not have_token:
             # A 404 WITHOUT a token is ambiguous: GitHub returns 404 (not 403) for a PRIVATE repo we

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -286,3 +286,43 @@ def test_default_fetcher_no_retry_on_200(monkeypatch):
     monkeypatch.setattr(wl, "_fetch_once", _once)
     status, _ = wl.default_fetcher(gu, None, attempts=3, sleep=lambda _s: None)
     assert status == 200 and calls["n"] == 1
+
+
+# --- v0.17.0: 404 in a repo we cannot read -> unverifiable, not a break (cross-org private repos) ---
+
+def test_classify_status_minus2_is_unverifiable():
+    """The -2 sentinel (404 whose destination repo is not readable with the token) classifies as
+    web_unverifiable — a private cross-org repo's 404 is ambiguous, not a break."""
+    from darnlink.weblinks import _classify, WebLink
+    from pathlib import Path
+    gu = GithubUrl("mapfre-tech", "some-repo", "main", "a.md")
+    link = WebLink(href="https://github.com/mapfre-tech/some-repo/blob/main/a.md", text="x",
+                   start=0, end=0, uuid="1111")
+    fnd = _classify(link, gu, -2, None, True, Path("f.md"))
+    assert fnd.kind == "web_unverifiable"
+    assert "not readable" in fnd.detail
+
+
+def test_default_fetcher_404_inaccessible_repo_returns_minus2(monkeypatch):
+    """WITH a token, a 404 whose repo is NOT accessible -> sentinel -2 (so _classify -> unverifiable).
+    A 404 whose repo IS accessible stays 404 (a real break)."""
+    import darnlink.weblinks as wl
+    wl._repo_accessible.cache_clear()
+    gu = wl.GithubUrl("otherorg", "priv", "main", "gone.md")
+    monkeypatch.setattr(wl, "_fetch_once", lambda g, t: (404, None))
+    monkeypatch.setattr(wl, "_repo_accessible", lambda o, r, t: False)  # repo not readable
+    assert wl.default_fetcher(gu, "tok", attempts=1, sleep=lambda _s: None) == (-2, None)
+    monkeypatch.setattr(wl, "_repo_accessible", lambda o, r, t: True)   # repo readable
+    assert wl.default_fetcher(gu, "tok", attempts=1, sleep=lambda _s: None) == (404, None)
+
+
+def test_default_fetcher_404_no_token_skips_repo_check(monkeypatch):
+    """WITHOUT a token, the repo-accessibility refinement is not attempted -> plain 404 (unverifiable
+    handling stays in _classify)."""
+    import darnlink.weblinks as wl
+    gu = wl.GithubUrl("o", "r", "main", "gone.md")
+    monkeypatch.setattr(wl, "_fetch_once", lambda g, t: (404, None))
+    called = {"n": 0}
+    monkeypatch.setattr(wl, "_repo_accessible", lambda o, r, t: called.__setitem__("n", called["n"]+1) or False)
+    assert wl.default_fetcher(gu, None, attempts=1, sleep=lambda _s: None) == (404, None)
+    assert called["n"] == 0  # no token -> no repo check


### PR DESCRIPTION
## Problem

0.16.0 made a 404 **with a token** a real break (`web_not_found`, exit 4). But a link to a **private
cross-org repo** — a client org our read-only PAT has no access to — 404s because we **cannot see it**,
not because the file moved. So `web: true` on any repo that links to client/third-party orgs produced a
wall of false breaks (project_map alone has ~**1383** `mapfre-tech` links).

## Fix

On a 404 **with a token**, `default_fetcher` does one extra probe — `GET /repos/{owner}/{repo}` — and:
- **repo readable (200)** → the file 404 is a real break → `web_not_found` (exit 4).
- **repo not readable (404/403)** → sentinel `-2` → `web_unverifiable` (does not fail).

The repo probe is **cached per `(owner, repo, token)`** (a repo linked N times is checked once) and
**falls back to plain 404-is-broken on a network blip** (never hides a real break on a transient error).

This lets `web: true` run on repos that link to client/third-party orgs without false breaks — the last
piece for "web on every repo where it makes sense."

## Verified
- `pytest` → **153 passed** (3 new: -2→unverifiable, fetcher returns -2 for inaccessible repo / 404 for accessible / skips probe with no token).
- Empirically: a link to `github.com/mapfre-tech/<private>` → `web_unverifiable` → exit 0 (was: false exit 4).

Pairs with the token-gated 404 (0.16.0) and the transient-retry (0.15.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)