### PR TITLE
gates: add the missing pre-push surface and dogfood the dangling axis

### DIFF
--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -20,5 +20,11 @@
 # (lang gate, tests, darnlink self-check at mode=max, dangling at zero).
 #
 # Bypass (discouraged, and it skips the wall for EVERY commit in the push): git push --no-verify
+#
+# stdin is redirected from /dev/null ON PURPOSE. git feeds a pre-push hook the list of refs being
+# pushed on stdin, and anything down the chain that reads stdin -- even incidentally, as `gh` does
+# inside a `while read` loop -- would silently swallow those lines and behave as if the input were
+# empty. That failure mode is invisible: no error, just a wrong answer. Nothing here needs the ref
+# list, so the safest thing is to not hand it over.
 set -euo pipefail
-exec bash "$(git rev-parse --show-toplevel)/tools/check.sh"
+exec bash "$(git rev-parse --show-toplevel)/tools/check.sh" < /dev/null

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Versioned git pre-push hook — the WHOLE-REPO wall, and the surface this repo was missing.
+#
+# Activate ONCE per clone (git will not auto-run versioned hooks, by design — security):
+#   git config core.hooksPath hooks
+# (Or let the toolbelt's global dispatcher do it: it runs hooks/<name> and hooks/<name>.d/*.)
+#
+# Why a pre-push when pre-commit already runs the same gate.
+# `git commit --no-verify` is one keystroke, and a machine that has never activated hooks runs no
+# gate at all — in both cases the first wall the work meets is CI, which is remote, slower, and
+# occasionally down (billing, outage). `git push` is deliberate and infrequent, so a whole-repo
+# judgment here is affordable, and it is the last place something broken can be stopped before it
+# leaves the machine.
+#
+# darnlink was the only repo in its own consuming fleet without this surface: it gates its Markdown
+# on pre-commit and in Actions, and had nothing in between. Fixed here, so the tool runs the same
+# four-surface wall it asks its consumers to run.
+#
+# Runs tools/check.sh — the same gate as pre-commit and CI, so there is no drift between surfaces
+# (lang gate, tests, darnlink self-check at mode=max, dangling at zero).
+#
+# Bypass (discouraged, and it skips the wall for EVERY commit in the push): git push --no-verify
+set -euo pipefail
+exec bash "$(git rev-parse --show-toplevel)/tools/check.sh"

--- a/specs/011-directory-links/spec.md
+++ b/specs/011-directory-links/spec.md
@@ -13,7 +13,7 @@ directory be a first-class link target, identified by the `uuid` of its `README.
 ## Motivation
 
 darnlink heals `.md`→`.md` links, but real doc trees link to **directories** too — "see the
-[deployment guide](ops/deploy/)", a hub folder, a country's report folder. Those links are outside
+deployment guide (`ops/deploy/`)", a hub folder, a country's report folder. Those links are outside
 the tool: move or rename the folder and they die with no warning, and no `--robustify`/gate can
 protect them. A directory already tends to carry a `README.md` hub with a `uuid`; that uuid is a
 perfectly good stable identity for the directory. This feature uses it.

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -24,3 +24,9 @@ uv run darnlink .              # repair check: robust links must not be broken
 # OUTBOUND links are still anchored with invisible <!-- uuid --> comments; only a frontmatter uuid would
 # show on the package page, which we don't want). See docs/elevating-your-link-gate.md.
 uv run darnlink . --robustify --create-frontmatter --no-create-frontmatter-for README.md
+
+# Dangling axis (dogfood `dangling: repo`, the strictest rung the recipe offers). Runs LAST
+# because it shells out to darnlink again; see tools/dangling_gate.py for why it lives in its own
+# file and why it is fail-closed at zero.
+python3 tools/dangling_gate.py
+

--- a/tools/dangling_gate.py
+++ b/tools/dangling_gate.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Fail if any Markdown link points at a path that does not exist (the `dangling` axis).
+
+Why this file exists at all
+---------------------------
+A dangling link is invisible to every other axis darnlink has. It is not `unresolvable` -- that is a
+*robust* link whose uuid died. It is not `to robustify` -- there is nothing to anchor to, because the
+target is not there. So it falls through all of them, and `check` reports it as **informational
+only**: the gating *policy* lives in `recipes/darnlink-gate`, which reads `check --json` and decides.
+
+The CLI deliberately has no `--dangling-fails` flag (the recipe owns policy, the library owns
+findings), so darnlink's own quality gate cannot dogfood the axis by passing a flag. It makes the
+same judgment the recipe makes, from the same JSON.
+
+Fail-closed at zero, on purpose
+-------------------------------
+This mirrors the strictest rung the recipe offers (`"dangling": "repo"`), which is what four repos in
+the consuming fleet already run. darnlink measures zero, so demanding zero costs nothing -- and a
+ratchet that costs nothing is one you take immediately, before the debt arrives.
+
+It would have caught the one that existed: `specs/011-directory-links/spec.md` illustrated the
+feature with *"see the [deployment guide](ops/deploy/)"* -- written as a real link to a path that has
+never existed in this repo. That is the shape to watch for: **an illustration must not be a link**,
+because a reader who clicks it gets a 404 from our own documentation.
+
+Usage:
+    python3 tools/dangling_gate.py            # scan the repo root
+    python3 tools/dangling_gate.py <path>     # scan somewhere else
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def main() -> int:
+    root = sys.argv[1] if len(sys.argv) > 1 else "."
+    # `uv run` so this uses the checked-out source, not an installed release: the gate must judge the
+    # tree it is being run on, otherwise a bug in the current branch could hide behind an older wheel.
+    proc = subprocess.run(
+        ["uv", "run", "darnlink", "check", root, "--json"],
+        capture_output=True,
+        text=True,
+    )
+    # `check` exits non-zero when it finds integrity/strict problems; that is a different axis and the
+    # earlier steps of check.sh already failed on it. What matters here is whether we got usable JSON.
+    if not proc.stdout.strip():
+        print("dangling gate: darnlink produced no JSON -- cannot judge, failing closed.", file=sys.stderr)
+        print(proc.stderr.strip()[:2000], file=sys.stderr)
+        return 2
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        print(f"dangling gate: unparseable JSON from darnlink ({exc}) -- failing closed.", file=sys.stderr)
+        return 2
+
+    findings = data.get("dangling", {}).get("findings", [])
+    if not findings:
+        print("dangling gate: 0 links pointing at a non-existent target -- ok.")
+        return 0
+
+    print(f"dangling gate: {len(findings)} link(s) whose target does not exist:", file=sys.stderr)
+    for f in findings:
+        print(f"  {f.get('file', '?')}:{f.get('line') or '?'}  {f.get('detail', '')}", file=sys.stderr)
+    print(
+        "Fix the path, or stop making it a link if it is an illustration.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/dangling_gate.py
+++ b/tools/dangling_gate.py
@@ -35,25 +35,71 @@ import subprocess
 import sys
 
 
+def _echo(stream_name: str, text: str, limit: int = 2000) -> None:
+    """Print the head of a captured stream, or say plainly that it was empty.
+
+    An empty stream printed as nothing is indistinguishable from "the gate forgot to print it", and
+    "stderr was empty" is itself a clue (a silent non-zero exit points at the wrapper, not darnlink).
+    """
+    body = text.strip()
+    if not body:
+        print(f"  ({stream_name} was empty)", file=sys.stderr)
+        return
+    head = body[:limit]
+    print(f"  --- {stream_name} ---", file=sys.stderr)
+    print("  " + head.replace("\n", "\n  "), file=sys.stderr)
+    if len(body) > limit:
+        print(f"  ... ({len(body) - limit} more chars)", file=sys.stderr)
+
+
 def main() -> int:
     root = sys.argv[1] if len(sys.argv) > 1 else "."
     # `uv run` so this uses the checked-out source, not an installed release: the gate must judge the
     # tree it is being run on, otherwise a bug in the current branch could hide behind an older wheel.
-    proc = subprocess.run(
-        ["uv", "run", "darnlink", "check", root, "--json"],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        proc = subprocess.run(
+            ["uv", "run", "darnlink", "check", root, "--json"],
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        # `uv` missing from PATH does NOT come back as a return code -- the exec itself fails, so
+        # subprocess raises before there is anything to inspect. Without this the gate dies with a
+        # raw traceback and exit 1, which reads like "the gate found something" rather than "the gate
+        # could not run". That distinction is the whole point of the 2 exit code, and it is exactly
+        # the scenario a machine without the toolbelt provisioned hits first.
+        print(
+            f"dangling gate: cannot run darnlink ({exc}) -- failing closed. "
+            "Install uv: curl -LsSf https://astral.sh/uv/install.sh | sh",
+            file=sys.stderr,
+        )
+        return 2
     # `check` exits non-zero when it finds integrity/strict problems; that is a different axis and the
     # earlier steps of check.sh already failed on it. What matters here is whether we got usable JSON.
     if not proc.stdout.strip():
-        print("dangling gate: darnlink produced no JSON -- cannot judge, failing closed.", file=sys.stderr)
-        print(proc.stderr.strip()[:2000], file=sys.stderr)
+        # The exit code is the fastest discriminator between the ways this goes wrong: 127 is "no uv
+        # on PATH", 1/2 are darnlink refusing to run, 126 is a permissions problem. Without it the
+        # message is the same for all of them and the reader has to reproduce the run by hand.
+        print(
+            f"dangling gate: darnlink produced no JSON (exit {proc.returncode}) "
+            "-- cannot judge, failing closed.",
+            file=sys.stderr,
+        )
+        _echo("stderr", proc.stderr)
         return 2
     try:
         data = json.loads(proc.stdout)
     except json.JSONDecodeError as exc:
-        print(f"dangling gate: unparseable JSON from darnlink ({exc}) -- failing closed.", file=sys.stderr)
+        # Something came out, it just was not JSON. Almost always a traceback or a warning printed on
+        # stdout ahead of the payload, so show the head of BOTH streams: the bare exception says where
+        # parsing died but not what was there instead, which is the only thing that identifies the cause.
+        print(
+            f"dangling gate: unparseable JSON from darnlink (exit {proc.returncode}: {exc}) "
+            "-- failing closed.",
+            file=sys.stderr,
+        )
+        _echo("stdout", proc.stdout)
+        _echo("stderr", proc.stderr)
         return 2
 
     findings = data.get("dangling", {}).get("findings", [])


### PR DESCRIPTION
This repo asks its consumers for four gate surfaces and for `dangling` at its strictest rung. It was running with three surfaces and the axis off.

**`pre-push` — the surface that was missing.** There was pre-commit and there was Actions, and nothing in between. `git commit --no-verify` is one keystroke, and a clone that never activated hooks runs no gate at all; in both cases the first wall the work meets is CI — remote, slower, and occasionally down. `git push` is deliberate and infrequent, so a whole-repo judgment there is affordable, and it is the last place something broken can be stopped before it leaves the machine. It runs `tools/check.sh`, the same gate as pre-commit and CI, so no drift between surfaces.

**`dangling`, fail-closed at zero.** A dangling link is invisible to every other axis: not `unresolvable` (that is a robust link whose uuid died), not `to robustify` (there is nothing to anchor to). `check` already reports it, but only as informational — the *policy* lives in `recipes/darnlink-gate`, and the CLI has no flag for it by design (recipe owns policy, library owns findings). So the self-gate makes the same judgment from the same JSON, in `tools/dangling_gate.py`, sibling to `lang_gate.py`. Zero baseline because the repo measures zero: a ratchet that costs nothing is one you take before the debt arrives. Four repos in the consuming fleet already run this rung.

**And there was exactly one — illustrating the very failure the axis is for.** `specs/011-directory-links/spec.md` explained the feature with *"see the [deployment guide](ops/deploy/)"*, written as a real link to a path that has never existed here. **An illustration must not be a link**: a reader who clicks it gets a 404 from our own documentation. It is now a code span, which is what it always was semantically.

Verified the gate actually bites: clean tree → exit 0; inject a link to a non-existent path → exit 1, naming file and line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
