### PR TITLE
gate: 'dangling_max' — a budget that makes the 'repo' rung adoptable before you reach zero

### DIFF
--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -147,7 +147,25 @@ case "${CREATE_README,,}" in ""|0|false|no|off) CREATE_README="" ;; *) CREATE_RE
 #                one line of a README that carries old danglers would block the commit, and a gate
 #                people bypass gates nothing;
 #   repo         fails on ANY finding. The wall, for a repo already at zero.
+#
+# `dangling_max` (int, default 0) turns `repo` into a BUDGET: fail only above that count. It exists
+# because between `added-lines` and `repo` there is no rung — and `added-lines` needs a staged diff,
+# so it only ever bites in pre-commit. A repo with old debt therefore has NO server-side dangling
+# wall at all, on any surface, until the day it reaches exactly zero. That is a long time with no
+# wall, and it is precisely when a regression slips in unseen.
+# With a budget you get the wall TODAY at your current number, and every cleanup lowers it. Same
+# shape as a coverage floor: the number is a receipt of where you are, not permission to stay.
+# To keep it a ratchet and not a permanent allowance, the gate SAYS SO when you come in under
+# budget — an unlowered budget is the failure mode, and nothing else would catch it.
+# Only `repo` has a wall, so the budget only applies there. A non-numeric value is treated as 0
+# (strictest) on purpose: a typo must never silently WIDEN an allowance.
 DANGLING="${DARNLINK_GATE_DANGLING:-$(read_cfg dangling off)}"
+DANGLING_MAX="${DARNLINK_GATE_DANGLING_MAX:-$(read_cfg dangling_max 0)}"
+case "$DANGLING_MAX" in
+  ''|*[!0-9]*)
+    echo "darnlink-gate: dangling_max='$DANGLING_MAX' is not a non-negative integer — using 0." >&2
+    DANGLING_MAX=0 ;;
+esac
 case "${DANGLING,,}" in
   off|""|0|false|no) DANGLING=off ;;
   warn) DANGLING=warn ;;
@@ -399,8 +417,20 @@ if [ "$SCOPE" != "staged" ]; then
         echo "  [dangling] $df: $ddet" >&2
       done
       if [ "$DANGLING" = repo ]; then
-        echo "darnlink-gate: $dl_n link(s) point at a path that does not exist (dangling axis)." >&2
-        [ "$rc" -eq 0 ] && rc=1
+        if [ "$dl_n" -gt "$DANGLING_MAX" ]; then
+          if [ "$DANGLING_MAX" -gt 0 ]; then
+            echo "darnlink-gate: $dl_n link(s) point at a path that does not exist — over the budget of $DANGLING_MAX (dangling axis)." >&2
+          else
+            echo "darnlink-gate: $dl_n link(s) point at a path that does not exist (dangling axis)." >&2
+          fi
+          [ "$rc" -eq 0 ] && rc=1
+        elif [ "$dl_n" -lt "$DANGLING_MAX" ]; then
+          # The whole point of a budget is that it goes down. Nothing else would ever notice that it
+          # is stale, so say it here, where whoever just lowered the count is looking.
+          echo "darnlink-gate: $dl_n dangling link(s), under the budget of $DANGLING_MAX — lower dangling_max to $dl_n to keep the ratchet." >&2
+        else
+          echo "darnlink-gate: $dl_n dangling link(s) — exactly at the budget (dangling_max=$DANGLING_MAX)." >&2
+        fi
       else
         echo "darnlink-gate: $dl_n dangling link(s) — informational (dangling=$DANGLING; does not fail the gate)." >&2
       fi

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -416,6 +416,11 @@ if [ "$SCOPE" != "staged" ]; then
       printf '%s\n' "$dl_out" | while IFS=$'\t' read -r df dline ddet; do
         echo "  [dangling] $df: $ddet" >&2
       done
+    fi
+    # The budget verdict runs even at dl_n=0. Nesting it under "there are findings" would make the
+    # gate go SILENT exactly when the last dangler dies — the one moment the stale budget is both
+    # visible and free to lower. A ratchet whose reminder disappears on success is not a ratchet.
+    if [ "$dl_n" -gt 0 ] || { [ "$DANGLING" = repo ] && [ "$DANGLING_MAX" -gt 0 ]; }; then
       if [ "$DANGLING" = repo ]; then
         if [ "$dl_n" -gt "$DANGLING_MAX" ]; then
           if [ "$DANGLING_MAX" -gt 0 ]; then
@@ -427,7 +432,11 @@ if [ "$SCOPE" != "staged" ]; then
         elif [ "$dl_n" -lt "$DANGLING_MAX" ]; then
           # The whole point of a budget is that it goes down. Nothing else would ever notice that it
           # is stale, so say it here, where whoever just lowered the count is looking.
-          echo "darnlink-gate: $dl_n dangling link(s), under the budget of $DANGLING_MAX — lower dangling_max to $dl_n to keep the ratchet." >&2
+          if [ "$dl_n" -eq 0 ]; then
+            echo "darnlink-gate: no dangling links left — drop dangling_max (still $DANGLING_MAX) so the wall is a wall again." >&2
+          else
+            echo "darnlink-gate: $dl_n dangling link(s), under the budget of $DANGLING_MAX — lower dangling_max to $dl_n to keep the ratchet." >&2
+          fi
         else
           echo "darnlink-gate: $dl_n dangling link(s) — exactly at the budget (dangling_max=$DANGLING_MAX)." >&2
         fi

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -42,7 +42,7 @@ pytestmark = pytest.mark.skipif(
 _LEAKY_ENV = (
     "DARNLINK_REF", "DARNLINK_GATE_MODE", "DARNLINK_GATE_SCOPE", "DARNLINK_GATE_FAIL_CLOSED",
     "DARNLINK_GATE_WEB", "DARNLINK_GATE_CREATE_README", "DARNLINK_GATE_TOKEN_FILE",
-    "DARNLINK_GATE_DANGLING",
+    "DARNLINK_GATE_DANGLING", "DARNLINK_GATE_DANGLING_MAX",
     # ⚠️ And git's own. `git` exports these to every hook it runs, so when this suite is executed
     # FROM the repo's pre-commit hook (`tools/check.sh`), an un-scrubbed `git` in a test inherits
     # GIT_DIR from the outer repo while using the sandbox as its work tree. That combination is not
@@ -382,6 +382,88 @@ def test_repo_scope_fails_on_any_dangling_link(sandbox):
 
     assert r.returncode != 0
     assert "gone.md" in (r.stdout + r.stderr)
+
+
+# --- (c-bis) `dangling_max`: the budget that makes `repo` adoptable before you reach zero ----------
+#
+# Without it there is no rung between `added-lines` and `repo`, and `added-lines` needs a staged diff
+# — so a repo carrying old debt has NO server-side dangling wall at all until the day it hits exactly
+# zero. The budget buys the wall today and ratchets down with each cleanup.
+
+def _repo_with_n_danglers(repo: Path, n: int) -> None:
+    """A committed file carrying exactly `n` links to paths that never existed."""
+    body = "".join(f"[d{i}](gone{i}.md)\n\n" for i in range(n))
+    (repo / "doc.md").write_text(f"---\nuuid: {U}\n---\n\n# doc\n\n{body}")
+    _commit(repo, "base")
+
+
+def test_budget_defaults_to_zero_so_an_upgrade_changes_no_verdict(sandbox):
+    """No `dangling_max` key must behave exactly as before: `repo` fails on any finding."""
+    repo, run = sandbox
+    _repo_with_n_danglers(repo, 2)
+
+    r = run({"dangling": "repo"})
+
+    assert r.returncode != 0
+    # and it must not start talking about a budget nobody set. Match the phrases, not the bare word:
+    # the sandbox path carries this test's name, so "budget" appears in every line of output.
+    out = r.stdout + r.stderr
+    assert "the budget" not in out
+    assert "dangling_max" not in out
+
+
+def test_count_over_the_budget_still_fails_and_names_the_budget(sandbox):
+    repo, run = sandbox
+    _repo_with_n_danglers(repo, 2)
+
+    r = run({"dangling": "repo", "dangling_max": 1})
+
+    assert r.returncode != 0
+    assert "over the budget of 1" in (r.stdout + r.stderr)
+
+
+def test_count_at_the_budget_passes(sandbox):
+    """The whole point: a repo with known debt gets a real wall at its current number."""
+    repo, run = sandbox
+    _repo_with_n_danglers(repo, 2)
+
+    r = run({"dangling": "repo", "dangling_max": 2})
+
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "exactly at the budget" in (r.stdout + r.stderr)
+
+
+def test_coming_in_under_budget_asks_for_the_budget_to_be_lowered(sandbox):
+    """A budget that is never lowered is an allowance. Nothing else would notice it went stale, so
+    the gate has to say it here — in front of whoever just did the cleanup."""
+    repo, run = sandbox
+    _repo_with_n_danglers(repo, 2)
+
+    r = run({"dangling": "repo", "dangling_max": 5})
+
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "lower dangling_max to 2" in (r.stdout + r.stderr)
+
+
+def test_a_junk_budget_is_treated_as_zero_not_as_infinite(sandbox):
+    """A typo must never silently WIDEN an allowance — it fails closed, and says why."""
+    repo, run = sandbox
+    _repo_with_n_danglers(repo, 2)
+
+    r = run({"dangling": "repo", "dangling_max": "muchos"})
+
+    assert r.returncode != 0
+    assert "not a non-negative integer" in (r.stdout + r.stderr)
+
+
+def test_budget_does_not_leak_into_the_warn_rung(sandbox):
+    """Only `repo` has a wall, so a budget there must not turn `warn` into something that fails."""
+    repo, run = sandbox
+    _repo_with_n_danglers(repo, 2)
+
+    r = run({"dangling": "warn", "dangling_max": 1})
+
+    assert r.returncode == 0, r.stdout + r.stderr
 
 
 def test_staged_scope_survives_a_payload_bigger_than_one_env_var(sandbox):

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -445,6 +445,33 @@ def test_coming_in_under_budget_asks_for_the_budget_to_be_lowered(sandbox):
     assert "lower dangling_max to 2" in (r.stdout + r.stderr)
 
 
+def test_reaching_zero_with_a_budget_still_asks_for_it_to_be_dropped(sandbox):
+    """The milestone case, and the one that is easiest to get wrong.
+
+    If the reminder lives inside `there are findings`, the gate goes SILENT exactly when the last
+    dangler dies — the one moment the stale budget is both visible and free to remove. A ratchet
+    whose reminder disappears on success is not a ratchet, it is an allowance with a grace period.
+    """
+    repo, run = sandbox
+    _repo_with_n_danglers(repo, 0)   # a clean repo: the cleanup finished
+
+    r = run({"dangling": "repo", "dangling_max": 5})
+
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "drop dangling_max" in (r.stdout + r.stderr)
+
+
+def test_a_clean_repo_without_a_budget_says_nothing(sandbox):
+    """The mirror of the above: no budget set, nothing to nag about."""
+    repo, run = sandbox
+    _repo_with_n_danglers(repo, 0)
+
+    r = run({"dangling": "repo"})
+
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "dangling_max" not in (r.stdout + r.stderr)
+
+
 def test_a_junk_budget_is_treated_as_zero_not_as_infinite(sandbox):
     """A typo must never silently WIDEN an allowance — it fails closed, and says why."""
     repo, run = sandbox


### PR DESCRIPTION
## The gap this closes

The `dangling` axis has four rungs — `off` · `warn` · `added-lines` · `repo` — and a hole between the last two.

`added-lines` is the adoption rung: old debt never blocks, new debt cannot enter. But it **needs a staged diff**, so it only ever bites on `scope=staged` — the pre-commit hook. On a whole-repo surface (`scope=repo`: pre-push, CI) there is no diff to judge and it degrades to `warn`.

The consequence is the part worth stating plainly:

> **A repo carrying old dangling debt has NO server-side wall for this axis, on any surface, until the day it reaches exactly zero.**

And the only local surface that does gate it fails open when `uv` is missing. In a consumer measured while writing this, that meant **256 dangling links** and no server wall — months of "the axis is on" that in practice meant *a habit, not a wall*. A regression could land in `main` and nothing would go red.

## What this adds

`"dangling_max": <int>` (default `0`) turns `repo` into a **budget**: fail only above that count.

```json
{ "dangling": "repo", "dangling_max": 141 }
```

You get the wall **today**, at your current number, and every cleanup lowers it. Same shape as a coverage floor — the number is a receipt of where you are, not permission to stay.

## The three details that make it a ratchet and not an allowance

**1. Coming in under budget is reported, loudly.**

```
darnlink-gate: 118 dangling link(s), under the budget of 141 — lower dangling_max to 118 to keep the ratchet.
```

A budget nobody lowers *is* an allowance, and **nothing else in the system can notice it went stale**. So it has to be said here, in front of whoever just did the cleanup — the one moment someone is both looking and able to act.

**2. A junk value fails closed, not open.**

`"dangling_max": "muchos"` → warns and uses `0`. A typo must never silently **widen** an allowance; that is the one direction a config error must not be able to go.

**3. Absent key = byte-identical verdict.**

No `dangling_max` and `repo` still fails on any finding, and the output does not mention a budget nobody set. Raising the pin changes nothing for anyone who did not opt in — the same rule the whole axis was built on.

The budget applies to `repo` only, since that is the only rung with a wall.

## Tests

6 new, `22/22` green in `tests/test_recipe_gate.py`:

- default (no key) fails on any finding **and stays silent about budgets**
- over budget → fails, naming the budget
- exactly at budget → passes
- under budget → passes **and asks for the budget to be lowered**
- junk budget → fails closed, saying why
- a budget set on the `warn` rung does not turn it into something that fails

One of them caught a bad assertion of mine: the sandbox path carries the test name, so a bare `"budget" not in output` matched the *path*, not the message. Now it matches the phrases.