### PR TITLE
docs(privacy): use fictitious org/repo names in specs, tests and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ All notable changes to darnlink are documented here. The format is based on
   otherwise it returns the sentinel `-2` → `web_unverifiable`. The repo probe is cached per
   `(owner, repo, token)` (a repo linked N times is checked once) and falls back to the plain
   404-is-broken behaviour on a network blip. This lets `web: true` run on repos that link to
-  client/third-party orgs (project_map's ~1383 `mapfre-tech` links, etc.) without a wall of false breaks.
+  client/third-party orgs (one consumer repo has ~1400 links into an org it cannot read) without a wall of false breaks.
   Pairs with the token-gated 404 (0.16.0) and the transient-retry (0.15.0).
 
 

--- a/specs/006-ignore-links-marker/spec.md
+++ b/specs/006-ignore-links-marker/spec.md
@@ -32,7 +32,7 @@ the moment it moves). There is no way to ask for that combination today.
 
 ## Evidence this gap is real (not hypothetical)
 
-A consumer repository (`project_map`, ~1500 uuids) hit exactly this and **could not adopt the
+A large consumer repository (~1500 uuids) hit exactly this and **could not adopt the
 marker**. Its generated files are heavily-linked targets, so `ignore-file` was not an option. It
 worked around it with an **external allowlist** consumed by its own gate — a list of globs the gate
 refuses to complain about (~675 exempt findings). The workaround is strictly worse than a marker:

--- a/specs/010-write-scope/spec.md
+++ b/specs/010-write-scope/spec.md
@@ -29,7 +29,7 @@ first is not a theoretical loss — it is the failure below.
 
 ## Evidence this gap is real (not hypothetical)
 
-The consumer repo `project_map` (~8.000 `.md`, ~15.000 Markdown links) runs a fail-closed pre-commit
+A large consumer repo (~8.000 `.md`, ~15.000 Markdown links) runs a fail-closed pre-commit
 gate: a commit is refused when a **staged** file carries a robustifiable plain link. Its advice to the
 contributor is `darnlink <your/path> --robustify --write`, and on 2026-07-21 that advice could not be
 followed:

--- a/specs/010-write-scope/spec.md
+++ b/specs/010-write-scope/spec.md
@@ -29,7 +29,7 @@ first is not a theoretical loss — it is the failure below.
 
 ## Evidence this gap is real (not hypothetical)
 
-A large consumer repo (~8.000 `.md`, ~15.000 Markdown links) runs a fail-closed pre-commit
+A large consumer repo (~8,000 `.md`, ~15,000 Markdown links) runs a fail-closed pre-commit
 gate: a commit is refused when a **staged** file carries a robustifiable plain link. Its advice to the
 contributor is `darnlink <your/path> --robustify --write`, and on 2026-07-21 that advice could not be
 followed:

--- a/specs/013-web-robustness/spec.md
+++ b/specs/013-web-robustness/spec.md
@@ -10,19 +10,19 @@ it costs the constitution. **Do not merge to `main`.**
 
 **Input**: Today darnlink only heals **local, relative** Markdown links (`is_local_md` rejects any
 `http(s)://`). A downstream setup (a Jenkins pipeline splitting living docs across **two repos**,
-`txnet1` and `txconta`) wires them together with **GitHub URLs**: a file in `txconta` links to a file
-in `txnet1` by its `https://github.com/txemi/txnet1/blob/main/…/jenkins_topologia.md` URL. When the
-target is renamed/moved inside `txnet1`, that URL 404s and darnlink cannot help — the target's `uuid`
+`handbook` and `ledger`) wires them together with **GitHub URLs**: a file in `ledger` links to a file
+in `handbook` by its `https://github.com/example-org/handbook/blob/main/…/service-topology.md` URL. When the
+target is renamed/moved inside `handbook`, that URL 404s and darnlink cannot help — the target's `uuid`
 lives in *another repository*, which darnlink, by design, never looks at. The ask: make those
 **cross-repo web links** robust too, anchored to the destination file's `uuid`.
 
 The motivating link (the real case the prototype exercises):
 
 ```
-Ver la [topología Jenkins](https://github.com/txemi/txnet1/blob/main/projects/software/homelab/docs_vivos/jenkins_topologia.md) <!-- web-uuid: 3f9c… -->
+Ver la [topología Jenkins](https://github.com/example-org/handbook/blob/main/docs/living/service-topology.md) <!-- web-uuid: 3f9c… -->
 ```
 
-lives in `txconta/.../jenkins_topologia.md` and points at `txnet1/.../docs_vivos/jenkins_topologia.md`.
+lives in `ledger/.../service-topology.md` and points at `handbook/.../living/service-topology.md`.
 
 ---
 

--- a/specs/013-web-robustness/spec.md
+++ b/specs/013-web-robustness/spec.md
@@ -19,7 +19,7 @@ lives in *another repository*, which darnlink, by design, never looks at. The as
 The motivating link (the real case the prototype exercises):
 
 ```
-Ver la [topología Jenkins](https://github.com/example-org/handbook/blob/main/docs/living/service-topology.md) <!-- web-uuid: 3f9c… -->
+See the [service topology](https://github.com/example-org/handbook/blob/main/docs/living/service-topology.md) <!-- web-uuid: 3f9c… -->
 ```
 
 lives in `ledger/.../service-topology.md` and points at `handbook/.../living/service-topology.md`.

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -2,7 +2,7 @@
 
 Network is never touched: every test injects a fake `fetcher` mapping a GithubUrl -> (status, text),
 so the fetch layer is exercised deterministically. Demonstrates the chosen design on the real case
-(txconta -> txnet1 by GitHub URL anchored to the destination's uuid): anchor a plain web link, verify
+(ledger -> handbook by GitHub URL anchored to the destination's uuid): anchor a plain web link, verify
 an anchored one, fail on mismatch/404, stay honest (web_unverifiable) on a private repo with no token,
 and never fire in the core / offline mode.
 """
@@ -18,7 +18,7 @@ from darnlink.weblinks import (GithubUrl, check_web_links_online, find_web_links
 
 UUID = "3f9c1a2b-4d5e-6f70-8192-a3b4c5d6e7f8"
 OTHER = "11111111-2222-3333-4444-555555555555"
-URL = "https://github.com/txemi/txnet1/blob/main/projects/software/homelab/docs_vivos/jenkins_topologia.md"
+URL = "https://github.com/example-org/handbook/blob/main/docs/living/service-topology.md"
 
 
 def _w(p: Path, text: str) -> None:
@@ -41,8 +41,8 @@ def _fetcher(responses):
 # --- pure URL parser (FR-007) ---
 
 def test_parse_github_blob_url():
-    assert parse_github_url("https://github.com/txemi/txnet1/blob/main/a/b/c.md") == \
-        GithubUrl("txemi", "txnet1", "main", "a/b/c.md")
+    assert parse_github_url("https://github.com/example-org/handbook/blob/main/a/b/c.md") == \
+        GithubUrl("example-org", "handbook", "main", "a/b/c.md")
 
 
 def test_parse_raw_and_www():
@@ -55,9 +55,9 @@ def test_parse_non_github_is_none():
 
 
 def test_contents_api_url():
-    gu = GithubUrl("txemi", "txnet1", "main", "docs/x.md")
+    gu = GithubUrl("example-org", "handbook", "main", "docs/x.md")
     assert gu.contents_api_url() == \
-        "https://api.github.com/repos/txemi/txnet1/contents/docs/x.md?ref=main"
+        "https://api.github.com/repos/example-org/handbook/contents/docs/x.md?ref=main"
 
 
 # --- link finder: robust vs plain web links, code fences ignored ---
@@ -324,8 +324,8 @@ def test_classify_status_minus2_is_unverifiable():
     web_unverifiable — a private cross-org repo's 404 is ambiguous, not a break."""
     from darnlink.weblinks import _classify, WebLink
     from pathlib import Path
-    gu = GithubUrl("mapfre-tech", "some-repo", "main", "a.md")
-    link = WebLink(href="https://github.com/mapfre-tech/some-repo/blob/main/a.md", text="x",
+    gu = GithubUrl("acme-tech", "some-repo", "main", "a.md")
+    link = WebLink(href="https://github.com/acme-tech/some-repo/blob/main/a.md", text="x",
                    start=0, end=0, uuid="1111")
     fnd = _classify(link, gu, -2, None, True, Path("f.md"))
     assert fnd.kind == "web_unverifiable"


### PR DESCRIPTION
Documentation and test fixtures referred to real private repositories and a real third-party organisation by name, plus one internal file path. Public repo, public history — none of it needs to be there, and the examples read exactly the same with placeholders.

## What changed

| File | Was | Now |
|---|---|---|
| `specs/013-web-robustness/spec.md` | two real private repo names + a real internal path | `example-org/handbook`, `ledger`, `docs/living/service-topology.md` |
| `tests/test_weblinks.py` | same names as URL fixtures, plus a real org in the unverifiable-repo test | `example-org/handbook`, `acme-tech` |
| `specs/006`, `specs/010` | "evidence this is real" paragraphs naming the consumer repo | reworded to "a large consumer repo"; the scale figures stay, since those carry the argument |
| `CHANGELOG.md` (0.17.0) | named the consumer repo and the third-party org | reworded generically |

The tests never touch the network (every one injects a fake fetcher), so the URLs are pure fixtures — swapping them changes nothing but the strings. **162 tests pass.**

## Note

This fixes the tree going forward. The names remain in the git history and in the sdists already on PyPI (which ship `specs/` and `tests/`); handling that is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)