### PR TITLE
release: 0.19.0 (recipe create_readme under mode=check + create_readme_excludes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.19.0] — 2026-07-30
+
 ### Changed
 - **`recipes/darnlink-gate`: the create-readme axis now works under `mode=check`/`repair` (not only
   `mode=max`), and gained a per-axis `create_readme_excludes` key — for repos with a big `mirrors/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.18.0"
+version = "0.19.0"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Release cut for 0.19.0. Stamps CHANGELOG + pyproject. Content = #30 (already merged): a recipe fit for repos with a large mirror tree. After merge, tag `v0.19.0` and move `v1`.

<sub>Translated from the original Spanish on 2026-08-11 — this repo is English-only on every surface, PR titles and descriptions included.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
