### PR TITLE
fix(web-check): summarise web_unverifiable instead of printing one line each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.19.1] — 2026-08-07
+
 ### Fixed
 - **`web-check`: the text report no longer prints one line per `web_unverifiable` finding.** It lists
   the first `UNVERIFIABLE_PREVIEW` (20) and then a `... and N more` line. `web_unverifiable` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **`web-check`: the text report no longer prints one line per `web_unverifiable` finding.** It lists
+  the first `UNVERIFIABLE_PREVIEW` (20) and then a `... and N more` line. `web_unverifiable` is
+  informational — it never fails the exit — so on a documentation repo whose Markdown holds a few
+  thousand ordinary external links (docs sites, videos, intranet URLs: anything that is not a GitHub
+  blob/raw URL) the old report emitted thousands of lines. Two consequences, both fixed: the
+  actionable `web_mismatch` / `web_not_found` lines were buried in the noise, and a caller reading
+  the output through a pipe could be flooded — in a `pre-push` git hook, whose stdio is a
+  non-blocking pipe, the run died with `BlockingIOError: write could not complete without blocking`,
+  so a phase that had found **nothing wrong** (`exit 0` when run standalone) blocked every push in
+  the repo until `--no-verify` was used. Nothing is silenced (Constitution II): the full total stays
+  in the summary line and `--json` still carries every finding. `web_mismatch`, `web_not_found` and
+  `web_anchor` are still listed in full — they are actionable and they do fail the exit. Tests in
+  `tests/test_weblinks.py`.
+
 ## [0.19.0] — 2026-07-30
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.19.0"
+version = "0.19.1"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -277,6 +277,13 @@ def _run_check_cli(argv: List[str]) -> int:
     return _run_check(root, excludes, args.json, tuple(args.ignore_block), only=only)
 
 
+#: How many `web_unverifiable` findings the text report lists individually. They are informational
+#: (they never fail the exit), so on a repo with thousands of non-GitHub URLs the full list buries the
+#: actionable findings and can overwhelm whatever is reading the output. The total always stays in the
+#: summary line (Constitution II — never silent) and `--json` still carries every finding.
+UNVERIFIABLE_PREVIEW = 20
+
+
 def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
     """Feature 013 (EXPERIMENTAL spike): `darnlink web-check PATH --online [--write] [--json]`.
 
@@ -391,8 +398,11 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
             print(f"  [web_not_found] {x.file}: {x.detail} ({x.href})")
         for x in anchors:
             print(f"  [web_anchor] {x.file}: {x.detail}")
-        for x in unverifiable:
+        for x in unverifiable[:UNVERIFIABLE_PREVIEW]:
             print(f"  [web_unverifiable] {x.file}: {x.detail} ({x.href})")
+        if len(unverifiable) > UNVERIFIABLE_PREVIEW:
+            print(f"  ... and {len(unverifiable) - UNVERIFIABLE_PREVIEW} more web_unverifiable "
+                  f"(informational; re-run with --json for the full list)")
         if args.write:
             print(f"  WROTE {wrote} file(s).")
         elif anchors_pending:

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -193,7 +193,7 @@ def test_many_unverifiable_are_summarised_not_listed_one_by_one(tmp_path, capsys
     The total stays in the summary line and --json keeps them all, so nothing is silenced."""
     n = UNVERIFIABLE_PREVIEW + 5
     for i in range(n):
-        _w(tmp_path / f"doc{i}.md", f"see [x](https://example.com/{i}) <!-- web-uuid: {UUID} -->\n")
+        _w(tmp_path / f"doc{i}.md", f"see [x](https://example.com/{i})\n")
 
     code = _run_web_check_cli([str(tmp_path), "--online"], fetcher=_fetcher({}))
     out = capsys.readouterr().out
@@ -207,7 +207,7 @@ def test_many_unverifiable_are_summarised_not_listed_one_by_one(tmp_path, capsys
 def test_json_still_carries_every_unverifiable(tmp_path, capsys):
     n = UNVERIFIABLE_PREVIEW + 5
     for i in range(n):
-        _w(tmp_path / f"doc{i}.md", f"see [x](https://example.com/{i}) <!-- web-uuid: {UUID} -->\n")
+        _w(tmp_path / f"doc{i}.md", f"see [x](https://example.com/{i})\n")
 
     _run_web_check_cli([str(tmp_path), "--online", "--json"], fetcher=_fetcher({}))
     out = json.loads(capsys.readouterr().out)

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from darnlink.cli import _run_web_check_cli, main
+from darnlink.cli import UNVERIFIABLE_PREVIEW, _run_web_check_cli, main
 from darnlink.weblinks import (GithubUrl, check_web_links_online, find_web_links,
                                parse_github_url)
 
@@ -185,6 +185,35 @@ def test_online_unparseable_url_is_unverifiable(tmp_path):
     _w(tmp_path / "conta.md", f"see [x](https://example.com/whatever) <!-- web-uuid: {UUID} -->\n")
     findings, _ = check_web_links_online(tmp_path, None, _fetcher({}))
     assert findings[0].kind == "web_unverifiable"
+
+
+def test_many_unverifiable_are_summarised_not_listed_one_by_one(tmp_path, capsys):
+    """web_unverifiable never fails the exit, so listing every one of them on a docs repo full of
+    ordinary external URLs drowns the actionable findings (and floods whoever reads the output).
+    The total stays in the summary line and --json keeps them all, so nothing is silenced."""
+    n = UNVERIFIABLE_PREVIEW + 5
+    for i in range(n):
+        _w(tmp_path / f"doc{i}.md", f"see [x](https://example.com/{i}) <!-- web-uuid: {UUID} -->\n")
+
+    code = _run_web_check_cli([str(tmp_path), "--online"], fetcher=_fetcher({}))
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert out.count("[web_unverifiable]") == UNVERIFIABLE_PREVIEW
+    assert f"... and {n - UNVERIFIABLE_PREVIEW} more web_unverifiable" in out
+    assert f"unverifiable {n}" in out  # the real total is never hidden
+
+
+def test_json_still_carries_every_unverifiable(tmp_path, capsys):
+    n = UNVERIFIABLE_PREVIEW + 5
+    for i in range(n):
+        _w(tmp_path / f"doc{i}.md", f"see [x](https://example.com/{i}) <!-- web-uuid: {UUID} -->\n")
+
+    _run_web_check_cli([str(tmp_path), "--online", "--json"], fetcher=_fetcher({}))
+    out = json.loads(capsys.readouterr().out)
+
+    assert out["web_unverifiable"] == n
+    assert len([f for f in out["findings"] if f["kind"] == "web_unverifiable"]) == n
 
 
 # --- OFF by default: no --online => no network, no writes, exit 0 ---


### PR DESCRIPTION
## What

`web-check`'s text report printed one line per `web_unverifiable` finding. It now lists
the first 20 and then `... and N more (informational; re-run with --json for the full list)`.

## Why

`web_unverifiable` is informational — it never fails the exit (only `web_mismatch` /
`web_not_found` do). But on a documentation repo whose Markdown holds a few thousand
ordinary external links (docs sites, videos, intranet URLs: anything that is not a GitHub
blob/raw URL), the old report emitted thousands of lines. Two consequences:

1. The actionable findings were buried in the noise.
2. Whoever read the output got flooded. In a `pre-push` git hook — whose stdio is a
   non-blocking pipe — the run died with
   `BlockingIOError: write could not complete without blocking`. So a phase that had found
   nothing wrong (`exit 0` when run standalone) blocked **every push in the repo** until
   `--no-verify` was used, which of course skips the rest of the wall too.

Observed on a repo with ~2200 such links: 2229 lines of output → 24, same `exit 0`.

## Not silenced (Constitution II)

The full count stays in the summary line, and `--json` still carries every finding.
`web_mismatch` / `web_not_found` / `web_anchor` are still listed in full.

## Tests

`tests/test_weblinks.py`: one test asserts the preview + `... and N more` + that the real
total stays visible; another asserts `--json` still returns all N findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
