### PR TITLE
docs: name the consumer monorepo generically in lang_gate

### DIFF
--- a/tools/lang_gate.py
+++ b/tools/lang_gate.py
@@ -11,7 +11,8 @@ WHY A RATCHET AND NOT FAIL-CLOSED. A repo that adopts the rule late already carr
 lines -- the first one to do so had ~1300 across 172 files, accumulated because the rule had never
 been written down. Demanding they all be translated before the next commit would simply get the
 gate deleted. So, following the owner's standing norm ("a repo's strictness only ever goes up,
-never down") and the mechanism txnet1's `entity-structure` gate already uses: legacy lines sit in
+never down") and the mechanism the consumer monorepo's `entity-structure` gate already
+uses: legacy lines sit in
 a baseline whose count can only DECREASE, while new or modified lines must be English from now on.
 A repo that starts clean pins its baseline at 0, which is fail-closed with no extra machinery.
 


### PR DESCRIPTION
A comment in `tools/lang_gate.py` names a private repository. One line, one word.

## How it got in, which is the part worth reading

**The privacy gate caught it.** The run on the push that introduced the file is red — a `failure`, correctly reported.

It landed anyway, because that push went **straight to `main`**. On `pull_request` a red gate blocks the merge; on `push` there is nothing left to block — the commit is already public and the failed run is just a marker someone has to notice. Nobody did. A closing audit found it, not the red run.

So the gate works and its coverage has a hole: it can only *prevent* on the PR path.

## Worth considering separately

Making `main` a protected branch with the gate as a required check would close it properly, by making the direct push impossible. That is a repository-settings change, not something to slip into this PR.