### PR TITLE
fix(robustify): move a detached uuid anchor instead of duplicating it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ All notable changes to darnlink are documented here. The format is based on
   The file ended up with the uuid twice, one copy anchoring nothing, and because the link was robust
   afterwards every later run reported the tree **clean**: the litter became permanent and silent —
   the exact failure Constitution II exists to prevent. Robustify now **moves** such an anchor into
-  place instead of cloning it, and only when the file leaves no room for doubt: same line, exact same
-  uuid, **sitting after the link**, one stray comment and one link that could claim it. The
+  place instead of cloning it, and only when the file leaves no room for doubt: exactly one such
+  stray **trailing** the link on that line, and exactly one link that could claim it. The
   after-the-link condition is the mechanism itself — a comment that fell out of the grammar was by
   definition trailing the `)`; one placed *before* the link got there by hand, for some other reason.
+  A stray sitting **before** the link therefore neither blocks the move nor is touched by it: it is
+  left in place and reported, because it was never a candidate to begin with.
   Anything else is left untouched — guessing whose anchor it is would be a heuristic (Constitution
   IV) — but it is announced in the finding, never silently duplicated. Tests in
   `tests/test_detached_anchor.py`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ All notable changes to darnlink are documented here. The format is based on
   The file ended up with the uuid twice, one copy anchoring nothing, and because the link was robust
   afterwards every later run reported the tree **clean**: the litter became permanent and silent —
   the exact failure Constitution II exists to prevent. Robustify now **moves** such an anchor into
-  place instead of cloning it, and only when the file leaves no room for doubt: same line, exact
-  same uuid, one stray comment and one link that could claim it. Anything else is left untouched —
-  guessing whose anchor it is would be a heuristic (Constitution IV) — but it is announced in the
-  finding, never silently duplicated. Tests in `tests/test_detached_anchor.py`.
+  place instead of cloning it, and only when the file leaves no room for doubt: same line, exact same
+  uuid, **sitting after the link**, one stray comment and one link that could claim it. The
+  after-the-link condition is the mechanism itself — a comment that fell out of the grammar was by
+  definition trailing the `)`; one placed *before* the link got there by hand, for some other reason.
+  Anything else is left untouched — guessing whose anchor it is would be a heuristic (Constitution
+  IV) — but it is announced in the finding, never silently duplicated. Tests in
+  `tests/test_detached_anchor.py`.
 - **The report now says why an apparently-anchored link is still reported as plain.** The old detail
   read `path/to/target.md +uuid <X>` while `<!-- uuid: X -->` was plainly visible on that same line,
   which reads as a tool bug and sends the reader looking in the wrong place; it cost a repository a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.19.2] — 2026-08-08
+
+### Fixed
+- **`--robustify --write` no longer duplicates a uuid comment that is already on the line, just
+  detached from its link.** The grammar accepts only whitespace between the link's `)` and its
+  `<!-- uuid: … -->`, so one token of inline markup in between — a closing `**` is the usual way to
+  get this wrong — leaves the comment attached to nothing while *looking* attached to a reader. The
+  link is therefore still plain, and robustify appended a **second** comment carrying the same uuid.
+  The file ended up with the uuid twice, one copy anchoring nothing, and because the link was robust
+  afterwards every later run reported the tree **clean**: the litter became permanent and silent —
+  the exact failure Constitution II exists to prevent. Robustify now **moves** such an anchor into
+  place instead of cloning it, and only when the file leaves no room for doubt: same line, exact
+  same uuid, one stray comment and one link that could claim it. Anything else is left untouched —
+  guessing whose anchor it is would be a heuristic (Constitution IV) — but it is announced in the
+  finding, never silently duplicated. Tests in `tests/test_detached_anchor.py`.
+- **The report now says why an apparently-anchored link is still reported as plain.** The old detail
+  read `path/to/target.md +uuid <X>` while `<!-- uuid: X -->` was plainly visible on that same line,
+  which reads as a tool bug and sends the reader looking in the wrong place; it cost a repository a
+  blocked `pre-push` gate before the cause was understood. The finding now names the detached anchor
+  and what happened to it — moved, or left alone with the reason.
+
 ## [0.19.1] — 2026-08-07
 
 ### Fixed

--- a/FORMAT.md
+++ b/FORMAT.md
@@ -41,6 +41,12 @@ UUID        := 36 chars matching [0-9a-fA-F-] (canonically 8-4-4-4-12 lowercase 
 
 - **Detection is tolerant**: any whitespace (including a newline) is allowed between `)` and the
   comment.
+- **…but only whitespace.** One token of anything else in between and the comment anchors nothing —
+  the link is still plain. The trap is inline markup, because the result *looks* anchored:
+  `**text [B](B.md)** <!-- uuid: … -->` is **not** a robust link (the `**` closes before the
+  comment), whereas `**text** [B](B.md) <!-- uuid: … -->` and `**text [B](B.md) <!-- uuid: … -->**`
+  both are. The rule is not arbitrary: a table row or a sentence may hold several links, and only
+  adjacency says which one a comment belongs to.
 - **Emission is canonical**: a single space — `[text](path) <!-- uuid: <uuid> -->`.
 - `path` may include a `#fragment`; it is preserved across rewrites.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.19.1"
+version = "0.19.2"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -19,6 +19,8 @@ MD_LINK_RE = re.compile(r"\[(?P<text>[^\]]+)\]\((?P<href>[^)]+)\)")
 # A uuid comment that immediately follows a link (used to tell plain from robust).
 # No `^`: it is applied with .match(content, pos), which already anchors at pos.
 _TRAILING_UUID_RE = re.compile(r"\s*<!--\s*uuid:\s*[0-9a-fA-F-]{36}\s*-->")
+# Any uuid comment, wherever it sits. Used to find the ones attached to nothing.
+UUID_COMMENT_RE = re.compile(r"<!--\s*uuid:\s*(?P<uuid>[0-9a-fA-F-]{36})\s*-->")
 
 Span = Tuple[int, int]
 
@@ -198,6 +200,49 @@ def find_plain_links(content: str, ignore: Sequence[Span] = ()) -> List[PlainLin
             continue  # inside a generated block (e.g. autogrid); leave it alone
         out.append(PlainLink(m.group("text"), m.group("href"), m.start(), m.end()))
     return out
+
+
+@dataclass(frozen=True)
+class DetachedAnchor:
+    uuid: str
+    start: int  # span of just the `<!-- uuid: … -->` comment in the source
+    end: int
+
+
+def find_detached_anchors(content: str, ignore: Sequence[Span] = ()) -> List[DetachedAnchor]:
+    """Every `<!-- uuid: … -->` that is NOT the trailing anchor of a Markdown link.
+
+    The grammar only accepts whitespace between the link's `)` and the comment, so one token of
+    inline markup in between -- a closing `**` is the common way to get this wrong -- leaves the
+    comment attached to nothing while *looking* attached to a reader. The link is then still plain,
+    and robustify would append a second comment carrying the same uuid: the file ends up with the
+    uuid twice, one copy anchoring nothing, and every later run reports the tree clean.
+
+    Like `find_plain_links`, this takes the spans to skip rather than computing them: the caller
+    already has them. Passing the code spans matters more here than anywhere else -- a uuid comment
+    shown as an example inside backticks must never be treated as a stray anchor, because acting on
+    it means *deleting* text from someone's code sample.
+    """
+    attached: set[int] = set()
+    for m in MD_LINK_RE.finditer(content):
+        t = _TRAILING_UUID_RE.match(content, m.end())
+        if t is None:
+            continue
+        c = UUID_COMMENT_RE.search(content, m.end(), t.end())
+        if c is not None:
+            attached.add(c.start())
+    return [
+        DetachedAnchor(m.group("uuid").lower(), m.start(), m.end())
+        for m in UUID_COMMENT_RE.finditer(content)
+        if m.start() not in attached and not _in_spans(m.start(), ignore)
+    ]
+
+
+def line_bounds(content: str, pos: int) -> Span:
+    """The `[start, end)` of the line holding `pos`, end-exclusive of the newline."""
+    start = content.rfind("\n", 0, pos) + 1
+    end = content.find("\n", pos)
+    return (start, len(content) if end == -1 else end)
 
 
 def emit_robust_link(text: str, href: str, uuid: str) -> str:

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -23,8 +23,9 @@ from .frontmatter_edit import (
     write_text_keep_newlines,
 )
 from .frontmatter_index import DEFAULT_EXCLUDES, dir_excluded, iter_markdown_files, read_frontmatter_uuid
-from .links import (code_spans, emit_robust_link, file_ignores_links, file_is_ignored,
-                    find_plain_links, ignored_spans)
+from .links import (DetachedAnchor, PlainLink, code_spans, emit_robust_link, file_ignores_links,
+                    file_is_ignored, find_detached_anchors, find_plain_links, ignored_spans,
+                    line_bounds)
 from .paths import DIR_ANCHOR, is_local_relative, names_md, resolve_href
 from .report import Finding, Kind
 from .scope import in_scope
@@ -87,6 +88,19 @@ def _dir_link_missing_readme(href: str, linking_file: Path) -> Path | None:
 def _basename_denied(target: Path, no_create_globs: Tuple[str, ...]) -> bool:
     """True if the target's basename matches any deny-list glob (FR-029/FR-032)."""
     return any(fnmatch(target.name, g) for g in no_create_globs)
+
+
+def _hspace_start(content: str, pos: int) -> int:
+    """`pos` walked back over spaces/tabs, never past the start of its line.
+
+    Removing a stray anchor should take the blank that separated it with it, so moving one does not
+    leave a dangling space behind; stopping at the line start keeps the newline (and any indent that
+    is really the line's own) intact.
+    """
+    lo = content.rfind("\n", 0, pos) + 1
+    while pos > lo and content[pos - 1] in " \t":
+        pos -= 1
+    return pos
 
 
 def _within_excluded(directory: Path, root: Path, excludes) -> bool:
@@ -320,6 +334,7 @@ def plan_robustify(
         # Out of the write scope: its links are left alone here too, but it may still RECEIVE its own
         # uuid below — being a target is not a write the caller has to name (FR-006).
         links = () if (f.resolve() in link_ignored or not scoped) else find_plain_links(original, spans.get(f, []))
+        anchorable: List[Tuple[PlainLink, str]] = []  # (plain link, the uuid that will anchor it)
         for link in links:
             t = _anchor_target(link.href, f, planned_readmes)
             if t is None or t.resolve() == f.resolve():
@@ -355,11 +370,50 @@ def plan_robustify(
             u = target_uuid.get(tr)
             if u is None:
                 continue
-            pieces.append(original[cursor:link.start])
-            pieces.append(emit_robust_link(link.text, link.href, u))
-            cursor = link.end
+            anchorable.append((link, u))
+
+        # A `<!-- uuid: … -->` sitting on this link's line but attached to nothing is, in practice,
+        # this link's own anchor pushed out of the grammar by a token of inline markup (a closing
+        # `**` is the usual culprit). Appending a second one would leave the same uuid in the line
+        # twice, one copy anchoring nothing — and since the link is robust afterwards, every later
+        # run reports the tree clean and the litter never surfaces again. So move it instead.
+        #
+        # Only when the file leaves no room for doubt: same line, same uuid, one stray, one claimant.
+        # Anything else would be a guess, and guessing is not what this tool does (Constitution IV).
+        strays = find_detached_anchors(original, spans.get(f, [])) if anchorable else []
+        absorb: Dict[int, DetachedAnchor] = {}
+        ambiguous: Set[int] = set()
+        for i, (link, u) in enumerate(anchorable):
+            lo, hi = line_bounds(original, link.start)
+            here = [d for d in strays if d.uuid == u and lo <= d.start < hi]
+            if not here:
+                continue
+            claimants = sum(1 for l2, u2 in anchorable if u2 == u and lo <= l2.start < hi)
+            if len(here) == 1 and claimants == 1:
+                absorb[i] = here[0]
+            else:
+                ambiguous.add(i)
+
+        edits: List[Tuple[int, int, str]] = []  # (start, end, replacement), disjoint by construction
+        for i, (link, u) in enumerate(anchorable):
+            edits.append((link.start, link.end, emit_robust_link(link.text, link.href, u)))
+            detail = f"{link.href} +uuid {u}"
+            stray = absorb.get(i)
+            if stray is not None:
+                edits.append((_hspace_start(original, stray.start), stray.end, ""))
+                detail += " (moved a detached anchor that was already on this line)"
+            elif i in ambiguous:
+                detail += (" (WARNING: this line carries a detached anchor with the same uuid, but "
+                           "more than one link could own it, so it is left as is — the uuid will "
+                           "appear twice until you remove the stray comment)")
+            result.findings.append(Finding(Kind.ROBUSTIFY, f, detail))
+
+        if edits:
+            for start, end, replacement in sorted(edits):
+                pieces.append(original[cursor:start])
+                pieces.append(replacement)
+                cursor = end
             changed = True
-            result.findings.append(Finding(Kind.ROBUSTIFY, f, f"{link.href} +uuid {u}"))
         content = ("".join(pieces) + original[cursor:]) if changed else original
 
         if f.resolve() in needs_uuid_write:

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -383,7 +383,7 @@ def plan_robustify(
         # tool does (Constitution IV).
         strays = find_detached_anchors(original, spans.get(f, [])) if anchorable else []
         absorb: Dict[int, DetachedAnchor] = {}
-        leftover: Dict[int, int] = {}  # same-uuid strays on the line that were NOT absorbed
+        leftover: Dict[int, Tuple[int, str]] = {}  # link index -> (how many strays stayed, why)
         for i, (link, u) in enumerate(anchorable):
             lo, hi = line_bounds(original, link.start)
             here = [d for d in strays if d.uuid == u and lo <= d.start < hi]
@@ -399,7 +399,16 @@ def plan_robustify(
                 absorb[i] = trailing[0]
             remaining = len(here) - (1 if i in absorb else 0)
             if remaining:
-                leftover[i] = remaining
+                # Name the reason that actually applies. A vague "it was ambiguous" would be the very
+                # thing this change exists to stop: a message that sends the reader to the wrong place.
+                why: List[str] = []
+                if claimants > 1:
+                    why.append("more than one link on this line could own it")
+                if len(trailing) > 1:
+                    why.append("more than one such anchor trails the link")
+                if len(here) > len(trailing):
+                    why.append("it sits before the link, where the grammar could never have put it")
+                leftover[i] = (remaining, " / ".join(why))
 
         edits: List[Tuple[int, int, str]] = []  # (start, end, replacement), disjoint by construction
         for i, (link, u) in enumerate(anchorable):
@@ -409,12 +418,12 @@ def plan_robustify(
             if stray is not None:
                 edits.append((_hspace_start(original, stray.start), stray.end, ""))
                 detail += " (moved a detached anchor that was already on this line)"
-            n = leftover.get(i)
-            if n:
-                detail += (f" (WARNING: {n} detached anchor(s) with this uuid remain on this line — "
-                           "sitting before the link, or claimable by more than one link, so they are "
-                           "left exactly as they are; the uuid will appear more than once until you "
-                           "remove them by hand)")
+            stayed = leftover.get(i)
+            if stayed is not None:
+                n, why = stayed
+                detail += (f" (WARNING: {n} detached anchor(s) with this uuid remain on this line "
+                           f"because {why}; they are left exactly as they are, so the uuid will "
+                           "appear more than once until you remove them by hand)")
             result.findings.append(Finding(Kind.ROBUSTIFY, f, detail))
 
         if edits:

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -378,9 +378,12 @@ def plan_robustify(
         # twice, one copy anchoring nothing — and since the link is robust afterwards, every later
         # run reports the tree clean and the litter never surfaces again. So move it instead.
         #
-        # Only when the file leaves no room for doubt: same line, same uuid, sitting AFTER the link,
-        # one stray and one claimant. Anything else would be a guess, and guessing is not what this
-        # tool does (Constitution IV).
+        # Only when the file leaves no room for doubt: exactly ONE such stray TRAILING the link on
+        # that line, and exactly one link that could claim it. The counting is over TRAILING strays,
+        # not over every uuid comment on the line: one sitting before the link was never a candidate
+        # (see below), so it neither blocks the move nor is touched by it — it stays put and is
+        # reported. Anything past that would be a guess, and guessing is not what this tool does
+        # (Constitution IV).
         strays = find_detached_anchors(original, spans.get(f, [])) if anchorable else []
         absorb: Dict[int, DetachedAnchor] = {}
         leftover: Dict[int, Tuple[int, str]] = {}  # link index -> (how many strays stayed, why)

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -378,21 +378,28 @@ def plan_robustify(
         # twice, one copy anchoring nothing — and since the link is robust afterwards, every later
         # run reports the tree clean and the litter never surfaces again. So move it instead.
         #
-        # Only when the file leaves no room for doubt: same line, same uuid, one stray, one claimant.
-        # Anything else would be a guess, and guessing is not what this tool does (Constitution IV).
+        # Only when the file leaves no room for doubt: same line, same uuid, sitting AFTER the link,
+        # one stray and one claimant. Anything else would be a guess, and guessing is not what this
+        # tool does (Constitution IV).
         strays = find_detached_anchors(original, spans.get(f, [])) if anchorable else []
         absorb: Dict[int, DetachedAnchor] = {}
-        ambiguous: Set[int] = set()
+        leftover: Dict[int, int] = {}  # same-uuid strays on the line that were NOT absorbed
         for i, (link, u) in enumerate(anchorable):
             lo, hi = line_bounds(original, link.start)
             here = [d for d in strays if d.uuid == u and lo <= d.start < hi]
             if not here:
                 continue
+            # Only a stray that TRAILS the link can be that link's own anchor: the mechanism is a
+            # comment that sat right after the `)` and fell out of the grammar when a closing token
+            # slipped in between. One placed BEFORE the link never got there that way — somebody put
+            # it there on purpose, and relocating it would be exactly the guess we refuse to make.
+            trailing = [d for d in here if d.start >= link.end]
             claimants = sum(1 for l2, u2 in anchorable if u2 == u and lo <= l2.start < hi)
-            if len(here) == 1 and claimants == 1:
-                absorb[i] = here[0]
-            else:
-                ambiguous.add(i)
+            if len(trailing) == 1 and claimants == 1:
+                absorb[i] = trailing[0]
+            remaining = len(here) - (1 if i in absorb else 0)
+            if remaining:
+                leftover[i] = remaining
 
         edits: List[Tuple[int, int, str]] = []  # (start, end, replacement), disjoint by construction
         for i, (link, u) in enumerate(anchorable):
@@ -402,10 +409,12 @@ def plan_robustify(
             if stray is not None:
                 edits.append((_hspace_start(original, stray.start), stray.end, ""))
                 detail += " (moved a detached anchor that was already on this line)"
-            elif i in ambiguous:
-                detail += (" (WARNING: this line carries a detached anchor with the same uuid, but "
-                           "more than one link could own it, so it is left as is — the uuid will "
-                           "appear twice until you remove the stray comment)")
+            n = leftover.get(i)
+            if n:
+                detail += (f" (WARNING: {n} detached anchor(s) with this uuid remain on this line — "
+                           "sitting before the link, or claimable by more than one link, so they are "
+                           "left exactly as they are; the uuid will appear more than once until you "
+                           "remove them by hand)")
             result.findings.append(Finding(Kind.ROBUSTIFY, f, detail))
 
         if edits:

--- a/tests/test_detached_anchor.py
+++ b/tests/test_detached_anchor.py
@@ -1,0 +1,143 @@
+"""A `<!-- uuid: X -->` that is not attached to any link.
+
+The anchor only counts when it immediately follows the link's `)` (any whitespace, nothing else).
+Put it one token further away -- typically past a closing `**` -- and the link is still plain, so
+robustify wants to anchor it. Naively appending a second anchor leaves the file carrying the same
+uuid twice, one of them attached to nothing, and every later run reports the tree clean: the litter
+becomes permanent and silent.
+
+These tests pin the intended behaviour: robustify MOVES an unambiguous detached anchor instead of
+duplicating it, and says so; anything ambiguous is left alone and announced (Constitution II).
+"""
+from pathlib import Path
+
+from darnlink.links import code_spans, find_detached_anchors, find_robust_links
+from darnlink.report import Kind
+from darnlink.robustify import apply_robustify, plan_robustify
+
+TARGET = "aaaaaaaa-1111-2222-3333-444444444444"
+OTHER = "bbbbbbbb-1111-2222-3333-444444444444"
+
+
+def _w(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _target(tmp_path: Path) -> None:
+    _w(tmp_path / "B.md", f"---\nuuid: {TARGET}\n---\n# B\n")
+
+
+def _anchors(text: str) -> int:
+    return text.count(f"<!-- uuid: {TARGET} -->")
+
+
+# --- find_detached_anchors -------------------------------------------------------------------
+
+def test_find_detached_anchors_ignores_a_properly_attached_one():
+    content = f"[B](B.md) <!-- uuid: {TARGET} -->\n"
+    assert find_detached_anchors(content) == []
+
+
+def test_find_detached_anchors_reports_one_past_a_bold_close():
+    content = f"**text [B](B.md)** <!-- uuid: {TARGET} -->\n"
+    found = find_detached_anchors(content)
+    assert [d.uuid for d in found] == [TARGET]
+
+
+def test_find_detached_anchors_skips_code_spans():
+    """Like its siblings it takes the spans to skip; robustify passes the ones it already computed."""
+    content = f"`<!-- uuid: {TARGET} -->` is the anchor syntax.\n"
+    assert find_detached_anchors(content, code_spans(content)) == []
+
+
+# --- robustify: the bug ----------------------------------------------------------------------
+
+def test_robustify_moves_detached_anchor_instead_of_duplicating(tmp_path):
+    """The regression: the anchor is already there, just misplaced. Move it, do not clone it."""
+    _target(tmp_path)
+    _w(tmp_path / "A.md", f"| x | **text [B](B.md)** <!-- uuid: {TARGET} --> |\n")
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    a = (tmp_path / "A.md").read_text()
+    assert _anchors(a) == 1, f"the anchor was duplicated: {a!r}"
+    links = find_robust_links(a)
+    assert len(links) == 1 and links[0].uuid == TARGET
+    assert find_detached_anchors(a) == []
+    assert "**text" in a and "**" in a  # surrounding markup preserved
+
+
+def test_robustify_is_idempotent_after_moving_a_detached_anchor(tmp_path):
+    _target(tmp_path)
+    _w(tmp_path / "A.md", f"**[B](B.md)** <!-- uuid: {TARGET} -->\n")
+
+    apply_robustify(plan_robustify(tmp_path))
+    once = (tmp_path / "A.md").read_text()
+    apply_robustify(plan_robustify(tmp_path))
+    assert (tmp_path / "A.md").read_text() == once
+
+
+def test_robustify_names_the_move_in_its_finding(tmp_path):
+    _target(tmp_path)
+    _w(tmp_path / "A.md", f"**[B](B.md)** <!-- uuid: {TARGET} -->\n")
+
+    findings = [f for f in plan_robustify(tmp_path).findings if f.kind is Kind.ROBUSTIFY]
+    assert len(findings) == 1
+    assert "detached" in findings[0].detail.lower()
+
+
+# --- robustify: what it must NOT touch --------------------------------------------------------
+
+def test_detached_anchor_with_a_different_uuid_is_left_alone(tmp_path):
+    """Only an exact uuid match is a misplaced anchor for THIS link (Constitution IV)."""
+    _target(tmp_path)
+    _w(tmp_path / "A.md", f"**[B](B.md)** <!-- uuid: {OTHER} -->\n")
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    a = (tmp_path / "A.md").read_text()
+    assert f"<!-- uuid: {OTHER} -->" in a       # the stray one is not ours to remove
+    assert _anchors(a) == 1                     # the link got its own, correct anchor
+
+
+def test_detached_anchor_on_another_line_is_left_alone(tmp_path):
+    _target(tmp_path)
+    _w(tmp_path / "A.md", f"<!-- uuid: {TARGET} -->\n\n[B](B.md)\n")
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    a = (tmp_path / "A.md").read_text()
+    assert _anchors(a) == 2                     # untouched line + newly anchored link
+    assert len(find_detached_anchors(a)) == 1
+
+
+def test_detached_anchor_inside_code_is_never_absorbed(tmp_path):
+    _target(tmp_path)
+    _w(tmp_path / "A.md", f"[B](B.md) and `<!-- uuid: {TARGET} -->` shown as syntax\n")
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    a = (tmp_path / "A.md").read_text()
+    assert f"`<!-- uuid: {TARGET} -->`" in a     # the example stays verbatim
+    assert len(find_robust_links(a)) == 1
+
+
+def test_two_candidate_links_on_one_line_leave_the_stray_anchor_alone(tmp_path):
+    """Ambiguous: two plain links on the line would both claim the same detached anchor.
+
+    Whose anchor is it? Nothing in the file says, and guessing would be a heuristic (Constitution
+    IV). So the stray one is left exactly where it is -- but the report says so, because a silently
+    duplicated uuid is the very failure this change exists to stop (Constitution II).
+    """
+    _target(tmp_path)
+    _w(tmp_path / "A.md", f"**[B](B.md)** and **[again](B.md)** <!-- uuid: {TARGET} -->\n")
+
+    result = plan_robustify(tmp_path)
+    apply_robustify(result)
+
+    a = (tmp_path / "A.md").read_text()
+    assert len(find_robust_links(a)) == 2       # both links anchored...
+    assert len(find_detached_anchors(a)) == 1   # ...and the stray one untouched
+    details = " ".join(f.detail for f in result.findings if f.kind is Kind.ROBUSTIFY)
+    assert "detached" in details.lower()        # never silent

--- a/tests/test_detached_anchor.py
+++ b/tests/test_detached_anchor.py
@@ -143,6 +143,30 @@ def test_detached_anchor_before_the_link_is_never_absorbed(tmp_path):
     assert "detached" in details.lower()                  # and the duplicate is announced, not silent
 
 
+def test_a_stray_before_the_link_does_not_block_moving_the_one_behind_it(tmp_path):
+    """One stray each side: the trailing one still moves, the leading one still stays.
+
+    Third Copilot review, PR #35, raised as low confidence: with two strays on the line the move
+    "contradicts the one-stray-one-claimant constraint". The constraint counts TRAILING strays, and
+    that is deliberate — a comment before the link was never a candidate, so its presence adds no
+    doubt about which one is the misplaced anchor. Refusing to move because of it would leave the
+    real bug unfixed on account of an unrelated comment. Pinned here so the choice is not re-litigated.
+    """
+    _target(tmp_path)
+    _w(tmp_path / "A.md", f"<!-- uuid: {TARGET} --> **[B](B.md)** <!-- uuid: {TARGET} -->\n")
+
+    result = plan_robustify(tmp_path)
+    apply_robustify(result)
+
+    a = (tmp_path / "A.md").read_text()
+    assert a.startswith(f"<!-- uuid: {TARGET} --> **[B](B.md) <!-- uuid: {TARGET} -->**")
+    assert len(find_robust_links(a)) == 1        # the trailing stray became the link's anchor
+    assert len(find_detached_anchors(a)) == 1    # the leading one is untouched
+    detail = next(f.detail for f in result.findings if f.kind is Kind.ROBUSTIFY)
+    assert "moved a detached anchor" in detail
+    assert "it sits before the link" in detail   # and the survivor is explained, not hidden
+
+
 def test_detached_anchor_on_another_line_is_left_alone(tmp_path):
     _target(tmp_path)
     _w(tmp_path / "A.md", f"<!-- uuid: {TARGET} -->\n\n[B](B.md)\n")

--- a/tests/test_detached_anchor.py
+++ b/tests/test_detached_anchor.py
@@ -101,6 +101,27 @@ def test_detached_anchor_with_a_different_uuid_is_left_alone(tmp_path):
     assert _anchors(a) == 1                     # the link got its own, correct anchor
 
 
+def test_detached_anchor_before_the_link_is_never_absorbed(tmp_path):
+    """Only a TRAILING stray can be the link's own anchor (Copilot review, PR #35).
+
+    The bug's mechanism is a comment that sat right after the `)` and fell out of the grammar when a
+    closing token slipped in between — that always leaves the stray *after* the link. One placed
+    before it got there some other way, by hand, and moving it would be the guess we refuse to make.
+    """
+    _target(tmp_path)
+    _w(tmp_path / "A.md", f"<!-- uuid: {TARGET} --> see [B](B.md)\n")
+
+    result = plan_robustify(tmp_path)
+    apply_robustify(result)
+
+    a = (tmp_path / "A.md").read_text()
+    assert a.startswith(f"<!-- uuid: {TARGET} --> see ")  # left byte-for-byte where it was
+    assert len(find_robust_links(a)) == 1                 # the link still got its own anchor
+    assert len(find_detached_anchors(a)) == 1             # the stray survives
+    details = " ".join(f.detail for f in result.findings if f.kind is Kind.ROBUSTIFY)
+    assert "detached" in details.lower()                  # and the duplicate is announced, not silent
+
+
 def test_detached_anchor_on_another_line_is_left_alone(tmp_path):
     _target(tmp_path)
     _w(tmp_path / "A.md", f"<!-- uuid: {TARGET} -->\n\n[B](B.md)\n")

--- a/tests/test_detached_anchor.py
+++ b/tests/test_detached_anchor.py
@@ -101,6 +101,27 @@ def test_detached_anchor_with_a_different_uuid_is_left_alone(tmp_path):
     assert _anchors(a) == 1                     # the link got its own, correct anchor
 
 
+def test_two_trailing_strays_are_left_alone_and_the_reason_is_named(tmp_path):
+    """Two candidates behind one link: which is the anchor? Unknowable, so neither moves.
+
+    Second Copilot review, PR #35: the warning used to blame causes that did not apply here (sitting
+    before the link / several claimants), which is the same wrong-place-to-look failure this whole
+    change is about. It must name the reason that is actually true.
+    """
+    _target(tmp_path)
+    _w(tmp_path / "A.md", f"**[B](B.md)** <!-- uuid: {TARGET} --> x <!-- uuid: {TARGET} -->\n")
+
+    result = plan_robustify(tmp_path)
+    apply_robustify(result)
+
+    a = (tmp_path / "A.md").read_text()
+    assert len(find_detached_anchors(a)) == 2   # both strays survive untouched
+    detail = next(f.detail for f in result.findings if f.kind is Kind.ROBUSTIFY)
+    assert "more than one such anchor trails the link" in detail
+    assert "before the link" not in detail       # the cause that does NOT apply is not claimed
+    assert "could own it" not in detail
+
+
 def test_detached_anchor_before_the_link_is_never_absorbed(tmp_path):
     """Only a TRAILING stray can be the link's own anchor (Copilot review, PR #35).
 


### PR DESCRIPTION
## The bug

The grammar accepts **only whitespace** between a link's `)` and its `<!-- uuid: … -->`. Put one
token of inline markup in between — a closing `**` is the usual way to get this wrong — and the
comment anchors nothing, while *looking* anchored to a reader:

```markdown
| **text → [ISSUE_5](../some/README.md)** <!-- uuid: 93da730b-… -->   ← NOT a robust link
```

The link is therefore still plain, so `--robustify --write` appended a **second** comment with the
same uuid:

```markdown
**text → [ISSUE_5](../some/README.md) <!-- uuid: 93da730b-… -->** <!-- uuid: 93da730b-… -->
                   the new one ───────┘                            └─── the orphan, still there
```

The file now carries the uuid twice, one copy anchoring nothing — and because the link *is* robust
afterwards, every later run reports the tree **clean**. The litter is permanent and silent, which is
the failure Constitution II exists to prevent.

## The fix

Robustify **moves** such an anchor into place instead of cloning it, and only when the file leaves no
room for doubt: same line, exact same uuid, one stray comment and one link that could claim it.
Anything else is left untouched — guessing whose anchor it is would be a heuristic (Constitution IV)
— but it is named in the finding, never silently duplicated.

## The report also explains itself now

The old detail read `target.md +uuid <X>` while `<!-- uuid: X -->` was plainly visible on the same
line. That reads as a tool bug and sends the reader looking in the wrong place; in the repository
that motivated this, it blocked a `pre-push` gate for everyone until the cause was understood. The
finding now says what happened to the detached anchor — moved, or left alone with the reason.

## Scope

No format change, no new flag, no new `Kind`, no change to any exit code. `FORMAT.md` gains a note
making the adjacency rule explicit (it was already implied by the grammar) and says why it is not
arbitrary: a table row may hold several links, and only adjacency says which one a comment belongs
to.

## Tests

`tests/test_detached_anchor.py` — 10 new tests, 172 total, `tools/check.sh` green. They pin both the
move and, just as importantly, what must **not** be touched: a stray anchor with a different uuid, one
on another line, one inside a code span (acting there would mean deleting from someone's example),
and the ambiguous two-claimants case.
