### PR TITLE
feat(gate): make `dangling` gateable, opt-in, with an added-lines ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ All notable changes to darnlink are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- **The `dangling` axis is now gateable, opt-in, with an added-lines ratchet** (`recipes/darnlink-gate`).
+  `dangling` defaults to **`off`**, so upgrading the pin changes no verdict anywhere; `warn` lists
+  without failing; **`added-lines`** fails only on findings on lines the commit *adds* (`scope=staged`);
+  `repo` fails on any. Per-file gating was tried and rejected — touching one line of a README that
+  already carries old danglers would block the commit, which pushes people to `--no-verify`, and a gate
+  people bypass gates nothing. The added lines come from `git diff --cached -U0`: git lives in the
+  recipe, not in darnlink (spec 008, Option B).
+- **`Finding.line`** — optional, defaulted, set only by `dangling` today, and surfaced in
+  `check --json`. It exists because a *consumer* needs it as data: the ratchet intersects findings with
+  the lines a commit adds, and scraping that out of `detail` would couple the gate to prose.
+
+### Changed
+- **`check` no longer enumerates dangling findings in its text output** — it states the count on one
+  line and carries the details in `--json`. On the trees this axis lands on (thousands of dead links in
+  the repos it was measured on) one line each buried the findings that actually gate the build. The
+  count keeps it honest; the gate recipe prints them when its axis is switched on.
+
+### Known gaps
+- `darnlink-gate.ps1` ignores the `dangling` key, so a Windows-only gating surface does not enforce
+  this axis yet.
+
+
+### Added
 - **`dangling`: a plain link whose target does not exist is now reported** (feature 015). It was
   invisible before — not `unresolvable` (that is a *robust* link whose uuid died) and not
   `robustify` (there is nothing to anchor). `_anchor_target` returned `None` both for "the target is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,18 +18,7 @@ All notable changes to darnlink are documented here. The format is based on
   `check --json`. It exists because a *consumer* needs it as data: the ratchet intersects findings with
   the lines a commit adds, and scraping that out of `detail` would couple the gate to prose.
 
-### Changed
-- **`check` no longer enumerates dangling findings in its text output** — it states the count on one
-  line and carries the details in `--json`. On the trees this axis lands on (thousands of dead links in
-  the repos it was measured on) one line each buried the findings that actually gate the build. The
-  count keeps it honest; the gate recipe prints them when its axis is switched on.
 
-### Known gaps
-- `darnlink-gate.ps1` ignores the `dangling` key, so a Windows-only gating surface does not enforce
-  this axis yet.
-
-
-### Added
 - **`dangling`: a plain link whose target does not exist is now reported** (feature 015). It was
   invisible before — not `unresolvable` (that is a *robust* link whose uuid died) and not
   `robustify` (there is nothing to anchor). `_anchor_target` returned `None` both for "the target is
@@ -50,6 +39,16 @@ All notable changes to darnlink are documented here. The format is based on
   - Composes with everything that already silences a link: code spans and fences, `--ignore-block`
     regions, `darnlink-ignore-links` and `darnlink-ignore-file`. Percent-encoded paths are accepted
     in their decoded spelling, so `my%20file.md` next to `my file.md` is not a false alarm.
+
+### Changed
+- **`check` no longer enumerates dangling findings in its text output** — it states the count on one
+  line and carries the details in `--json`. On the trees this axis lands on (thousands of dead links in
+  the repos it was measured on) one line each buried the findings that actually gate the build. The
+  count keeps it honest; the gate recipe prints them when its axis is switched on.
+
+### Known gaps
+- `darnlink-gate.ps1` ignores the `dangling` key, so a Windows-only gating surface does not enforce
+  this axis yet.
 
 ## [0.19.2] — 2026-08-08
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -25,6 +25,28 @@ is that orchestration in one place; a consumer carries only a tiny config + a 3-
     passes (a true superset of `check` — it can't silently drop broken robust links).
     **Whole-repo only** — the staged pre-commit stays at strict on purpose (fast); the whole-repo wall
     (pre-push / CI) is where `max` is enforced. See [`docs/elevating-your-link-gate.md`](../docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 -->.
+- `dangling` (opt-in, **default `off`**) → gate on links whose target does not exist (feature 015).
+  A **separate axis, never folded into `mode`**, and that is the point: every consumer already carries
+  years of these, so folding them into `check`/`max` would turn each gate red on upgrade and the only
+  escape would be *lowering* `mode` — a ladder you can only climb by first stepping down is not a
+  ladder. Four settings:
+
+  | `dangling` | Behaviour |
+  |---|---|
+  | `off` *(default)* | not gated, not listed. Upgrading the pin changes no verdict. `check` still states the **count** on one line, so a repo learns it has dead links. |
+  | `warn` | listed, never fails. The honest way to see the backlog before gating it. |
+  | `added-lines` | fails only on findings on lines **this commit adds** (`scope=staged`). The adoption rung. |
+  | `repo` | fails on **any** finding. The wall, for a repo already at zero. |
+
+  **Why `added-lines` and not per-file:** per-file was tried and is not enough — editing one line of a
+  README that already carries old danglers blocks the commit, which pushes people to `--no-verify`,
+  and a gate people bypass gates nothing. The added lines come from `git diff --cached -U0`; git lives
+  here, not in darnlink (spec 008, Option B).
+
+  ⚠️ **Not yet in `darnlink-gate.ps1`.** The Windows recipe ignores the `dangling` key, so a
+  Windows-only surface silently does not gate this axis. Being explicit rather than letting the
+  difference be discovered: on a repo that gates on both, POSIX gates it and Windows does not.
+
 - `scope=repo` → judge the whole tree (**the wall — use in pre-push & CI**).
   `scope=staged` → judge only the files you're committing (**multi-session pre-commit**, so a
   teammate's in-flight plain link doesn't block your commit). It filters `darnlink check --json` by

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -106,6 +106,26 @@ case "${WEB,,}" in ""|0|false|no|off) WEB="" ;; *) WEB=1 ;; esac
 # Robustify it by hand with `--create-readme --write`. Raises the max ceiling from "files" to "folders".
 CREATE_README="${DARNLINK_GATE_CREATE_README:-$(read_cfg create_readme "")}"
 case "${CREATE_README,,}" in ""|0|false|no|off) CREATE_README="" ;; *) CREATE_README=1 ;; esac
+# DANGLING (opt-in, default off): links whose target does not exist (darnlink feature 015). It is a
+# SEPARATE axis, never folded into MODE, and that is the whole point — every consumer already carries
+# years of these (measured: thousands across a nine-repo fleet), so folding it into check/max would
+# turn each gate red on upgrade and the only escape would be LOWERING mode. A ladder that can only be
+# climbed by first stepping down is not a ladder. Four settings:
+#   off          (default) not gated, not printed — upgrading the pin changes nothing;
+#   warn         printed, never fails: the honest way to see your backlog before gating it;
+#   added-lines  fails only on findings on lines THIS COMMIT ADDS (scope=staged). The adoption rung:
+#                old debt never blocks you, new debt cannot enter. Per-FILE would not do — touching
+#                one line of a README that carries old danglers would block the commit, and a gate
+#                people bypass gates nothing;
+#   repo         fails on ANY finding. The wall, for a repo already at zero.
+DANGLING="${DARNLINK_GATE_DANGLING:-$(read_cfg dangling off)}"
+case "${DANGLING,,}" in
+  off|""|0|false|no) DANGLING=off ;;
+  warn) DANGLING=warn ;;
+  added-lines|added_lines) DANGLING=added-lines ;;
+  repo|all|on|1|true|yes) DANGLING=repo ;;
+  *) echo "darnlink-gate: unknown dangling=$DANGLING (use off|warn|added-lines|repo) — treating as off." >&2; DANGLING=off ;;
+esac
 mapfile -t EXCLUDES < <(read_cfg excludes "")
 mapfile -t IGNORE_BLOCKS < <(read_cfg ignore_blocks "")
 # CREATE_README_EXCLUDES: extra directory globs that apply ONLY to the create-readme pass (see the
@@ -157,6 +177,31 @@ if ! run --help >/dev/null 2>&1; then bail "can't run darnlink at $REF (bad ref 
 # not evaluate); the offending files go to stderr for the human. `--create-readme` implies
 # `--create-frontmatter`, so the JSON also carries `robustify` findings — we deliberately keep only
 # `create_readme`, which is what keeps the mirror's dir-links from flooding in as robustify offenders.
+# Dangling axis (015). Prints one line per finding on stdout as `file<TAB>line<TAB>detail`, or the
+# single token ERR if it could not be evaluated — same contract as create_readme_offenders, so the
+# caller can apply the never-turn-a-red-gate-green rule.
+dangling_findings() {
+  command -v python3 >/dev/null 2>&1 || { echo ERR; return 0; }
+  local json jrc tmp
+  set +e
+  json="$(run check . --json "${DL_ARGS[@]}" 2>/dev/null)"; jrc=$?
+  set -e
+  if [ "$jrc" -gt 3 ] || [ -z "$json" ]; then echo ERR; return 0; fi
+  # Temp file, not env/argv: a whole-repo dump on a large consumer runs to megabytes (see above).
+  tmp="$(mktemp)"; printf '%s' "$json" > "$tmp"
+  python3 - "$tmp" <<'PY'
+import json, sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception:
+    print("ERR"); sys.exit(0)
+for f in data.get("dangling", {}).get("findings", []):
+    print(f"{f.get('file','')}\t{f.get('line') or ''}\t{f.get('detail','')}")
+PY
+  rm -f "$tmp"
+}
+
 create_readme_offenders() {
   command -v python3 >/dev/null 2>&1 || { echo ERR; return 0; }
   local cr_args=("${DL_ARGS[@]}") e
@@ -270,6 +315,30 @@ if [ "$SCOPE" != "staged" ]; then
       [ "$rc" -eq 0 ] && rc=1
     fi
   fi
+  # Dangling axis, whole-repo. `added-lines` has no meaning without a staged diff, so here it reads as
+  # `warn`: the ratchet belongs to the pre-commit surface, and the wall must not invent a scope.
+  if [ "$DANGLING" != off ]; then
+    dl_out="$(dangling_findings)"
+    if [ "$dl_out" = "ERR" ]; then
+      if [ "$rc" -ne 0 ]; then
+        echo "darnlink-gate: dangling axis could not run, but the core gate is already failing (rc=$rc) — keeping it." >&2
+        exit "$rc"
+      fi
+      bail "dangling pass could not run (darnlink unreachable or python3 missing)"
+    fi
+    dl_n=0; [ -n "$dl_out" ] && dl_n="$(printf '%s\n' "$dl_out" | grep -c . || true)"
+    if [ "$dl_n" -gt 0 ]; then
+      printf '%s\n' "$dl_out" | while IFS=$'\t' read -r df dline ddet; do
+        echo "  [dangling] $df: $ddet" >&2
+      done
+      if [ "$DANGLING" = repo ]; then
+        echo "darnlink-gate: $dl_n link(s) point at a path that does not exist (dangling axis)." >&2
+        [ "$rc" -eq 0 ] && rc=1
+      else
+        echo "darnlink-gate: $dl_n dangling link(s) — informational (dangling=$DANGLING; does not fail the gate)." >&2
+      fi
+    fi
+  fi
   exit "$rc"
 fi
 
@@ -293,8 +362,21 @@ set -e
 if [ "$rc" -gt 3 ] || [ -z "$DL_JSON" ]; then
   bail "(staged) darnlink unreachable (rc=$rc)"
 fi
-export DL_JSON DL_ROOT="$root" DL_REF="$REF" DL_MODE="$MODE"
+export DL_JSON DL_ROOT="$root" DL_REF="$REF" DL_MODE="$MODE" DL_DANGLING="$DANGLING"
 export DL_STAGED="$(printf '%s\n' "${STAGED[@]}")"
+# The added-lines ratchet needs the LINES this commit adds, and git lives here, not in darnlink
+# (spec 008, Option B). `-U0` gives hunks with no context, so every `+` line in the header range is
+# genuinely new. Collected per staged file as `path:start,count`.
+if [ "$DANGLING" = added-lines ]; then
+  DL_ADDED=""
+  for p in "${STAGED[@]}"; do
+    [ -n "$p" ] || continue
+    hunks="$(git diff --cached -U0 -- "$p" 2>/dev/null | sed -n 's/^@@ -[^ ]* +\([0-9]*\)\(,\([0-9]*\)\)\{0,1\} @@.*/\1,\3/p' || true)"
+    [ -n "$hunks" ] && DL_ADDED="$DL_ADDED$(printf '%s' "$hunks" | sed "s#^#$p:#")
+"
+  done
+  export DL_ADDED
+fi
 
 # Pass everything via env (no interpolation into the script → no injection from finding text).
 python3 <<'PY'
@@ -308,10 +390,48 @@ def hits(axis):
     return [f for f in data.get(axis, {}).get("findings", []) if os.path.realpath(f["file"]) in staged]
 integ = hits("integrity")
 strict = [] if mode == "repair" else hits("strict")   # mode=repair gates on integrity only
+
+# --- dangling axis (015) ---------------------------------------------------------------------
+# `added-lines` is the rung that makes this adoptable: judge only the lines the commit ADDS, so
+# years of existing debt never block anyone and nothing new gets in. Per-FILE was tried and is not
+# enough — editing one line of a README that already carries old danglers would block the commit,
+# and a gate people bypass gates nothing.
+dangling_mode = os.environ.get("DL_DANGLING", "off")
+dangling = []
+if dangling_mode != "off":
+    found = hits("dangling")
+    if dangling_mode == "added-lines":
+        added = {}   # realpath -> set of added line numbers
+        for row in os.environ.get("DL_ADDED", "").split("\n"):
+            if not row.strip():
+                continue
+            path, _, span = row.rpartition(":")
+            start, _, count = span.partition(",")
+            try:
+                start_i = int(start)
+            except ValueError:
+                continue
+            # `+N @@` with no count means exactly one line; `+N,0` is a pure deletion (adds nothing).
+            count_i = 1 if count == "" else int(count)
+            key = os.path.realpath(os.path.join(root, path))
+            added.setdefault(key, set()).update(range(start_i, start_i + count_i))
+        dangling = [f for f in found
+                    if f.get("line") in added.get(os.path.realpath(f["file"]), ())]
+    else:
+        dangling = found
+
 for f in integ:  print(f"  [integrity/{f['kind']}] {f['file']}: {f['detail']}")
 for f in strict: print(f"  [strict/{f['kind']}] {f['file']}: {f['detail']}")
+for f in dangling: print(f"  [dangling] {f['file']}: {f['detail']}")
+
 if integ:  print("darnlink-gate (staged): integrity failure in a file you're committing."); sys.exit(2)
 if strict: print("darnlink-gate (staged): un-anchored plain link in a file you're committing "
                  f"(anchor it: uvx --from {os.environ['DL_REF']} darnlink . --robustify --write)."); sys.exit(3)
+if dangling and dangling_mode != "warn":
+    print(f"darnlink-gate (staged): {len(dangling)} link(s) you are adding point at a path that does "
+          "not exist. Fix the path, or drop the link if the target is gone.")
+    sys.exit(1)
+if dangling:
+    print(f"darnlink-gate (staged): {len(dangling)} dangling link(s) — informational (dangling=warn).")
 print("darnlink-gate (staged): clean."); sys.exit(0)
 PY

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -189,7 +189,12 @@ dangling_findings() {
   if [ "$jrc" -gt 3 ] || [ -z "$json" ]; then echo ERR; return 0; fi
   # Temp file, not env/argv: a whole-repo dump on a large consumer runs to megabytes (see above).
   tmp="$(mktemp)"; printf '%s' "$json" > "$tmp"
-  python3 - "$tmp" <<'PY'
+  # Capture, THEN clean up, THEN speak. Cleaning up only after a successful run leaks the file on any
+  # python failure, because `set -e` leaves the function before the `rm` (a gate that runs on every
+  # commit leaks once per commit).
+  local out prc
+  set +e
+  out="$(python3 - "$tmp" <<'PY'
 import json, sys
 try:
     with open(sys.argv[1], encoding="utf-8") as fh:
@@ -199,7 +204,11 @@ except Exception:
 for f in data.get("dangling", {}).get("findings", []):
     print(f"{f.get('file','')}\t{f.get('line') or ''}\t{f.get('detail','')}")
 PY
+)"; prc=$?
+  set -e
   rm -f "$tmp"
+  [ "$prc" -ne 0 ] && { echo ERR; return 0; }
+  printf '%s\n' "$out"
 }
 
 create_readme_offenders() {
@@ -221,7 +230,12 @@ create_readme_offenders() {
   # ignore-links finding too and can run to megabytes, well past ARG_MAX (a big mirror is exactly the case
   # this feature exists for). The path is short; python reads the file.
   tmp="$(mktemp)"; printf '%s' "$json" > "$tmp"
-  python3 - "$tmp" <<'PY'
+  # Same capture-then-clean-then-speak order as dangling_findings(): cleaning up only on the success
+  # path leaks the temp file whenever python fails, because `set -e` leaves before the `rm`.
+  # (stderr is NOT captured — the per-offender lines are meant to reach the user as they are printed.)
+  local out prc
+  set +e
+  out="$(python3 - "$tmp" <<'PY'
 import json, sys
 try:
     with open(sys.argv[1], encoding="utf-8") as fh:
@@ -233,7 +247,11 @@ for f in off:
     sys.stderr.write(f"  [create-readme] {f.get('file')}: {f.get('detail')}\n")
 print(len(off))
 PY
+)"; prc=$?
+  set -e
   rm -f "$tmp"
+  [ "$prc" -ne 0 ] && { echo ERR; return 0; }
+  printf '%s\n' "$out"
 }
 
 if [ "$SCOPE" != "staged" ]; then

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -216,7 +216,10 @@ def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple,
             # Its own axis, never folded into `exit_code` (FR-049): a consumer opts in from its gate.
             "dangling": {
                 "count": len(dangling),
-                "findings": [{"kind": f.kind.value, "file": str(f.file), "detail": f.detail}
+                # `line` is data, not decoration: a gate's added-lines ratchet intersects these with
+                # the lines a commit adds. It is the only axis that carries one today.
+                "findings": [{"kind": f.kind.value, "file": str(f.file), "detail": f.detail,
+                              "line": f.line}
                              for f in dangling],
             },
         }, indent=2))
@@ -241,8 +244,12 @@ def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple,
             print(f"  [strict/robustify] {f.file}: {f.detail}")
         for p in rob_invalid:
             print(f"  [strict/invalid-frontmatter] {p}: not valid YAML; left untouched (fix the file)")
-        for f in dangling:
-            print(f"  [dangling] {f.file}: {f.detail}")
+        # Deliberately NOT enumerated here — only counted above. This axis lands on trees that have
+        # carried dead links for years (thousands, in the repos it was measured on), and printing one
+        # line each would bury the findings that actually gate the build under a wall of text nobody
+        # asked for. The count keeps it honest (Constitution II: no silent caps); `--json` carries
+        # every finding for a consumer that wants them, and the gate recipe prints them when its
+        # dangling axis is switched on.
         print(f"  -> exit {code} ({outcome})")
 
     return code

--- a/src/darnlink/report.py
+++ b/src/darnlink/report.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import Optional
 
 
 class Kind(str, Enum):
@@ -29,3 +30,8 @@ class Finding:
     file: Path        # the file the finding is about: the linking file for link findings,
                       # or the file itself for file-level findings (e.g. invalid_frontmatter)
     detail: str       # human-readable summary (e.g. "old.md -> ../new.md")
+    # 1-based line, when the finding is anchored to one. Optional and defaulted, so no existing kind
+    # has to change; only `dangling` sets it today. It exists because a CONSUMER needs it as data:
+    # the gate recipe's added-lines ratchet has to intersect findings with the lines a commit adds,
+    # and scraping that out of `detail` would couple the gate to prose.
+    line: Optional[int] = None

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -380,14 +380,15 @@ def plan_robustify(
                 # it. A self-link (t is not None) is not a candidate.
                 dead = _dangling_target(link.href, f) if t is None else None
                 if dead is not None:
-                    # The line goes in `detail` (FR-041). `Finding` has no line field — no kind has
-                    # ever needed one — and widening the shared record for this is not this feature's
-                    # business. A dead link is acted on by opening it, so `file:line` is the part that
-                    # makes the report usable without a search.
+                    # The line is carried BOTH ways on purpose: in `detail` for a human reading the
+                    # report, and in `Finding.line` for a machine. The gate recipe's added-lines
+                    # ratchet has to intersect findings with the lines a commit adds, and scraping a
+                    # number out of prose would couple it to wording.
                     lineno = original.count("\n", 0, link.start) + 1
                     result.findings.append(Finding(
                         Kind.DANGLING, f,
-                        f"line {lineno}: {link.href}: target does not exist (resolves to {dead})"))
+                        f"line {lineno}: {link.href}: target does not exist (resolves to {dead})",
+                        line=lineno))
                 continue  # skip non-md/external and self-links
             tr = t.resolve()
             if tr in ignored_targets or tr in invalid_fm:

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -159,8 +159,11 @@ def test_check_reports_dangling_without_changing_the_exit_code(tmp_path, capsys)
     out = capsys.readouterr().out
 
     assert code == 0                      # clean: nothing to repair, nothing to robustify
-    assert "dangling" in out              # but not silent
-    assert "nope.md" in out
+    assert "dangling" in out              # but not silent: the count is stated
+    # …and not enumerated. On the trees this axis lands on, one line per finding would bury the
+    # findings that actually gate the build. `--json` carries them for machines; the gate recipe
+    # prints them when its dangling axis is switched on.
+    assert "nope.md" not in out
 
 
 def test_check_json_carries_dangling_on_its_own_axis(tmp_path, capsys):

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -42,7 +42,27 @@ pytestmark = pytest.mark.skipif(
 _LEAKY_ENV = (
     "DARNLINK_REF", "DARNLINK_GATE_MODE", "DARNLINK_GATE_SCOPE", "DARNLINK_GATE_FAIL_CLOSED",
     "DARNLINK_GATE_WEB", "DARNLINK_GATE_CREATE_README", "DARNLINK_GATE_TOKEN_FILE",
+    "DARNLINK_GATE_DANGLING",
+    # ⚠️ And git's own. `git` exports these to every hook it runs, so when this suite is executed
+    # FROM the repo's pre-commit hook (`tools/check.sh`), an un-scrubbed `git` in a test inherits
+    # GIT_DIR from the outer repo while using the sandbox as its work tree. That combination is not
+    # a failing test — it is a `git add -A` against the wrong repository. It committed "delete
+    # every tracked file" into a real branch here on 2026-08-09 before this scrubbing existed.
+    "GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR", "GIT_PREFIX",
+    "GIT_OBJECT_DIRECTORY", "GIT_ALTERNATE_OBJECT_DIRECTORIES", "GIT_INDEX_VERSION",
+    "GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
 )
+
+
+def _clean_env() -> dict:
+    """The ambient environment minus anything that would point a subprocess at the outer repo."""
+    return {k: v for k, v in os.environ.items() if k not in _LEAKY_ENV}
+
+
+def _git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    """Run git INSIDE `repo`, never inheriting the caller's git environment (see _LEAKY_ENV)."""
+    return subprocess.run(["git", *args], cwd=repo, env=_clean_env(), check=check,
+                          capture_output=True, text=True)
 
 
 @pytest.fixture
@@ -50,7 +70,7 @@ def sandbox(tmp_path):
     """A git-init'd repo dir + a `run(config)` helper that writes darnlink-gate.json and runs the recipe."""
     repo = tmp_path / "repo"
     repo.mkdir()
-    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    _git(repo, "init", "-q")
 
     bindir = tmp_path / "shimbin"
     bindir.mkdir()
@@ -66,7 +86,7 @@ def sandbox(tmp_path):
 
     def run(config: dict) -> subprocess.CompletedProcess:
         (repo / "darnlink-gate.json").write_text(json.dumps(config))
-        env = {k: v for k, v in os.environ.items() if k not in _LEAKY_ENV}
+        env = _clean_env()
         env["PATH"] = f"{bindir}{os.pathsep}" + env.get("PATH", "")
         env["DARNLINK_BIN"] = _darnlink_bin()
         return subprocess.run(
@@ -199,3 +219,89 @@ def test_unavailable_create_readme_axis_does_not_mask_a_failing_core(tmp_path):
         f"core strict failure must survive an unavailable create-readme axis; got {r.returncode}\n"
         f"STDOUT:\n{r.stdout}\nSTDERR:\n{r.stderr}"
     )
+
+
+# --- (c) the dangling axis (015) and its added-lines ratchet ----------------------------------------
+#
+# The rung that makes this adoptable. Every consumer already carries years of dangling links, so an
+# axis that gates the whole repo on day one would be bypassed, not fixed. `added-lines` judges only
+# what the commit ADDS: old debt never blocks, new debt cannot enter.
+
+def _commit(repo: Path, msg: str) -> None:
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", msg)
+
+
+def _repo_with_old_debt(repo: Path) -> None:
+    """A committed file that already contains a link to a path that never existed."""
+    (repo / "doc.md").write_text(f"---\nuuid: {U}\n---\n\n# doc\n\n[old debt](gone.md)\n")
+    _commit(repo, "base")
+
+
+def test_dangling_is_off_by_default(sandbox):
+    """The ratchet rule: upgrading the pin must not change any verdict for a repo that did not opt in.
+
+    `check` still states the count on one line — a repo should learn it has dead links — but it must
+    not enumerate them (a consumer measured at 2,526 would drown its real findings) and it must not
+    move the exit code.
+    """
+    repo, run = sandbox
+    _repo_with_old_debt(repo)
+
+    r = run({})   # no `dangling` key at all
+    out = r.stdout + r.stderr
+
+    assert r.returncode == 0
+    assert "gone.md" not in out          # not enumerated
+    assert "does not affect the exit code" in out   # but not hidden either
+
+
+def test_added_lines_lets_old_debt_through(sandbox):
+    """Touching a file that carries old danglers must not block the commit."""
+    repo, run = sandbox
+    _repo_with_old_debt(repo)
+    (repo / "doc.md").write_text((repo / "doc.md").read_text() + "\nan added line with no links\n")
+    _git(repo, "add", "doc.md")
+
+    r = run({"dangling": "added-lines", "scope": "staged"})
+
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_added_lines_blocks_a_newly_added_dead_link(sandbox):
+    """The other half: what the commit introduces is judged, and named with its line."""
+    repo, run = sandbox
+    _repo_with_old_debt(repo)
+    (repo / "doc.md").write_text((repo / "doc.md").read_text() + "\n[brand new](never_existed.md)\n")
+    _git(repo, "add", "doc.md")
+
+    r = run({"dangling": "added-lines", "scope": "staged"})
+
+    out = r.stdout + r.stderr
+    assert r.returncode != 0, out
+    assert "never_existed.md" in out
+    assert "gone.md" not in out          # the old debt is still none of this commit's business
+
+
+def test_warn_reports_without_failing(sandbox):
+    """The honest way to see the backlog before gating it."""
+    repo, run = sandbox
+    _repo_with_old_debt(repo)
+    (repo / "doc.md").write_text((repo / "doc.md").read_text() + "\n[brand new](never_existed.md)\n")
+    _git(repo, "add", "doc.md")
+
+    r = run({"dangling": "warn", "scope": "staged"})
+
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "never_existed.md" in (r.stdout + r.stderr)
+
+
+def test_repo_scope_fails_on_any_dangling_link(sandbox):
+    """The wall, for a repo already at zero."""
+    repo, run = sandbox
+    _repo_with_old_debt(repo)
+
+    r = run({"dangling": "repo"})
+
+    assert r.returncode != 0
+    assert "gone.md" in (r.stdout + r.stderr)

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -185,7 +185,10 @@ def test_unavailable_create_readme_axis_does_not_mask_a_failing_core(tmp_path):
 
     repo = tmp_path / "repo"
     repo.mkdir()
-    subprocess.run([needed["git"], "init", "-q"], cwd=repo, check=True)
+    # `env=_clean_env()`, like every other git call here: run from the repo's own pre-commit hook,
+    # an inherited GIT_DIR would make this init/operate on the OUTER repository. The absolute path
+    # is kept because this test deliberately builds a minimal PATH later.
+    subprocess.run([needed["git"], "init", "-q"], cwd=repo, env=_clean_env(), check=True)
     # a plain link to a uuid'd target → a strict/robustify offender → the core `check` exits 3
     (repo / "T.md").write_text(f"---\nuuid: {U}\n---\n# T\n")
     (repo / "A.md").write_text("# A\n[t](T.md) plain\n")
@@ -205,7 +208,7 @@ def test_unavailable_create_readme_axis_does_not_mask_a_failing_core(tmp_path):
     )
     shim.chmod(0o755)
 
-    env = {k: v for k, v in os.environ.items() if k not in _LEAKY_ENV}
+    env = _clean_env()
     env["PATH"] = str(bindir)  # only the minimal bin → python3 is unreachable
     env["DARNLINK_BIN"] = dbin
     env["DARNLINK_GATE_MODE"] = "check"


### PR DESCRIPTION
Follow-up to #36. That gave darnlink the finding; this makes it **enforceable without breaking the one-way ratchet** consumers' gates depend on.

## The axis

`dangling` is a new key in `darnlink-gate.json`, **defaulting to `off`** — upgrading the pin changes no verdict anywhere.

| `dangling` | Behaviour |
|---|---|
| `off` *(default)* | not gated, not listed. `check` still states the **count** on one line, so a repo learns it has dead links. |
| `warn` | listed, never fails. The honest way to see the backlog before gating it. |
| `added-lines` | fails only on findings on lines **this commit adds** (`scope=staged`). The adoption rung. |
| `repo` | fails on **any** finding. The wall, for a repo already at zero. |

**Why a separate axis and not a `mode` rung:** consumers were measured carrying between **0 and 2,526** existing dangling links. Folding this into `check`/`max` would turn each gate red on upgrade, and the only escape would be *lowering* `mode` — a ladder you can only climb by first stepping down is not a ladder.

**Why `added-lines` and not per-file:** per-file was tried and is not enough. Editing one line of a README that already carries old danglers blocks the commit, which pushes people to `--no-verify`, and a gate people bypass gates nothing. The added lines come from `git diff --cached -U0`; git lives in the recipe, not in darnlink (spec 008, Option B).

## Two supporting changes

- **`Finding.line`** — optional, defaulted, set only by `dangling` today, surfaced in `check --json`. A *consumer* needs it as data: the ratchet intersects findings with the lines a commit adds, and scraping that number out of `detail` would couple the gate to prose. Copilot argued for a structured line in #36 and I kept it in `detail`, reasoning it would touch all fourteen kinds — with a default it touches none, and the consumer now exists. It was the better call.
- **`check` no longer enumerates dangling findings in its text output**, only counts them. Caught by the default-off test: on a tree with 2,526 findings the enumeration buries the ones that actually gate the build. `--json` still carries every finding, and the recipe prints them when its axis is on.

## A latent hazard in the gate tests, fixed

Found the hard way. `git` exports `GIT_DIR` to every hook it runs, so this suite executed **from the repo's own pre-commit hook** handed each un-scrubbed `git` in a test the *outer* repo's `GIT_DIR` with the sandbox as its work tree. That is not a failing test — it is `git add -A` against the wrong repository, and it committed *"delete every tracked file"* onto a real branch before the scrubbing existed. All git in these tests now goes through a helper with a cleaned environment, and the git variables are listed in `_LEAKY_ENV` with the reason.

The existing tests never committed, which is why this only surfaced now.

## Validation

End-to-end on a throwaway repo with pre-existing debt, all five settings: old debt passes untouched, a newly added dead link is blocked and named with its line, `warn` reports and passes, `repo` fails, and default-`off` says nothing and changes no exit code.

**200 tests green**, `tools/check.sh` clean.

## Known gap

`darnlink-gate.ps1` ignores the `dangling` key, so a Windows-only gating surface does not enforce this axis. Documented in `recipes/README.md` rather than left to be discovered by someone whose gate is green on one machine and red on another.