### PR TITLE
recipes: the example config recommended two rungs below what it should

### DIFF
--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -33,15 +33,20 @@
 #     findings: 2 integrity / 3 strict).
 #
 # CONFIG. Reads `darnlink-gate.json` at the repo root (all keys optional):
-#   { "ref": "git+https://github.com/txemi/darnlink@v0.20.1",
+#   { "ref": "git+https://github.com/txemi/darnlink@vX.Y.Z",
 #     "excludes": ["secrets","node_modules",".venv"], "ignore_blocks": ["txmd-autogrid"],
 #     "mode": "max", "scope": "repo", "fail_closed": true,
 #     "web": true, "dangling": "repo", "create_readme": true,
 #     "create_readme_excludes": ["mirrors"] }
 #
-#   ^ That is the TARGET, not a starting point: every axis at its strictest. Pin `ref` to the
-#   LATEST release, not to whatever this comment happens to say -- this example sat at v0.7.0 for
-#   thirteen releases and quietly recommended two rungs below what its own author was running.
+#   ^ That is the TARGET, not a starting point: every axis at its strictest.
+#
+#   `vX.Y.Z` is a PLACEHOLDER ON PURPOSE, and it is the one thing here you must not copy verbatim.
+#   Resolve it when you paste:
+#       gh release view -R txemi/darnlink --json tagName -q .tagName
+#   A concrete tag written into this comment is exactly how the example rotted last time: it sat at
+#   v0.7.0 for thirteen releases and quietly recommended two rungs below what its own author was
+#   running. Any pin printed here ages the moment it is committed, so nothing is printed.
 #
 #   ADOPTING AN EXISTING REPO? Do not paste the above on day one; it will fail on contact with a
 #   tree that has never been gated, and a gate that fails on arrival gets deleted. Climb instead,
@@ -52,9 +57,15 @@
 #     4. "create_readme": true             -> + a link to a FOLDER requires its README.md
 #     5. "web": true                       -> + cross-repo GitHub links verified over the network
 #     6. "dangling": "warn" -> "added-lines" -> "repo"
-#        `warn` measures without failing, `added-lines` fails only on lines the commit ADDS (so old
-#        debt never blocks anyone), `repo` fails on any. Measured on a nine-repo fleet: 2,356 links
-#        pointing at files that do not exist, none of them named by any other axis. Expect a number.
+#        `warn` measures without failing; `added-lines` fails only on lines the commit ADDS (so old
+#        debt never blocks anyone); `repo` fails on any.
+#        ⚠️ `added-lines` needs a staged diff, so it only ever bites on `scope=staged` — i.e. the
+#        pre-commit hook. On a whole-repo surface (`scope=repo`: pre-push, CI) there is no diff to
+#        judge and it degrades to `warn`. So this rung is enforced ONLY by a local hook, which fails
+#        open when uv/network is missing: nothing on the server catches a new dangling link. If you
+#        want a wall rather than a habit, the rung that has one is `repo`.
+#        Measured on a nine-repo fleet: 2,356 links pointing at files that do not exist, none of
+#        them named by any other axis. Expect a number.
 #   mode ∈ { repair | check | max } — see WHAT IT DOES. Raising it is a one-way ratchet: only up.
 #   web (mode=max only): add a `web-check --online` pass — cross-repo links to OTHER GitHub repos must
 #     resolve to the destination's uuid (read online). Public targets need no token; private ones send

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -33,10 +33,28 @@
 #     findings: 2 integrity / 3 strict).
 #
 # CONFIG. Reads `darnlink-gate.json` at the repo root (all keys optional):
-#   { "ref": "git+https://github.com/txemi/darnlink@v0.7.0",
-#     "excludes": ["secrets","external_repos"], "ignore_blocks": ["txmd-autogrid"],
-#     "mode": "check", "scope": "repo", "fail_closed": true,
-#     "web": true, "create_readme": true, "create_readme_excludes": ["mirrors"] }
+#   { "ref": "git+https://github.com/txemi/darnlink@v0.20.1",
+#     "excludes": ["secrets","node_modules",".venv"], "ignore_blocks": ["txmd-autogrid"],
+#     "mode": "max", "scope": "repo", "fail_closed": true,
+#     "web": true, "dangling": "repo", "create_readme": true,
+#     "create_readme_excludes": ["mirrors"] }
+#
+#   ^ That is the TARGET, not a starting point: every axis at its strictest. Pin `ref` to the
+#   LATEST release, not to whatever this comment happens to say -- this example sat at v0.7.0 for
+#   thirteen releases and quietly recommended two rungs below what its own author was running.
+#
+#   ADOPTING AN EXISTING REPO? Do not paste the above on day one; it will fail on contact with a
+#   tree that has never been gated, and a gate that fails on arrival gets deleted. Climb instead,
+#   fixing content at each rung (the ratchet only goes up):
+#     1. "mode": "repair"                  -> broken robust links + invalid YAML
+#     2. "mode": "check"                   -> + every anchorable link actually anchored
+#     3. "mode": "max"                     -> + every link points at a file that HAS a uuid
+#     4. "create_readme": true             -> + a link to a FOLDER requires its README.md
+#     5. "web": true                       -> + cross-repo GitHub links verified over the network
+#     6. "dangling": "warn" -> "added-lines" -> "repo"
+#        `warn` measures without failing, `added-lines` fails only on lines the commit ADDS (so old
+#        debt never blocks anyone), `repo` fails on any. Measured on a nine-repo fleet: 2,356 links
+#        pointing at files that do not exist, none of them named by any other axis. Expect a number.
 #   mode ∈ { repair | check | max } — see WHAT IT DOES. Raising it is a one-way ratchet: only up.
 #   web (mode=max only): add a `web-check --online` pass — cross-repo links to OTHER GitHub repos must
 #     resolve to the destination's uuid (read online). Public targets need no token; private ones send


### PR DESCRIPTION
The `darnlink-gate.json` example in the recipe header still pinned **v0.7.0** — thirteen releases behind — and recommended `"mode": "check"` with **no `dangling` key at all**, while the axis has existed since v0.20.0 and this very file implements it.

A reference config that lags its own tool teaches the wrong thing to everyone who copies it, which is what a reference config is *for*. Found while checking that what a fleet actually applies matches what its own docs recommend — it did not.

**What changes**

- The example now shows the **target**: every axis at its strictest, and says so, so nobody reads it as a minimum.
- **Adoption path added.** Pasting the target into a repo that has never been gated fails on contact, and a gate that fails on arrival gets deleted rather than climbed. The six rungs are now spelled out in order, each fixing content before raising the bar — which is what the one-way ratchet has always meant but never showed.
- The `dangling` rung carries its own sub-ladder, because it is the axis that surfaces the most debt at once: `warn` measures without failing, `added-lines` fails only on lines the commit *adds* (old debt never blocks anyone), `repo` fails on any. Quoted with a real figure — **2,356 links pointing at files that do not exist** across a nine-repo fleet, none named by any other axis — so a reader expects a number instead of being surprised by one.
- A note to pin `ref` to the **latest release** rather than to whatever the comment says: a hardcoded version in an example is exactly how this drifted for thirteen releases.

Docs/comments only; no behaviour change. `tools/check.sh` green (201 tests, link gate clean, lang gate clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)