### PR TITLE
lang-gate: resolve the baseline against the repo, not against the tool

### DIFF
--- a/tools/lang_gate.py
+++ b/tools/lang_gate.py
@@ -67,7 +67,33 @@ _SPANISH = re.compile(rf"\b(?:{_WORDS})\b|[áéíóúñ¿¡]", re.IGNORECASE)
 _ESCAPE = "lang-ok"
 _EXTS = (".py",)
 _SKIP_DIRS = {".git", ".venv", "node_modules", "__pycache__", "_build", "backup", "dist", "build"}
-_BASELINE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "lang_gate_baseline.json")
+def _baseline_path() -> str:
+    """Where the baseline lives. Resolved against the REPO, never against this file.
+
+    WHY (2026-08-11). It used to be `dirname(__file__)/lang_gate_baseline.json` — i.e. next to the
+    tool. That works only because the tool happens to sit inside the repo it checks: the moment it
+    is installed anywhere else (a venv, `uvx`, a shared bin) the gate reads and writes a baseline in
+    a directory that has nothing to do with the project, and silently reports a clean tree. It was
+    correct by accident of location, which is not a property you want under a gate.
+
+    Resolution order: `LANG_GATE_BASELINE` (explicit wins) -> `<git root>/tools/lang_gate_baseline.json`
+    -> next to this file, only if there is no git repo at all. The default keeps the file exactly
+    where every consumer already has it, so this fix moves nothing and breaks no one.
+    """
+    env = os.environ.get("LANG_GATE_BASELINE")
+    if env:
+        return os.path.abspath(env)
+    try:
+        r = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                           capture_output=True, text=True, timeout=10)
+        if r.returncode == 0 and r.stdout.strip():
+            return os.path.join(r.stdout.strip(), "tools", "lang_gate_baseline.json")
+    except Exception:
+        pass
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "lang_gate_baseline.json")
+
+
+_BASELINE = _baseline_path()
 
 
 def _is_commentish(line: str) -> bool:


### PR DESCRIPTION
The baseline path was `dirname(__file__)/lang_gate_baseline.json` — next to the tool. That works
only because this file happens to sit inside the repo it checks. Install it anywhere else (a venv,
`uvx`, a shared bin) and the gate reads and writes a baseline in a directory unrelated to the
project, then reports a clean tree.

Correct by accident of location is not a property you want under a gate, and it is the one blocker
that would have to be fixed before this file could ever be shared instead of copied into each repo
that uses it.

## What changes

Resolution order: `LANG_GATE_BASELINE` if set → `<git root>/tools/lang_gate_baseline.json` → next
to the file, only when there is no git repo at all.

The default keeps the baseline exactly where it already is, so **nothing moves and nothing breaks**.

## How it was verified

Not by "does it still pass here", which proves nothing — the old code passes that too. The test
that matters: this tool, executed from inside a **different** repo, now resolves to **that** repo's
baseline. Before the fix it read its own.

The same change was applied identically everywhere this file is vendored; `main` is protected here,
so this one goes through a PR.

Context: it is step 0 of an analysis on whether this gate should become its own package instead of
being vendored several times over — the copies have already drifted, and an improvement made in one
of them never reached the rest. This fix is worth doing **whether or not** that extraction ever
happens, which is why it ships first and alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
