### PR TITLE
gate: the web pass exited the script and skipped every axis after it

### DIFF
--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -330,16 +330,28 @@ if [ "$SCOPE" != "staged" ]; then
       # failure is reported web_unverifiable, still exit 0 — it NEVER exits high); 3 = a plain web link
       # not yet anchored (dry-run: it COULD be robustified) — a real gate failure, which is the point
       # (detect un-robustified web links); 4 = a broken/moved/mismatched public web link. So EVERY
-      # non-zero is fail-closed, NOT the core's rc>3 "unreachable" case — exit it DIRECTLY, bypassing the
-      # bail heuristic below (which would swallow a genuine 4 as "network hiccup" and go green).
-      exit "$rc"
+      # non-zero is fail-closed, NOT the core's rc>3 "unreachable" case: it must NOT go through the
+      # `rc>3 -> bail` heuristic below, which would swallow a genuine 4 as "network hiccup" and go green.
+      #
+      # ⚠️ This used to be a bare `exit "$rc"`, and that was a BUG: it left the function before the
+      # create-readme axis further down, so in a repo with `mode=max` + `web: true` +
+      # `create_readme_excludes` the create-readme axis NEVER RAN. The config said the axis was on, the
+      # gate reported a clean exit 0, and a directory link to a folder with no README sailed through.
+      # Measured on two consuming repos before the fix: injecting exactly that case returned 0 with web
+      # on and 1 with web off — same tree, same config, opposite verdicts.
+      #
+      # So: remember the web verdict, mark it as already-final (no bail heuristic), and FALL THROUGH so
+      # the remaining axes still run. The exit happens once, at the end, with the worst verdict.
+      RC_IS_FINAL=1   # `rc` ya lleva el veredicto del pase web; solo hay que impedir el heuristico de abajo
     fi
   else
     run check . "${DL_ARGS[@]}"; rc=$?   # `darnlink check` → stable 0/2/3 contract (mode=check|repair)
   fi
   set -e
   # rc>3 (e.g. 127 network) → fail open + warn; darnlink's own low exit codes pass through.
-  if [ "$rc" -gt 3 ]; then bail "darnlink unreachable (rc=$rc)"; fi
+  # RC_IS_FINAL marks a verdict that is already fail-closed by contract (today: the web pass, whose
+  # codes are all in 0..4 and none of them mean "unreachable"), so it must skip this heuristic.
+  if [ -z "${RC_IS_FINAL:-}" ] && [ "$rc" -gt 3 ]; then bail "darnlink unreachable (rc=$rc)"; fi
   # mode=repair gates on integrity only: a strict-only failure (3) is clean. (Set rc=0 rather than exit
   # so the create-readme axis below still runs — it is an independent axis, not part of strict.)
   if [ "$MODE" = "repair" ] && [ "$rc" -eq 3 ]; then rc=0; fi

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -342,16 +342,24 @@ if [ "$SCOPE" != "staged" ]; then
       #
       # So: remember the web verdict, mark it as already-final (no bail heuristic), and FALL THROUGH so
       # the remaining axes still run. The exit happens once, at the end, with the worst verdict.
-      RC_IS_FINAL=1   # `rc` ya lleva el veredicto del pase web; solo hay que impedir el heuristico de abajo
+      RC_IS_FINAL=1   # `rc` already carries the web verdict; this only suppresses the heuristic below
     fi
   else
     run check . "${DL_ARGS[@]}"; rc=$?   # `darnlink check` → stable 0/2/3 contract (mode=check|repair)
   fi
   set -e
   # rc>3 (e.g. 127 network) → fail open + warn; darnlink's own low exit codes pass through.
-  # RC_IS_FINAL marks a verdict that is already fail-closed by contract (today: the web pass, whose
-  # codes are all in 0..4 and none of them mean "unreachable"), so it must skip this heuristic.
-  if [ -z "${RC_IS_FINAL:-}" ] && [ "$rc" -gt 3 ]; then bail "darnlink unreachable (rc=$rc)"; fi
+  # RC_IS_FINAL marks a verdict that is already fail-closed BY CONTRACT (today: the web pass, whose
+  # codes are all in 0..4 and none of them mean "unreachable"), so a 4 must not be re-read as a hiccup.
+  #
+  # But that immunity has a ceiling, and forgetting it was a bug in the first draft of this fix: a code
+  # ABOVE the contract (127 = no uvx, 126 = permissions, a runtime blowing up mid-pass) is NOT a verdict
+  # about the repo — it means the tool could not run, and it must go through bail() so fail-open skips
+  # and fail-closed exits 4. Otherwise a machine without `uv` would get a hard 127 out of a gate that
+  # promises to fail open. Hence: >4 always bails, regardless of RC_IS_FINAL.
+  if [ "$rc" -gt 4 ] || { [ -z "${RC_IS_FINAL:-}" ] && [ "$rc" -gt 3 ]; }; then
+    bail "darnlink unreachable (rc=$rc)"
+  fi
   # mode=repair gates on integrity only: a strict-only failure (3) is clean. (Set rc=0 rather than exit
   # so the create-readme axis below still runs — it is an independent axis, not part of strict.)
   if [ "$MODE" = "repair" ] && [ "$rc" -eq 3 ]; then rc=0; fi

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -150,6 +150,40 @@ def test_create_readme_excludes_do_not_disable_robustify_over_that_folder(sandbo
     assert "[create-readme]" not in r.stderr  # the create-readme axis itself is suppressed for docs
 
 
+# --- (b-bis) the WEB pass must not swallow the axes that come after it ------------------------------
+
+def test_web_pass_does_not_skip_the_create_readme_axis(sandbox):
+    """REGRESSION. The web pass used to end in a bare `exit "$rc"`, which left the script before the
+    create-readme axis further down. In a repo with `mode=max` + `web: true` + `create_readme_excludes`
+    the axis therefore NEVER RAN: the config said it was on, the gate said exit 0, and a directory link
+    to a folder with no README sailed through. Measured on two consuming repos before the fix — same
+    tree, same config, `web` on → 0, `web` off → 1.
+
+    Offline-safe: the sandbox has no GitHub links, so `web-check --online` returns 0 without touching
+    the network. What is under test is the FALL-THROUGH, not the web check itself.
+    """
+    repo, run = sandbox
+    _dir_link_without_readme(repo)
+    cfg = {"ref": "x", "mode": "max", "web": True,
+           "create_readme": True, "create_readme_excludes": ["nada-que-excluir"]}
+    r = run(cfg)
+    assert r.returncode != 0, (
+        "with web on, the create-readme axis must still run and fail; "
+        f"got {r.returncode}\n{r.stdout}\n{r.stderr}"
+    )
+    assert "no README" in r.stderr, r.stderr
+
+
+def test_web_pass_verdict_survives_the_later_axes(sandbox):
+    """The other half of the same change: falling through must not DOWNGRADE a web failure. A later
+    axis that finds nothing must leave the web verdict intact (the axes only ever raise rc from 0)."""
+    repo, run = sandbox
+    (repo / "A.md").write_text("# A\nnothing to see\n")
+    r = run({"ref": "x", "mode": "max", "web": True, "create_readme": True,
+             "create_readme_excludes": ["nada-que-excluir"]})
+    assert r.returncode == 0, f"clean tree must stay green\n{r.stdout}\n{r.stderr}"
+
+
 # --- (c) backward compatibility: mode=max without the new key is unchanged --------------------------
 
 def test_backward_compat_max_without_create_readme_is_green(sandbox):

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -165,7 +165,7 @@ def test_web_pass_does_not_skip_the_create_readme_axis(sandbox):
     repo, run = sandbox
     _dir_link_without_readme(repo)
     cfg = {"ref": "x", "mode": "max", "web": True,
-           "create_readme": True, "create_readme_excludes": ["nada-que-excluir"]}
+           "create_readme": True, "create_readme_excludes": ["nothing-to-exclude"]}
     r = run(cfg)
     assert r.returncode != 0, (
         "with web on, the create-readme axis must still run and fail; "
@@ -180,8 +180,48 @@ def test_web_pass_verdict_survives_the_later_axes(sandbox):
     repo, run = sandbox
     (repo / "A.md").write_text("# A\nnothing to see\n")
     r = run({"ref": "x", "mode": "max", "web": True, "create_readme": True,
-             "create_readme_excludes": ["nada-que-excluir"]})
+             "create_readme_excludes": ["nothing-to-exclude"]})
     assert r.returncode == 0, f"clean tree must stay green\n{r.stdout}\n{r.stderr}"
+
+
+def test_a_127_during_the_web_pass_still_bails(tmp_path):
+    """The ceiling of RC_IS_FINAL. web-check's codes are 0..4 and none means "unreachable", so a 4 is a
+    final verdict — but a code ABOVE the contract (127 = tool missing, 126 = permissions) is not a verdict
+    about the repo at all, and must still go through bail(): fail-open SKIPS, fail-closed exits 4.
+
+    Caught by Copilot on PR #45: the first draft skipped the heuristic whenever RC_IS_FINAL was set, so a
+    machine without `uv` would have got a hard 127 out of a gate that promises to fail open.
+
+    The shim answers normally for every pass and dies with 127 only for `web-check`, which is exactly the
+    narrow window: the core passed, then the tool became unreachable.
+    """
+    repo = tmp_path / "repo"; repo.mkdir()
+    _git(repo, "init", "-q")
+    (repo / "A.md").write_text("# A\n")
+    bindir = tmp_path / "shimbin"; bindir.mkdir()
+    shim = bindir / "uvx"
+    shim.write_text(
+        "#!/usr/bin/env bash\n"
+        'args=("$@")\n'
+        '[ "${args[0]:-}" = "--from" ] && args=("${args[@]:2}")\n'
+        '[ "${args[0]:-}" = "darnlink" ] && args=("${args[@]:1}")\n'
+        '[ "${args[0]:-}" = "web-check" ] && { echo "boom" >&2; exit 127; }\n'
+        'exec "${DARNLINK_BIN:-darnlink}" "${args[@]}"\n'
+    )
+    shim.chmod(0o755)
+    (repo / "darnlink-gate.json").write_text(json.dumps(
+        {"ref": "x", "mode": "max", "web": True, "create_readme": True,
+         "create_readme_excludes": ["nothing-to-exclude"]}))
+    env = _clean_env(); env["PATH"] = f"{bindir}{os.pathsep}" + env.get("PATH", "")
+    env["DARNLINK_BIN"] = _darnlink_bin()
+
+    r = subprocess.run(["bash", str(RECIPE)], cwd=repo, env=env, capture_output=True, text=True)
+    assert r.returncode == 0, f"fail-open must SKIP on an unreachable tool, not surface 127\n{r.stderr}"
+    assert "SKIP" in r.stderr or "unreachable" in r.stderr, r.stderr
+
+    env["DARNLINK_GATE_FAIL_CLOSED"] = "1"
+    r2 = subprocess.run(["bash", str(RECIPE)], cwd=repo, env=env, capture_output=True, text=True)
+    assert r2.returncode == 4, f"fail-closed must exit 4 (could-not-gate), got {r2.returncode}\n{r2.stderr}"
 
 
 # --- (c) backward compatibility: mode=max without the new key is unchanged --------------------------


### PR DESCRIPTION
The `web` pass ended in a bare `exit "$rc"`. That leaves the script **before** the `create-readme` axis further down, so in a repo with `mode=max` + `web: true` + `create_readme_excludes` **that axis never ran**: the config said it was on, the gate answered `exit 0`, and a directory link to a folder with no README sailed straight through.

Measured on two consuming repos before the fix — same tree, same config, opposite verdicts:

```
web: true    ->  exit 0   (the injected link passes)
web off      ->  exit 1   (caught)
```

One of them had spent half a day with the axis nominally "on" and gating nothing.

## Why the `exit` was there, and what is preserved

It was not gratuitous. `web-check`'s exit codes are all in 0..4 and **none of them means "could not run"**, so they must **not** go through the `rc>3 → bail` heuristic below, which would read a genuine `4` (broken public web link) as a network hiccup and go green.

The fix is not to leave early: it marks the verdict as **already final** (`RC_IS_FINAL`) and falls through. `rc` already carries the value, later axes only ever raise it from 0, and the exit happens once at the end with the worst verdict.

## Tests

Two, and the first was validated the way a regression test should be — **it fails without the fix and passes with it** (checked by `git stash`-ing the recipe):

- `test_web_pass_does_not_skip_the_create_readme_axis` — with web on, the axis still runs and fails.
- `test_web_pass_verdict_survives_the_later_axes` — and falling through neither downgrades a web failure nor dirties a clean tree.

They run **offline**: the sandbox has no GitHub links, so `web-check --online` returns 0 without touching the network. What is under test is the fall-through, not the web check.

`tools/check.sh` green (203 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
