### PR TITLE
fix(gate): pass payloads through files, not the environment (E2BIG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **`darnlink-gate`: the staged scope crashed on any repo whose `check --json` exceeded 128 KiB.**
+  Linux caps a *single* environment variable at `MAX_ARG_STRLEN` = 32 pages = **128 KiB** — a
+  per-string limit, separate from the ~2 MB `ARG_MAX` total — and exceeding it makes the next `exec`
+  fail with `E2BIG`. The staged path exported the whole JSON payload, so on a real consumer (~200 KB)
+  the gate did not report a finding, it **crashed**: `sed: Argument list too long`, exit 126. A gate
+  that cannot run gates nothing, and it fails *loudly* only if someone is watching the output.
+  Payloads (findings JSON, staged list, added-lines map) now travel through temp files, cleaned up by
+  an `EXIT` trap; only short paths go through the environment. `create_readme_offenders` already did
+  this for the same reason — the staged path did not, and only tipped over once the JSON grew.
+  Pinned by a regression test whose scenario produces a ~547 KB payload.
+
+
 ## [0.20.0] — 2026-08-09
 
 ### Added

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -380,30 +380,49 @@ set -e
 if [ "$rc" -gt 3 ] || [ -z "$DL_JSON" ]; then
   bail "(staged) darnlink unreachable (rc=$rc)"
 fi
-export DL_JSON DL_ROOT="$root" DL_REF="$REF" DL_MODE="$MODE" DL_DANGLING="$DANGLING"
-export DL_STAGED="$(printf '%s\n' "${STAGED[@]}")"
+# ⚠️ The payloads go through TEMP FILES, never through the environment. Linux caps a SINGLE env var
+# (or argv entry) at MAX_ARG_STRLEN = 32 pages = 128 KiB — a per-string limit, quite separate from the
+# ~2 MB ARG_MAX total, and exceeding it makes the next `exec` fail with E2BIG. A whole-repo
+# `check --json` on a large consumer is ~200 KB, so exporting it broke the staged path outright:
+# `sed: Argument list too long`, and a gate that cannot run is a gate that gates nothing.
+# (`create_readme_offenders` already used a temp file for exactly this reason; the staged path did
+# not, and only tipped over once the JSON grew.)
+DL_JSON_FILE="$(mktemp)"; printf '%s' "$DL_JSON" > "$DL_JSON_FILE"
+DL_STAGED_FILE="$(mktemp)"; printf '%s\n' "${STAGED[@]}" > "$DL_STAGED_FILE"
+DL_ADDED_FILE="$(mktemp)"
+# Best-effort cleanup on every exit path, including the failure ones (`set -e`, a signal).
+trap 'rm -f "$DL_JSON_FILE" "$DL_STAGED_FILE" "$DL_ADDED_FILE"' EXIT
+export DL_JSON_FILE DL_STAGED_FILE DL_ADDED_FILE
+export DL_ROOT="$root" DL_REF="$REF" DL_MODE="$MODE" DL_DANGLING="$DANGLING"
 # The added-lines ratchet needs the LINES this commit adds, and git lives here, not in darnlink
 # (spec 008, Option B). `-U0` gives hunks with no context, so every `+` line in the header range is
 # genuinely new. Collected per staged file as `path:start,count`.
 if [ "$DANGLING" = added-lines ]; then
-  DL_ADDED=""
   for p in "${STAGED[@]}"; do
     [ -n "$p" ] || continue
-    hunks="$(git diff --cached -U0 -- "$p" 2>/dev/null | sed -n 's/^@@ -[^ ]* +\([0-9]*\)\(,\([0-9]*\)\)\{0,1\} @@.*/\1,\3/p' || true)"
-    [ -n "$hunks" ] && DL_ADDED="$DL_ADDED$(printf '%s' "$hunks" | sed "s#^#$p:#")
-"
+    git diff --cached -U0 -- "$p" 2>/dev/null \
+      | sed -n 's/^@@ -[^ ]* +\([0-9]*\)\(,\([0-9]*\)\)\{0,1\} @@.*/\1,\3/p' \
+      | sed "s#^#$p:#" >> "$DL_ADDED_FILE" || true
   done
-  export DL_ADDED
 fi
 
-# Pass everything via env (no interpolation into the script → no injection from finding text).
+# Paths via env, PAYLOADS via files (see the MAX_ARG_STRLEN note above). No interpolation into the
+# script either way → no injection from finding text.
 python3 <<'PY'
 import json, os, sys
 root = os.environ["DL_ROOT"]
 mode = os.environ.get("DL_MODE", "check")
+
+def _read(var):
+    path = os.environ.get(var)
+    if not path or not os.path.exists(path):
+        return ""
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
 # realpath both sides: darnlink emits resolved absolute paths, so resolve symlinks here too to match.
-staged = {os.path.realpath(os.path.join(root, p)) for p in os.environ["DL_STAGED"].split("\n") if p.strip()}
-data = json.loads(os.environ["DL_JSON"])
+staged = {os.path.realpath(os.path.join(root, p)) for p in _read("DL_STAGED_FILE").split("\n") if p.strip()}
+data = json.loads(_read("DL_JSON_FILE"))
 def hits(axis):
     return [f for f in data.get(axis, {}).get("findings", []) if os.path.realpath(f["file"]) in staged]
 integ = hits("integrity")
@@ -420,7 +439,7 @@ if dangling_mode != "off":
     found = hits("dangling")
     if dangling_mode == "added-lines":
         added = {}   # realpath -> set of added line numbers
-        for row in os.environ.get("DL_ADDED", "").split("\n"):
+        for row in _read("DL_ADDED_FILE").split("\n"):
             if not row.strip():
                 continue
             path, _, span = row.rpartition(":")

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -329,6 +329,16 @@ def test_staged_scope_survives_a_payload_bigger_than_one_env_var(sandbox):
     (repo / "big.md").write_text((repo / "big.md").read_text() + "\ntail line\n")
     _git(repo, "add", "big.md")
 
+    # Assert the PRECONDITION, or this stops being a regression test the day the payload shrinks
+    # (a shorter `detail`, a leaner JSON shape) and silently starts passing for the wrong reason.
+    limit = os.sysconf("SC_PAGESIZE") * 32          # MAX_ARG_STRLEN, in bytes
+    payload = subprocess.run([_darnlink_bin(), "check", str(repo), "--json"],
+                             capture_output=True, text=True, env=_clean_env()).stdout
+    assert len(payload) > limit, (
+        f"scenario no longer reproduces the bug: payload is {len(payload)} B, "
+        f"under the {limit} B per-string limit. Make it bigger or delete this test."
+    )
+
     r = run({"dangling": "added-lines", "scope": "staged"})
     out = r.stdout + r.stderr
 

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -308,3 +308,29 @@ def test_repo_scope_fails_on_any_dangling_link(sandbox):
 
     assert r.returncode != 0
     assert "gone.md" in (r.stdout + r.stderr)
+
+
+def test_staged_scope_survives_a_payload_bigger_than_one_env_var(sandbox):
+    """Regression: the payload must not travel through the environment.
+
+    Linux caps a SINGLE env var (or argv entry) at MAX_ARG_STRLEN = 32 pages = 128 KiB — a per-string
+    limit, separate from the ~2 MB ARG_MAX total. Exceeding it makes the next `exec` fail with E2BIG,
+    so the gate does not report a finding, it *crashes*: `sed: Argument list too long`, exit 126. A
+    gate that cannot run gates nothing.
+
+    A whole-repo `check --json` on a real consumer measured ~200 KB. This builds a comparable payload
+    from a single file so the test stays fast.
+    """
+    repo, run = sandbox
+    links = "\n".join(f"[dead {i}](missing_target_with_a_deliberately_long_name_{i}.md)"
+                      for i in range(1200))
+    (repo / "big.md").write_text(f"---\nuuid: {U}\n---\n\n{links}\n")
+    _commit(repo, "base")
+    (repo / "big.md").write_text((repo / "big.md").read_text() + "\ntail line\n")
+    _git(repo, "add", "big.md")
+
+    r = run({"dangling": "added-lines", "scope": "staged"})
+    out = r.stdout + r.stderr
+
+    assert "Argument list too long" not in out, out[:400]
+    assert r.returncode == 0, out[:400]   # the added line carries no link → nothing to gate on


### PR DESCRIPTION
Found in the field, minutes into enabling the `dangling` axis on a real consumer. The staged scope did not report a finding — it **crashed**:

```
darnlink-gate: line 392: /usr/bin/sed: Argument list too long
darnlink-gate: line 400: /usr/bin/python3: Argument list too long
exit=126
```

## The cause

Linux caps a **single** environment variable (or argv entry) at `MAX_ARG_STRLEN` = 32 pages = **128 KiB**. That is a *per-string* limit, quite separate from the ~2 MB `ARG_MAX` total — so the intuitive check ("the whole environment is nowhere near the limit") passes while the exec still fails. Measured here: a 127 KB variable execs fine, a 130 KB one gives `E2BIG`.

The staged path exported the entire `check --json` payload. On the consumer in question that JSON is **~200 KB**, so every `exec` after the export failed.

**This is a latent bug, not a new one.** Exporting the payload was always over the line for a big enough repo; the `dangling` section merely pushed that consumer past it. `create_readme_offenders` already used a temp file *for exactly this reason* — the staged path never did.

## The fix

Payloads (findings JSON, staged list, added-lines map) travel through temp files; only short paths ride in the environment. Cleanup is an `EXIT` trap rather than an `rm` at the end — under `set -e` the failure paths never reach a trailing `rm`, which is the same shape Copilot flagged in #37.

## Why this matters more than a normal crash

A gate that cannot run gates nothing, and this one fails **loudly only if somebody is watching**. Wired into `pre-commit`, exit 126 blocks the commit, so it is noisy — but a consumer whose fragment fails open on a non-zero exit would have gone silently unguarded.

## Tests

Regression test pins it with a scenario that produces a **~547 KB** payload. Verified that the scenario genuinely exceeds the limit rather than merely being "large" — a regression test that does not reproduce the bug is decoration.

201 tests green, `tools/check.sh` clean.