### PR TITLE
spec 016: fail on web links to repos you own whose destination has no uuid

### DIFF
--- a/specs/016-own-repo-web-strictness/spec.md
+++ b/specs/016-own-repo-web-strictness/spec.md
@@ -40,68 +40,94 @@ ownership costs **no extra fetch**: it is a textual comparison on a value the ru
 
 ## Evidence this gap is real (measured, not hypothetical)
 
-Measured 2026-08-11 across a nine-repository private fleet, all of which already carry web links:
+Measured 2026-08-11 across a nine-repository private fleet, all of which already carry web links.
+Scope of the count, so it is reproducible: Markdown outside vendored `clones/` and `mirrors/`, with
+fenced code blocks excluded.
 
-- **345** GitHub `blob`/`raw` links in Markdown; **265 (77%)** point at repositories owned by the
-  same account as the linking repo. Cross-repo linking here is overwhelmingly *self*-linking.
-- Of the **46** own links still plain, resolving each destination against a local checkout:
-  **27 point at a `.md` whose frontmatter has no `uuid`** — every one of them invisible to every
-  darnlink axis today. Only 7 would already be caught as `web_anchor`. The rest of the 46: 2 target a
-  non-`.md` file, 2 are pinned to a commit SHA, 1 target no longer exists, and for 9 the destination
-  repository was not checked out locally, so they could not be resolved offline at all.
-- Restricted to the repos that actually run the web axis today (`web: true`), the numbers are
-  **11 links** blocked on **8 destination files** across 3 repositories. All 8 were hand-written
-  documents; none was machine-generated.
+- **255** GitHub `blob`/`raw` links; **228 (89%)** point at repositories owned by the same account as
+  the linking repo. Cross-repo linking here is overwhelmingly *self*-linking.
+- **193 of those 228 are already anchored.** The axis is in daily use, not a proposal.
+- The **35** still plain break down like this — one bucket each, in this order:
+
+| Bucket | Count | Meaning |
+|---|---|---|
+| destination `.md` **without** `uuid` | **17** | invisible to every darnlink axis today — *this feature* |
+| destination has a `uuid` | 5 | already caught as `web_anchor` where the axis is on |
+| destination is not `.md` | 6 | can never carry frontmatter (FR-005) |
+| destination repo not checked out locally | 7 | could not be resolved offline for this count |
+| ref pinned to a commit SHA | 0 | none in the current snapshot (see FR-006) |
+| destination file missing | 0 | would be `web_not_found`, not this |
 
 Two secondary measurements shape the design:
 
-- **In repos where the web axis is already on and fail-closed, the "destination has a uuid" column is
-  zero.** That is structural, not luck: such a link fails the gate as `web_anchor`, so it gets
+- **In repos where the web axis is already on and fail-closed, the "destination has a uuid" bucket is
+  empty.** That is structural, not luck: such a link fails the gate as `web_anchor`, so it gets
   anchored immediately. Everything still plain in those repos is, by construction, in the silent
-  bucket this feature targets. The axis has no overlap with what already exists.
+  bucket this feature targets. The axis has no overlap with what already exists. (The 5 above all sit
+  in repos that have not switched the axis on.)
 - **The practice is growing fast.** In the largest consumer, own web links went 1 → 3 → 3 → 39 →
-  **191** over twelve months (146 of them anchored). A 27-link backlog is not the point; the open
-  door is.
+  **191** over twelve months. A 17-link backlog is not the point; the open door is.
 
-One repository in the fleet mixes **26 own plain links with 30 third-party ones in the same tree** —
-the clearest statement of the problem: to tolerate the 30 you must today also tolerate the 26.
+Two caveats stated rather than buried, because the whole case rests on these numbers:
+
+- **The snapshot is post-remediation.** On the day of measurement, 11 of these links were fixed by
+  hand — `uuid` added to 8 destination files, then anchored — precisely to let the new axis start at
+  zero. Before that day the uuid-less bucket was 27.
+- **Every ref in the fleet is a branch**: `main` 201, `master` 20, `HEAD` 7, and nothing else across
+  all 228. The immutable-ref exclusion below is therefore **reasoning, not measurement** — it has zero
+  occurrences today and is specified so the first one does not become an unfixable failure.
 
 ---
 
-## Decision: an explicit owner list, `auto` as a convenience
+## Decision: an explicit owner list, `--own-from-origin` as a convenience
 
 `web-check` gains **`--own OWNER`** (repeatable). A web link whose destination owner matches (ASCII
 case-insensitively, as GitHub logins are) is **owned**; every other link keeps today's behaviour
 exactly.
 
-`--own auto` derives the owner from the scanned repository's `origin` remote. It is a convenience,
-**not** the primary mechanism, because the explicit list is the only one that survives the real
-cases: a fork (origin is yours, the content is not), a vendored checkout of a foreign repo, and an
-organisation you push to whose name is not your login.
+**`--own-from-origin`** is a separate boolean flag that adds the owner of the scanned repository's
+`origin` remote to that list. It is a convenience, **not** the primary mechanism, because the
+explicit list is the only one that survives the real cases: a fork (origin is yours, the content is
+not), a vendored checkout of a foreign repo, and an organisation you push to whose name is not your
+login.
 
-**`auto` that cannot resolve is a usage error (exit 1), never a silent "nothing is owned".** Degrading
-to zero owned links would produce a green run that means nothing — the exact false pass this feature
-exists to remove (Principle II: never silent).
+It is a **separate flag and not a magic `--own auto` value** on purpose: a sentinel inside a list of
+owner names is unexpressible for anyone whose account or organisation is literally called `auto`, and
+a flag that cannot name a legal input is a defect waiting for its first user.
 
-**And that holds even when explicit `--own` values were also given** — `--own me --own auto` in a
-tarball with no `origin` still exits 1. The rule is about the *request*, not about whether the owner
-set ends up empty: the caller asked darnlink to discover an owner and it could not, so any verdict it
-prints afterwards is answering a narrower question than the one it was asked. Reporting green on a
-subset the user did not fully specify is the same false pass by a smaller door.
+**`--own-from-origin` that cannot resolve is a usage error (exit 1), never a silent "nothing is
+owned".** Degrading to zero owned links would produce a green run that means nothing — the exact
+false pass this feature exists to remove (Principle II: never silent).
+
+**And that holds even when explicit `--own` values were also given** — the owner set would not be
+empty, and it still exits 1. The rule is about the *request*, not about the resulting set: the caller
+asked darnlink to discover an owner and it could not, so any verdict printed afterwards answers a
+narrower question than the one asked. Reporting green on a subset the user did not fully specify is
+the same false pass by a smaller door.
 
 ### What fails, and the two things that deliberately do not
 
 The new finding fires **only** for: destination fetched 200 · destination has no `uuid` · owner is in
-the `--own` list. Two exclusions, both from measured cases in the fleet:
+the owner set. Two exclusions:
 
 - **A destination that is not `.md`** (compared case-insensitively, as `iter_markdown_files` already
   does) never fails. It cannot carry frontmatter, so demanding a `uuid` is incoherent. This mirrors
-  015's FR-044 (anchoring stays `.md`-only). Measured: 2 such links.
-- **A destination pinned to an immutable ref** never fails. You cannot add frontmatter to a commit
-  that is already made, so the finding would be unfixable by construction. "Immutable" is **not** just
-  a 40-hex SHA: a **tag** and a **short SHA** are equally unfixable — re-tagging to plant a `uuid` is
-  not a thing anyone will do. The rule is therefore *"the ref must be a moving branch head"*, and
-  everything else is excluded. Measured: 2 SHA-pinned links against 262 on `main`/`master`/`HEAD`.
+  015's FR-044 (anchoring stays `.md`-only). Measured: 6 such links.
+- **A destination pinned to a commit SHA** never fails: you cannot add frontmatter to a commit that
+  is already made, so the finding would be unfixable by construction.
+
+**The exclusion is textual, and stops there — deliberately.** An earlier draft of this spec widened
+it to *"any ref that is not a moving branch head"*, to also cover tags. That was a mistake and it is
+recorded here so it is not reintroduced: **`v1.2.3` as a tag and `v1.2.3` as a branch are textually
+identical**, so honouring it would require `GET /repos/{o}/{r}/git/refs` — a network call, against
+FR-009 and against the "no extra fetch" acceptance — and its failure direction is the worst one: a
+maintenance branch (`v2`, `release-1.2`) would be excluded for *looking like* a tag, producing a
+false green, which is the exact failure this feature exists to remove. The rule is therefore
+`^[0-9a-f]{7,40}$` and nothing else. A tag-pinned link that genuinely cannot be fixed uses the FR-011
+marker, which is what it is for.
+
+That rule has its own small false-green — a branch named `deadbeef` — accepted knowingly: it is
+textual, offline, auditable, and its failure mode is one link, not a class of them.
 
 ### The finding, and why exit 4 and not 3
 
@@ -125,10 +151,10 @@ into it later.
 
 ### Adoption: a budget, not a cliff
 
-The gate recipe gains `own_web` (off · on) and **`own_web_max` (int, default 0)**: fail only above the
-budget, and print the "lower it to N" nudge when the count drops. Without it, switching the axis on
-fails several repos at once on day one, and an axis that cannot be adopted incrementally gets turned
-off instead of obeyed — the lesson 015 already paid.
+The gate recipe gains `own_web` (the owner list, or `origin`) and **`own_web_max`**: fail only above
+the budget, and print the "lower it to N" nudge when the count drops. Without it, switching the axis
+on fails several repos at once on day one, and an axis that cannot be adopted incrementally gets
+turned off instead of obeyed — the lesson 015 already paid.
 
 **But the budget cannot be built the way `dangling_max` was, and that has to be said here or it will
 be discovered during implementation.** `dangling_max` works because the recipe re-counts the findings
@@ -139,9 +165,8 @@ without re-running everything as `--json` and giving up the human-readable repor
 
 Therefore the budget lives in **darnlink**, not in the recipe: a `--own-max N` flag that suppresses
 `web_own_no_uuid`'s contribution to the exit code while the count is at or below `N` (the findings are
-still reported — a budget silences the *verdict*, never the *finding*). The recipe's `own_web_max` is
-then a thin pass-through, and it can keep taking the exit code verbatim exactly as it does today. See
-FR-012/FR-013.
+still reported — a budget silences the *verdict*, never the *finding*). The recipe's keys are thin
+pass-throughs. See FR-012/FR-013/FR-015.
 
 ### Escape hatch (required, and it is not 005's)
 
@@ -150,11 +175,23 @@ and the anchor points at nothing — strictly worse than a plain link. Without a
 is permanently un-greenable, and a permanently red axis gets disabled rather than obeyed.
 
 **The marker is a trailing `<!-- darnlink-own-exempt -->` beside the link**, in the **source** repo —
-where the knowledge lives — with the same grammar and placement as the existing trailing markers:
+where the knowledge lives:
 
 ```
 See the [nightly export](https://github.com/owned/repo/blob/main/mirrors/export.md) <!-- darnlink-own-exempt -->
 ```
+
+Because the same position already belongs to `<!-- web-uuid: X -->` — `_TRAILING_WEB_UUID_RE` is
+applied immediately after the closing `)` — **the order is fixed and normative**: the anchor first,
+the exemption second.
+
+```
+[text](url) <!-- web-uuid: X --> <!-- darnlink-own-exempt -->
+```
+
+Getting this wrong is not cosmetic: with the exemption first, the link parses as *plain*, and under
+`--write` a **second** `<!-- web-uuid: X -->` is appended after the exemption, silently corrupting the
+line. FR-011 and its acceptance scenario pin the order for exactly that reason.
 
 Why not each of the three opt-outs that already exist, in the order someone will suggest them:
 
@@ -197,29 +234,28 @@ Reviewed against `.specify/memory/constitution.md` v1.1.0.
 - **P-I Single Responsibility:** the new competence is *comparing one string from a URL darnlink has
   already parsed*. No document semantics, no entity model. It stays inside the non-core `web-check`
   adjunct; the two core operations remain two. **Held.** ✅
-  ⚠️ True of `--own OWNER`, **not** of `--own auto`, which must find a repository root and read its
-  git configuration — I/O of a kind the package does nowhere else today (there is no `subprocess` and
-  no git access anywhere in `src/darnlink/`). Still no document semantics, so the principle holds,
-  but that new competence is the **second** reason `auto` is opt-in rather than the default.
+  ⚠️ True of `--own OWNER`, **not** of `--own-from-origin`, which must locate a repository and read
+  its remote — I/O of a kind the package does nowhere else today (there is no `subprocess` and no git
+  access anywhere in `src/darnlink/`). Still no document semantics, so the principle holds, but that
+  new competence is the **second** reason the flag is opt-in rather than the default.
 - **P-II Safe by Default:** the finding is report-only and, unlike every other web finding, is
   **unfixable by `--write` on purpose** — darnlink never writes to the destination repository. The
   feature adds no write path at all. **Held, and reinforced.** ✅
 - **P-III Plain, Self-Contained:** nothing is stored in either repository **as a `uuid → path`
   index** — that, and only that, is what this principle forbids, and it is why 013 rejected the
   manifest. Two things this feature does put in a repo, and both are ordinary configuration the
-  principle has never covered: the owner list may live as a key in the gate recipe's committed
-  `darnlink-gate.json`, and the FR-011 exemption is a comment in the source Markdown. Neither is a
-  location database, neither rots into a stale index, and a darnlink-less repo still renders both.
-  **Held.** ✅
+  principle has never covered: the owner list as the `own_web` key of the gate recipe's committed
+  config (FR-015), and the FR-011 exemption as a comment in the source Markdown. Neither is a location
+  database, neither rots into a stale index, and a darnlink-less repo still renders both. **Held.** ✅
 - **P-IV Deterministic:** with an explicit `--own`, output remains a function of *(tree + live
   responses)* — the same conditional determinism 013 already declared, with nothing added. With
-  **`--own auto` it also becomes a function of the clone's git configuration**: the same tree yields
-  different verdicts in a fork or a mirror. That is a new, small dependency on state outside the
-  tree, and it is why explicit is primary and `auto` opt-in. **Amendment required** (see below).
-  ⚠️ (only for `auto`)
+  **`--own-from-origin` it also becomes a function of the clone's git configuration**: the same tree
+  yields different verdicts in a fork or a mirror. That is a new, small dependency on state outside
+  the tree, and it is why explicit is primary and the flag opt-in. **Amendment required** (see below).
+  ⚠️ (only for `--own-from-origin`)
 
-**Bottom line:** the base rule costs the constitution **nothing**; only the `auto` convenience needs a
-named sentence in P-IV.
+**Bottom line:** the base rule costs the constitution **nothing**; only the `--own-from-origin`
+convenience needs a named sentence in P-IV.
 
 ---
 
@@ -235,6 +271,8 @@ named sentence in P-IV.
 - **Infer "own" from the destination repo being cloned next to the source.** Revives the
   sibling-checkout coupling 013 already rejected as alternative (c), and makes the verdict depend on
   what happens to be on disk.
+- **Exclude tags as well as SHAs from the failing rule.** Undecidable offline; rejected in
+  §What fails above, with its failure direction.
 - **Fold it into `web: true`, with no key of its own.** Tempting, and it loses the one thing that
   makes the rung adoptable: a **separate budget**. (Note what this alternative is *not* about:
   reaching `mode: max` — the web pass already runs only inside the recipe's `max` branch, so
@@ -248,89 +286,122 @@ named sentence in P-IV.
 ### Functional Requirements
 
 - **FR-001** `web-check` MUST accept `--own OWNER`, repeatable. A destination whose parsed owner
-  equals any given value (ASCII case-insensitive) is **owned**. With no `--own`, behaviour MUST be
-  byte-identical to today.
-- **FR-002** `--own auto` MUST derive the owner from the scanned repository's `origin` remote,
-  accepting both the `https://github.com/<owner>/<repo>` and `git@github.com:<owner>/<repo>` forms.
-  It MUST combine with explicit `--own` values (union).
-- **FR-003** If `--own auto` cannot resolve an owner (no repository, no `origin`, non-GitHub remote),
-  the run MUST exit **1** with a message naming the reason — **including when explicit `--own` values
-  were also given**, so the owner set would not have been empty. `auto` is a request that either
-  succeeds or is a usage error; it never silently narrows the question being answered.
+  equals any given value (ASCII case-insensitive; the parser preserves the case it found, so the
+  comparison must fold it) is **owned**. With no owner set, behaviour MUST be byte-identical to today.
+- **FR-002** `web-check` MUST accept `--own-from-origin`, which adds the owner of the scanned
+  repository's `origin` remote to the owner set, accepting both the
+  `https://github.com/<owner>/<repo>` and `git@github.com:<owner>/<repo>` forms. It MUST compose with
+  explicit `--own` values (union). Resolution MUST use `git config --get remote.origin.url` executed
+  in the scanned root, **not** a hand parse of `.git/config`: in a worktree `.git` is a *file*, not a
+  directory, so a naive parse fails in the project's own development environment.
+- **FR-003** If `--own-from-origin` cannot resolve an owner (no repository, no `origin`, non-GitHub
+  remote, `git` not on `PATH`), the run MUST exit **1** with a message naming the reason — **including
+  when explicit `--own` values were also given**, so the owner set would not have been empty. It is a
+  request that either succeeds or is a usage error; it never silently narrows the question answered.
 - **FR-004** A link classified `web_unverifiable` **solely** because the fetched destination returned
   200 with no frontmatter `uuid`, whose owner is owned, MUST instead be reported
-  **`web_own_no_uuid`**, and MUST set the exit code to **4**.
+  **`web_own_no_uuid`**, and MUST set the exit code to **4** (subject to FR-012).
 - **FR-005** FR-004 MUST NOT fire when the destination path does not end in `.md`, compared
   **case-insensitively** (`iter_markdown_files` already lowercases; `A.MD` is a Markdown file).
-- **FR-006** FR-004 MUST NOT fire when the URL's ref is **not a moving branch head** — a full or
-  short commit SHA, or a tag. Only a ref that can still receive a commit is fixable.
+- **FR-006** FR-004 MUST NOT fire when the URL's ref matches `^[0-9a-f]{7,40}$` — a commit SHA, long
+  or short. The test MUST be purely textual: no other ref shape is excluded, and in particular a tag
+  MUST NOT be, because a tag is textually indistinguishable from a branch of the same name and
+  telling them apart needs the network (see §What fails).
 - **FR-007** No other classification changes. In particular a 404 (with or without token), an
-  unreadable repo, a non-GitHub URL and a transport error MUST keep today's kind and exit
-  contribution, owned or not.
+  unreadable repo (the `-2` sentinel), a non-GitHub URL and a transport error MUST keep today's kind
+  and exit contribution, owned or not.
 - **FR-008** The `web_own_no_uuid` message MUST name owner, repo, destination path, and state the
   action (add a `uuid` to that file's frontmatter in that repository). It MUST NOT suggest `--write`.
-- **FR-009** Ownership MUST be decided without any additional network request.
+- **FR-009** Ownership and every exclusion MUST be decided without any additional network request.
 - **FR-010** `--json` MUST emit the new kind under its own `kind`, and include a `web_own_no_uuid`
-  count in the summary object, so a gate can branch on it and apply a budget.
-- **FR-011** A link followed by **`<!-- darnlink-own-exempt -->`** (same grammar and placement as the
-  existing trailing markers, and combinable with a `web-uuid` anchor) MUST be exempt from FR-004. It
-  MUST still be reported, as its own tolerated kind, and MUST NOT contribute to the exit code —
-  silently dropping it would hide the exemption from whoever audits the repo later.
-- **FR-012** `web-check` MUST accept **`--own-max N`** (default 0). While the number of
-  `web_own_no_uuid` findings is **at or below** `N`, they MUST NOT contribute to the exit code; above
-  `N`, FR-004's exit 4 applies. The findings are always reported: the budget silences the *verdict*,
-  never the *finding*. `--own-max` without any `--own` MUST be a usage error (exit 1).
+  count in the summary object, so a consumer can report on it.
+- **FR-011** A link followed by **`<!-- darnlink-own-exempt -->`** MUST be exempt from FR-004 **and
+  from 013's FR-005** (`web_anchor`): an exempt link is never anchored, under `--write` or otherwise —
+  anchoring it is the very damage the marker exists to prevent, since the destination's `uuid` will
+  not survive its next regeneration. When combined with an anchor the order is normative — 
+  `[text](url) <!-- web-uuid: X --> <!-- darnlink-own-exempt -->` — because both markers claim the
+  position immediately after `)`. The link MUST still be reported, as its own tolerated kind, and MUST
+  NOT contribute to the exit code: silently dropping it would hide the exemption from whoever audits
+  the repo later.
+- **FR-012** `web-check` MUST accept **`--own-max N`**. While the number of `web_own_no_uuid` findings
+  is **at or below** `N`, they MUST NOT contribute to the exit code; above `N`, FR-004's exit 4
+  applies. Other exit-4 causes are unaffected: one budgeted finding plus one real `web_not_found`
+  still exits 4. The findings are always reported — the budget silences the *verdict*, never the
+  *finding*. Omitting the flag MUST be distinguishable from `--own-max 0` (default `None`), and
+  `--own-max` without any owner set MUST be a usage error (exit 1).
 - **FR-013** When the count is at or below a non-zero `--own-max`, the report MUST print the count and
-  say that lowering the budget to that number keeps the ratchet — the same nudge `dangling_max` gives.
-  A budget nobody is told to lower is a budget that never goes down.
+  say that lowering the budget to that number keeps the ratchet; when the count reaches **zero** it
+  MUST say to drop the flag entirely. Both nudges, as `dangling_max` gives. A budget nobody is told to
+  lower is a budget that never goes down.
 - **FR-014** The new finding MUST compose with the existing opt-outs: a file carrying
   `darnlink-ignore-file` (003) or `darnlink-ignore-links` (006), and any region inside an
-  `--ignore-block` marker, MUST NOT produce it. Today `web-check` honours only `--ignore-block` and
-  code fences, so 003 and 006 are new work here, not an existing guarantee (this mirrors 015's
-  FR-045).
+  `--ignore-block` marker, MUST NOT produce it. This is a filter **by kind**, applied to
+  `web_own_no_uuid` only — it MUST NOT suppress `web_mismatch`, `web_not_found` or any other web
+  finding in that file, which would silently violate FR-007. That is a **third** semantics for those
+  markers, narrower than the "removed from the darnlink graph entirely" the core gives them, and it
+  is declared here rather than left to the implementer. Today `web-check` honours only
+  `--ignore-block` and code fences, so 003 and 006 are new work here, not an existing guarantee (this
+  mirrors 015's FR-045).
+- **FR-015** The gate recipe MUST expose `own_web` (a list of owner names, or the string `origin`
+  meaning `--own-from-origin`) and `own_web_max` (int), passing them through as `--own` / 
+  `--own-from-origin` / `--own-max`. Because FR-003 and FR-012 make **exit 1 reachable from
+  configuration**, the recipe MUST treat exit 1 from `web-check` as a *tool/usage* error — its
+  existing fail-open-and-warn path — and MUST NOT report it as a repository verdict. Today the recipe
+  documents web-check's contract as "0/3/4, every non-zero fail-closed"; that contract is what this
+  requirement changes.
 
 ### Key Entities
 
-- **Owner set** — the values from `--own` (plus `auto`'s resolution). Pure configuration; never
-  persisted in either repository.
-- **`web_own_no_uuid`** — a fourteenth finding kind: a destination *you control* that has not been
+- **Owner set** — the values from `--own` plus, if requested, the one from `--own-from-origin`. Pure
+  configuration; never persisted as an index.
+- **`web_own_no_uuid`** — the **sixth** web finding kind (beside `web_ok`, `web_anchor`,
+  `web_mismatch`, `web_not_found`, `web_unverifiable`): a destination *you control* that has not been
   given the `uuid` its inbound cross-repo link needs.
 
-## Acceptance (all with a mocked fetcher — no test touches the network)
+## Acceptance
+
+The fetch layer is mocked in every scenario — no test touches the network. Scenarios 8 and 9 also need
+a git fixture: a `tmp_path` with `git init` and a set (or absent) `remote.origin.url`, since FR-002
+resolves through `git config`.
 
 1. **Owned, no uuid.** Plain link to `owned/repo/blob/main/a.md`, destination returns 200 with no
    `uuid`, `--own owned` → `web_own_no_uuid`, exit 4; the message names `owned/repo` and `a.md`.
 2. **Not owned, no uuid.** Same fetch, `--own someone-else` → `web_unverifiable`, exit 0 (unchanged).
-3. **No flag.** Same fetch, no `--own` → `web_unverifiable`, exit 0 (unchanged).
+3. **No flag.** Same fetch, no owner set → `web_unverifiable`, exit 0 (unchanged).
 4. **Owned, has uuid.** Destination returns 200 with `uuid: X` → `web_anchor`, exit 3, and `--write`
    anchors it (the existing path is untouched by ownership).
 5. **Owned, non-`.md` destination.** `owned/repo/blob/main/tool.py`, 200, no uuid → `web_unverifiable`,
-   exit 0.
-6. **Owned, immutable ref.** Three links, `blob/<40-hex>/a.md`, `blob/<7-hex>/a.md` and
-   `blob/v1.2.3/a.md`, all 200 without uuid → all three `web_unverifiable`, exit 0.
+   exit 0. And `owned/repo/blob/main/A.MD` **is** treated as Markdown (FR-005's case folding).
+6. **Owned, SHA-pinned.** `blob/<40-hex>/a.md` and `blob/<7-hex>/a.md`, 200 without uuid → both
+   `web_unverifiable`, exit 0. **And the negative that guards FR-006:** `blob/v1.2.3/a.md` — a ref
+   that looks like a tag — **does** produce `web_own_no_uuid`, exit 4.
 7. **Owned, 404.** With and without token → `web_not_found` / `web_unverifiable` exactly as today.
-8. **`auto` resolves.** A tree whose `origin` is `git@github.com:owned/src.git` behaves as
-   `--own owned`; both remote URL forms parse.
-9. **`auto` cannot resolve.** No `origin` → exit 1, message names the reason, no findings emitted —
-   **and the same with `--own explicit --own auto`**, where the owner set would not be empty (FR-003).
-10. **No extra fetch.** The mocked fetcher is called exactly as many times as without `--own`.
+8. **`--own-from-origin` resolves.** A repo whose `origin` is `git@github.com:owned/src.git` behaves
+   as `--own owned`; the `https://` form parses identically; and `--own other --own-from-origin`
+   treats **both** `other/…` and `owned/…` as owned (the union of FR-002).
+9. **`--own-from-origin` cannot resolve.** No `origin` → exit 1, message names the reason, no findings
+   emitted — **and the same with `--own explicit --own-from-origin`**, where the owner set would not
+   be empty (FR-003).
+10. **No extra fetch.** The mocked fetcher is called exactly as many times as without any owner set.
 11. **Opt-out.** A link followed by `<!-- darnlink-own-exempt -->` reports under its tolerated kind and
-    does not affect the exit code; the same link without the marker is `web_own_no_uuid`, exit 4.
-12. **Owner case.** `--own OWNED` against a `owned/repo/…` URL is owned, and vice versa (FR-001); the
-    parser preserves the case it found, so the comparison — not the parse — must fold it.
+    does not affect the exit code; the same link without the marker is `web_own_no_uuid`, exit 4. An
+    exempt link whose destination **does** have a uuid is **not** reported `web_anchor` and is **not**
+    rewritten under `--write` (FR-011). With both markers present in the normative order, the anchor is
+    still recognised and the file is byte-identical after a `--write` run.
+12. **Owner case.** `--own OWNED` against a `owned/repo/…` URL is owned, and vice versa (FR-001).
 13. **Budget.** With two owned uuid-less destinations: `--own-max 2` → both reported, exit **0**, and
-    the report says to lower the budget to 2; `--own-max 1` → exit **4**. `--own-max` with no `--own`
-    → exit 1.
+    the report says to lower the budget to 2; `--own-max 1` → exit **4**; `--own-max 2` with an
+    additional real `web_not_found` → exit **4** (FR-012). `--own-max` with no owner set → exit 1.
 14. **Composition.** The same failing link is silent when its file carries `darnlink-ignore-file`,
-    when it carries `darnlink-ignore-links`, and when it sits inside an `--ignore-block` region
-    (FR-014).
+    when it carries `darnlink-ignore-links`, and when it sits inside an `--ignore-block` region — while
+    a `web_not_found` in that same file is **still reported** (FR-014's by-kind filter).
 15. **JSON shape.** `--json` carries every `web_own_no_uuid` in `findings` with that literal `kind`,
     plus a `web_own_no_uuid` count in the summary object (FR-010).
 16. **The message does not lie.** The `web_own_no_uuid` text contains the owner, the repo, the path,
     and the word `frontmatter`, and does **not** contain `--write` (FR-008).
-17. **Other classifications untouched (FR-007).** With `--own owned` set, an owned destination that
-    returns 401/403, one that returns the transport-error sentinel, and a non-GitHub URL each keep
-    exactly the kind and exit contribution they have today.
+17. **Other classifications untouched (FR-007).** With an owner set, an owned destination that returns
+    401/403, one that returns the `-2` unreadable-repo sentinel, one that returns the transport-error
+    sentinel, and a non-GitHub URL each keep exactly the kind and exit contribution they have today.
 
 ## Out of scope
 
@@ -342,7 +413,7 @@ named sentence in P-IV.
 - **Push-permission-based ownership** — rejected above.
 - **`raw.githubusercontent.com` URLs.** 013's parser does not recognise that host at all (only
   `github.com/<owner>/<repo>/{blob,raw}/…`), so such a link never yields an owner and stays
-  `web_unverifiable`. The 345-link measurement above counts only what the parser recognises.
+  `web_unverifiable`. The measurement above counts only what the parser recognises.
 - **Repository renames and transfers.** Ownership is the owner **written in the URL**, not the current
   owner after a transfer — and GitHub's redirect makes the divergence invisible, because the fetch
   still succeeds. A repo you transferred away keeps reading as yours (an unfixable finding); one
@@ -352,9 +423,10 @@ named sentence in P-IV.
 
 ## Amendments the Constitution needs
 
-- **P-IV** — add to the network carve-out paragraph: *"The opt-in `--own auto` resolution reads the
-  scanned repository's `origin` remote, so in that mode the output is also a function of the clone's
-  git configuration; the explicit `--own` form has no such dependency and is the primary mechanism."*
+- **P-IV** — add to the network carve-out paragraph: *"The opt-in `--own-from-origin` resolution reads
+  the scanned repository's `origin` remote, so in that mode the output is also a function of the
+  clone's git configuration; the explicit `--own` form has no such dependency and is the primary
+  mechanism."*
 
 No other principle changes: the base rule is a pure textual predicate over data the run already holds.
 

--- a/specs/016-own-repo-web-strictness/spec.md
+++ b/specs/016-own-repo-web-strictness/spec.md
@@ -1,0 +1,259 @@
+# Feature Specification: fail on cross-repo web links to **your own** repos whose destination has no `uuid`
+
+**Feature Branch**: `016-own-repo-web-strictness`
+
+**Created**: 2026-08-11
+
+**Status**: Draft
+
+**Input**: Feature 013 gave darnlink a cross-repo web axis: `web-check --online` anchors a plain web
+link to the destination file's `uuid`, and verifies an already-anchored one. It is deliberately
+forgiving, because the destination lives in **someone else's repository** and cannot be fixed from
+here: when the destination returns 200 but carries **no `uuid`**, the link is reported
+`web_unverifiable` and the run still exits 0 (013 FR-011).
+
+That forgiveness is right for a third-party destination and **wrong for a destination you own**. If
+the target repo is yours, "the destination has no uuid" is not an external limitation — it is a
+missing two-line edit in a repo you control, and today nothing ever tells you so. This feature adds
+an opt-in flag that names the owners you control, and turns exactly that case into a failure whose
+message says what to add and where.
+
+---
+
+## The gap, precisely
+
+`_classify` collapses two very different situations into one non-failing bucket:
+
+| Situation | Today | Should be |
+|---|---|---|
+| 200, destination **has** a uuid, link plain | `web_anchor` (exit 3) | unchanged |
+| 200, destination has **no** uuid, destination **not yours** | `web_unverifiable` (exit 0) | unchanged — you cannot fix it |
+| 200, destination has **no** uuid, destination **yours** | `web_unverifiable` (exit 0) | **a failure**: add the uuid at the destination |
+| 404 (with token, readable repo) | `web_not_found` (exit 4) | unchanged |
+| 404 (no token) / repo unreadable | `web_unverifiable` (exit 0) | unchanged in this feature (see §The second rung) |
+
+The distinguishing datum — the destination's **owner** — is already parsed and sitting unused in
+`GithubUrl.owner`. Deciding ownership costs **no extra fetch**: it is a textual comparison on a value
+the run already has.
+
+---
+
+## Evidence this gap is real (measured, not hypothetical)
+
+Measured 2026-08-11 across a nine-repository private fleet, all of which already carry web links:
+
+- **345** GitHub `blob`/`raw` links in Markdown; **265 (77%)** point at repositories owned by the
+  same account as the linking repo. Cross-repo linking here is overwhelmingly *self*-linking.
+- Of the **46** own links still plain, resolving each destination against a local checkout:
+  **27 point at a `.md` whose frontmatter has no `uuid`** — every one of them invisible to every
+  darnlink axis today. Only 7 would already be caught as `web_anchor`.
+- Restricted to the repos that actually run the web axis today (`web: true`), the numbers are
+  **11 links** blocked on **8 destination files** across 3 repositories. All 8 were hand-written
+  documents; none was machine-generated.
+
+Two secondary measurements shape the design:
+
+- **In repos where the web axis is already on and fail-closed, the "destination has a uuid" column is
+  zero.** That is structural, not luck: such a link fails the gate as `web_anchor`, so it gets
+  anchored immediately. Everything still plain in those repos is, by construction, in the silent
+  bucket this feature targets. The axis has no overlap with what already exists.
+- **The practice is growing fast.** In the largest consumer, own web links went 1 → 3 → 3 → 39 →
+  **191** over twelve months (146 of them anchored). A 27-link backlog is not the point; the open
+  door is.
+
+One repository in the fleet mixes **26 own plain links with 30 third-party ones in the same tree** —
+the clearest statement of the problem: to tolerate the 30 you must today also tolerate the 26.
+
+---
+
+## Decision: an explicit owner list, `auto` as a convenience
+
+`web-check` gains **`--own OWNER`** (repeatable). A web link whose destination owner matches (ASCII
+case-insensitively, as GitHub logins are) is **owned**; every other link keeps today's behaviour
+exactly.
+
+`--own auto` derives the owner from the scanned repository's `origin` remote. It is a convenience,
+**not** the primary mechanism, because the explicit list is the only one that survives the real
+cases: a fork (origin is yours, the content is not), a vendored checkout of a foreign repo, and an
+organisation you push to whose name is not your login.
+
+**`auto` that cannot resolve is a usage error (exit 1), never a silent "nothing is owned".** Degrading
+to zero owned links would produce a green run that means nothing — the exact false pass this feature
+exists to remove (Principle II: never silent).
+
+### What fails, and the two things that deliberately do not
+
+The new finding fires **only** for: destination fetched 200 · destination has no `uuid` · owner is in
+the `--own` list. Two exclusions, both from measured cases in the fleet:
+
+- **A destination that is not `.md`** never fails. It cannot carry frontmatter, so demanding a `uuid`
+  is incoherent. This mirrors 015's FR-044 (anchoring stays `.md`-only). Measured: 2 such links.
+- **A destination pinned to an immutable ref** (a full 40-hex commit SHA) never fails. You cannot add
+  frontmatter to a past commit, so the finding would be unfixable by construction. Measured: 2 such
+  links against 262 on moving refs (`main`/`master`/`HEAD`).
+
+### The finding, and why exit 4 and not 3
+
+New kind **`web_own_no_uuid`**, exit **4** (integrity), not 3.
+
+Exit 3 means "a plain link darnlink can anchor for you — re-run with `--write`". This one darnlink
+**cannot** fix: the edit belongs to the destination repository, and Principle II forbids writing
+there. Reporting it as 3 would promise a `--write` that does nothing. The message must therefore
+carry everything the human or LLM layer needs to act in the *other* repo: owner, repo, path, and the
+literal instruction to add a `uuid` to that file's frontmatter.
+
+### The second rung (separate, off by default)
+
+A stricter variant — *"a destination you own must be **verifiable at all**"* — would also fail the
+`web_unverifiable` cases when the owner is yours: a 404 without a token, and a 404 in a repo the
+token cannot read. The reasoning is sound (for your own repo, "I could not check" is a provisioning
+failure, not an external limit), but it is a **different rung** and must ship off by default: turning
+it on together with the base rule reproduces the wall of false breaks that 013's tokenless-404 carve
+out was written to prevent. Not specified further here; named so the base rule is not quietly widened
+into it later.
+
+### Adoption: a budget, not a cliff
+
+The gate recipe gains `own_web` (off · on) and **`own_web_max` (int, default 0)**, the same ratchet
+shape as `dangling_max`: fail only above the budget, and print the "lower it to N" nudge when the
+count drops. Without it, switching the axis on fails several repos at once on day one, and an axis
+that cannot be adopted incrementally gets turned off instead of obeyed — the lesson 015 already paid.
+
+### Escape hatch (required, and it is not 005's)
+
+A destination may be **machine-regenerated**, where a `uuid` is futile: the next regeneration wipes it
+and the anchor points at nothing — strictly worse than a plain link. That is exactly the case 005
+handles with `--no-create-frontmatter-for`, but **005's deny-list cannot be reused here**: it matches
+basenames of targets *in your own tree*, and from the linking repo you cannot see whether a file in
+another repo is generated. Without an opt-out, such a link would be permanently un-greenable, and a
+permanently red axis gets disabled. The opt-out belongs in the **source** repo (where the knowledge
+is), not in the destination.
+
+---
+
+## Prerequisite (external to this spec)
+
+`web-check --online` currently **crashes** — it does not fail, it raises — when a Markdown href
+contains whitespace: `_GITHUB_BLOB_RE` accepts spaces in its path group, and `http.client.InvalidURL`
+derives from `HTTPException`, not `OSError`, so it escapes `_fetch_once`'s `except` clause. This
+violates 013's FR-008 (an unrecognised URL shape is `web_unverifiable`, never a crash) and FR-009 (no
+transport error propagates as an exception). Any repository that mirrors third-party content is
+liable to contain such an href. Fixed separately; this axis is not adoptable before it.
+
+---
+
+## Constitution Check *(mandatory)*
+
+Reviewed against `.specify/memory/constitution.md` v1.1.0.
+
+- **P-I Single Responsibility:** the new competence is *comparing one string from a URL darnlink has
+  already parsed*. No document semantics, no entity model. It stays inside the non-core `web-check`
+  adjunct; the two core operations remain two. **Held.** ✅
+- **P-II Safe by Default:** the finding is report-only and, unlike every other web finding, is
+  **unfixable by `--write` on purpose** — darnlink never writes to the destination repository. The
+  feature adds no write path at all. **Held, and reinforced.** ✅
+- **P-III Plain, Self-Contained:** nothing is stored in either repository. The owner list is *tool
+  configuration* (a flag, or a key in the gate recipe alongside `mode`/`web`/`dangling`), not a
+  `uuid → path` index — it is not the manifest 013 rejected under this principle. **Held.** ✅
+- **P-IV Deterministic:** with an explicit `--own`, output remains a function of *(tree + live
+  responses)* — the same conditional determinism 013 already declared, with nothing added. With
+  **`--own auto` it also becomes a function of the clone's git configuration**: the same tree yields
+  different verdicts in a fork or a mirror. That is a new, small dependency on state outside the
+  tree, and it is why explicit is primary and `auto` opt-in. **Amendment required** (see below).
+  ⚠️ (only for `auto`)
+
+**Bottom line:** the base rule costs the constitution **nothing**; only the `auto` convenience needs a
+named sentence in P-IV.
+
+---
+
+## Alternatives considered (and why rejected)
+
+- **Infer ownership from push permission** (`GET /repos/{o}/{r}` → `permissions.push`). Semantically
+  the most correct definition of "controllable", and it is the question the user actually means. But
+  it costs a second request per repo, and the answer varies with the token: the same tree passes on a
+  laptop with a write PAT and fails in CI with a read-only one. Verdict-by-credential is worse than a
+  slightly coarse owner match. **Rejected on reproducibility.**
+- **Make it unconditional (every 200-without-uuid fails).** Simple, and wrong: it fails on
+  destinations nobody here can edit, which is precisely the behaviour 013 chose against.
+- **Infer "own" from the destination repo being cloned next to the source.** Revives the
+  sibling-checkout coupling 013 already rejected as alternative (c), and makes the verdict depend on
+  what happens to be on disk.
+- **Fold it into `mode: max`.** The web axis is already coupled to `mode=max` in the recipe; adding a
+  second coupling would make this rung unreachable for any repo that cannot pay the local ratchet.
+  It is a separate axis with a separate budget, like `dangling`.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001** `web-check` MUST accept `--own OWNER`, repeatable. A destination whose parsed owner
+  equals any given value (ASCII case-insensitive) is **owned**. With no `--own`, behaviour MUST be
+  byte-identical to today.
+- **FR-002** `--own auto` MUST derive the owner from the scanned repository's `origin` remote,
+  accepting both the `https://github.com/<owner>/<repo>` and `git@github.com:<owner>/<repo>` forms.
+  It MUST combine with explicit `--own` values (union).
+- **FR-003** If `--own auto` cannot resolve an owner (no repository, no `origin`, non-GitHub remote),
+  the run MUST exit **1** with a message naming the reason. It MUST NOT proceed with an empty owner
+  set.
+- **FR-004** A link classified `web_unverifiable` **solely** because the fetched destination returned
+  200 with no frontmatter `uuid`, whose owner is owned, MUST instead be reported
+  **`web_own_no_uuid`**, and MUST set the exit code to **4**.
+- **FR-005** FR-004 MUST NOT fire when the destination path does not end in `.md`.
+- **FR-006** FR-004 MUST NOT fire when the URL's ref is an immutable full commit SHA (40 hex chars).
+- **FR-007** No other classification changes. In particular a 404 (with or without token), an
+  unreadable repo, a non-GitHub URL and a transport error MUST keep today's kind and exit
+  contribution, owned or not.
+- **FR-008** The `web_own_no_uuid` message MUST name owner, repo, destination path, and state the
+  action (add a `uuid` to that file's frontmatter in that repository). It MUST NOT suggest `--write`.
+- **FR-009** Ownership MUST be decided without any additional network request.
+- **FR-010** `--json` MUST emit the new kind under its own `kind`, and include a `web_own_no_uuid`
+  count in the summary object, so a gate can branch on it and apply a budget.
+- **FR-011** A per-link opt-out MUST exist for destinations that are machine-regenerated, expressed in
+  the **source** repository. A link carrying it MUST be reported as tolerated (never silently
+  dropped) and MUST NOT contribute to the exit code.
+
+### Key Entities
+
+- **Owner set** — the values from `--own` (plus `auto`'s resolution). Pure configuration; never
+  persisted in either repository.
+- **`web_own_no_uuid`** — a fourteenth finding kind: a destination *you control* that has not been
+  given the `uuid` its inbound cross-repo link needs.
+
+## Acceptance (all with a mocked fetcher — no test touches the network)
+
+1. **Owned, no uuid.** Plain link to `owned/repo/blob/main/a.md`, destination returns 200 with no
+   `uuid`, `--own owned` → `web_own_no_uuid`, exit 4; the message names `owned/repo` and `a.md`.
+2. **Not owned, no uuid.** Same fetch, `--own someone-else` → `web_unverifiable`, exit 0 (unchanged).
+3. **No flag.** Same fetch, no `--own` → `web_unverifiable`, exit 0 (unchanged).
+4. **Owned, has uuid.** Destination returns 200 with `uuid: X` → `web_anchor`, exit 3, and `--write`
+   anchors it (the existing path is untouched by ownership).
+5. **Owned, non-`.md` destination.** `owned/repo/blob/main/tool.py`, 200, no uuid → `web_unverifiable`,
+   exit 0.
+6. **Owned, SHA-pinned.** `owned/repo/blob/<40-hex>/a.md`, 200, no uuid → `web_unverifiable`, exit 0.
+7. **Owned, 404.** With and without token → `web_not_found` / `web_unverifiable` exactly as today.
+8. **`auto` resolves.** A tree whose `origin` is `git@github.com:owned/src.git` behaves as
+   `--own owned`; both remote URL forms parse.
+9. **`auto` cannot resolve.** No `origin` → exit 1, message names the reason, no findings emitted.
+10. **No extra fetch.** The mocked fetcher is called exactly as many times as without `--own`.
+11. **Opt-out.** A link marked with the FR-011 opt-out reports as tolerated and does not affect the
+    exit code.
+
+## Out of scope
+
+- **The second rung** (failing owned `web_unverifiable` for 404 / unreadable repo) — named above,
+  specified separately if wanted.
+- **Writing the `uuid` into the destination repository**, by any means, including a checked-out
+  sibling. Principle II; also 013's rejected alternative (c).
+- **Non-GitHub forges** — ownership is parsed from the GitHub URL shape, as in 013.
+- **Push-permission-based ownership** — rejected above.
+
+## Amendments the Constitution needs
+
+- **P-IV** — add to the network carve-out paragraph: *"The opt-in `--own auto` resolution reads the
+  scanned repository's `origin` remote, so in that mode the output is also a function of the clone's
+  git configuration; the explicit `--own` form has no such dependency and is the primary mechanism."*
+
+No other principle changes: the base rule is a pure textual predicate over data the run already holds.

--- a/specs/016-own-repo-web-strictness/spec.md
+++ b/specs/016-own-repo-web-strictness/spec.md
@@ -71,8 +71,13 @@ Two secondary measurements shape the design:
 Two caveats stated rather than buried, because the whole case rests on these numbers:
 
 - **The snapshot is post-remediation.** On the day of measurement, 11 of these links were fixed by
-  hand — `uuid` added to 8 destination files, then anchored — precisely to let the new axis start at
-  zero. Before that day the uuid-less bucket was 27.
+  hand — `uuid` added to 8 destination files, then anchored — precisely to keep the new axis's opening
+  budget small. An earlier count that day put the uuid-less bucket at 27, but under a **wider scope**
+  (it included vendored `clones/` and `mirrors/`), so the two figures are **not subtractable**; only
+  the 17 above is measured under the scope stated here.
+- **The 17 is a floor, not a total.** Seven more links point at repositories not checked out locally,
+  so they could not be resolved offline; some of those destinations may also lack a `uuid`. The honest
+  headline is *"17 confirmed, up to 24"*.
 - **Every ref in the fleet is a branch**: `main` 201, `master` 20, `HEAD` 7, and nothing else across
   all 228. The immutable-ref exclusion below is therefore **reasoning, not measurement** — it has zero
   occurrences today and is specified so the first one does not become an unfixable failure.
@@ -151,8 +156,11 @@ into it later.
 
 ### Adoption: a budget, not a cliff
 
-The gate recipe gains `own_web` (the owner list, or `origin`) and **`own_web_max`**: fail only above
-the budget, and print the "lower it to N" nudge when the count drops. Without it, switching the axis
+The gate recipe gains `own_web` (a list of owner names), `own_web_from_origin` (a boolean) and
+**`own_web_max`**: fail only above the budget, and print the "lower it to N" nudge when the count
+drops. The boolean is separate for the same reason the CLI has a separate flag and not an `auto`
+value — putting `origin` inside the list re-creates, one layer down, the sentinel collision this
+design rejected above. Without it, switching the axis
 on fails several repos at once on day one, and an axis that cannot be adopted incrementally gets
 turned off instead of obeyed — the lesson 015 already paid.
 
@@ -189,9 +197,18 @@ the exemption second.
 [text](url) <!-- web-uuid: X --> <!-- darnlink-own-exempt -->
 ```
 
-Getting this wrong is not cosmetic: with the exemption first, the link parses as *plain*, and under
-`--write` a **second** `<!-- web-uuid: X -->` is appended after the exemption, silently corrupting the
-line. FR-011 and its acceptance scenario pin the order for exactly that reason.
+**Measured, because the obvious rationale for this is wrong and was written down once already.** With
+the exemption first and no anchor, `--write` inserts the anchor *before* the untouched exemption, so
+the line **self-heals into the normative order** — no corruption. The corruption is a different case:
+an anchor that already sits **after** the exemption,
+
+```
+[text](url) <!-- darnlink-own-exempt --> <!-- web-uuid: X -->
+```
+
+which the tail regex cannot see, so the link reads as plain and a **second** anchor is appended,
+leaving two. That is the case the acceptance scenario must assert, and the reason the order is
+normative rather than advisory.
 
 Why not each of the three opt-outs that already exist, in the order someone will suggest them:
 
@@ -201,8 +218,9 @@ Why not each of the three opt-outs that already exist, in the order someone will
 - **006's file-level `darnlink-ignore-links`** is too blunt: it disables link handling for the
   **whole file**, including the core's intra-repo robustify. Exempting one cross-repo link must not
   cost the file its local link healing.
-- **`--ignore-block`** works on regions, not links, and web-check already honours it — it is the right
-  tool for a generated *section*, and it stays available. It is not a per-link exemption.
+- **`--ignore-block`** works on regions, not links, and web-check already honours it by dropping the
+  link **before any finding exists** — it is the right tool for a generated *section*, and it stays
+  exactly as it is. It is not a per-link exemption, and FR-014 must not turn it into one.
 
 **Composition is a requirement, not a bonus** — and it is not free today: web-check currently ignores
 the 003 and 006 file-level markers entirely (it only skips `--ignore-block` regions and code fences).
@@ -303,52 +321,78 @@ convenience needs a named sentence in P-IV.
   **`web_own_no_uuid`**, and MUST set the exit code to **4** (subject to FR-012).
 - **FR-005** FR-004 MUST NOT fire when the destination path does not end in `.md`, compared
   **case-insensitively** (`iter_markdown_files` already lowercases; `A.MD` is a Markdown file).
-- **FR-006** FR-004 MUST NOT fire when the URL's ref matches `^[0-9a-f]{7,40}$` — a commit SHA, long
-  or short. The test MUST be purely textual: no other ref shape is excluded, and in particular a tag
-  MUST NOT be, because a tag is textually indistinguishable from a branch of the same name and
-  telling them apart needs the network (see §What fails).
+- **FR-006** FR-004 MUST NOT fire when the URL's ref matches `^[0-9a-fA-F]{7,40}$` — a commit SHA,
+  long or short, in either case (GitHub accepts an uppercase SHA in a blob URL, and FR-001 and FR-005
+  both fold case; a rule that did not would make such a link an unfixable failure). The test MUST be
+  purely textual: no other ref shape is excluded, and in particular a tag MUST NOT be, because a tag
+  is textually indistinguishable from a branch of the same name and telling them apart needs the
+  network (see §What fails).
 - **FR-007** No other classification changes. In particular a 404 (with or without token), an
   unreadable repo (the `-2` sentinel), a non-GitHub URL and a transport error MUST keep today's kind
   and exit contribution, owned or not.
 - **FR-008** The `web_own_no_uuid` message MUST name owner, repo, destination path, and state the
   action (add a `uuid` to that file's frontmatter in that repository). It MUST NOT suggest `--write`.
 - **FR-009** Ownership and every exclusion MUST be decided without any additional network request.
-- **FR-010** `--json` MUST emit the new kind under its own `kind`, and include a `web_own_no_uuid`
-  count in the summary object, so a consumer can report on it.
-- **FR-011** A link followed by **`<!-- darnlink-own-exempt -->`** MUST be exempt from FR-004 **and
-  from 013's FR-005** (`web_anchor`): an exempt link is never anchored, under `--write` or otherwise —
-  anchoring it is the very damage the marker exists to prevent, since the destination's `uuid` will
-  not survive its next regeneration. When combined with an anchor the order is normative — 
+- **FR-010** `--json` MUST emit both new kinds (`web_own_no_uuid`, `web_own_exempt`) under their own
+  `kind`, and include a count of each in the summary object, so a consumer can report on them.
+- **FR-011** A link followed by **`<!-- darnlink-own-exempt -->`** MUST be exempt from **three**
+  verdicts, and from exactly three:
+  - **FR-004** (`web_own_no_uuid`) — the point of the marker.
+  - **013's FR-005** (`web_anchor`) — an exempt link is never anchored, under `--write` or otherwise;
+    anchoring it is the very damage the marker exists to prevent, since the destination's `uuid` will
+    not survive its next regeneration.
+  - **`web_mismatch`** — without this the escape hatch does not escape. A destination that
+    regenerates is precisely one whose `uuid` drifts, and the normal migration path (adding the marker
+    to a link anchored earlier) would otherwise leave a permanent exit-4 `web_mismatch` — the same
+    dead end by another door.
+
+  It MUST **not** exempt from `web_not_found`: a dead link is dead whether or not its destination is
+  regenerated, and that is still worth failing on.
+
+  When combined with an anchor the order is normative —
   `[text](url) <!-- web-uuid: X --> <!-- darnlink-own-exempt -->` — because both markers claim the
-  position immediately after `)`. The link MUST still be reported, as its own tolerated kind, and MUST
-  NOT contribute to the exit code: silently dropping it would hide the exemption from whoever audits
-  the repo later.
+  position immediately after `)`. The link MUST still be reported, under the kind **`web_own_exempt`**,
+  and MUST NOT contribute to the exit code: silently dropping it would hide the exemption from whoever
+  audits the repo later.
 - **FR-012** `web-check` MUST accept **`--own-max N`**. While the number of `web_own_no_uuid` findings
   is **at or below** `N`, they MUST NOT contribute to the exit code; above `N`, FR-004's exit 4
-  applies. Other exit-4 causes are unaffected: one budgeted finding plus one real `web_not_found`
+  applies. The count is of **findings, not destinations**: two links in different files pointing at
+  the same uuid-less file cost 2, and one edit at the destination clears both. `web_own_exempt` never
+  counts. Other exit-4 causes are unaffected: one budgeted finding plus one real `web_not_found`
   still exits 4. The findings are always reported — the budget silences the *verdict*, never the
   *finding*. Omitting the flag MUST be distinguishable from `--own-max 0` (default `None`), and
   `--own-max` without any owner set MUST be a usage error (exit 1).
 - **FR-013** When the count is at or below a non-zero `--own-max`, the report MUST print the count and
   say that lowering the budget to that number keeps the ratchet; when the count reaches **zero** it
   MUST say to drop the flag entirely. Both nudges, as `dangling_max` gives. A budget nobody is told to
-  lower is a budget that never goes down.
-- **FR-014** The new finding MUST compose with the existing opt-outs: a file carrying
-  `darnlink-ignore-file` (003) or `darnlink-ignore-links` (006), and any region inside an
-  `--ignore-block` marker, MUST NOT produce it. This is a filter **by kind**, applied to
-  `web_own_no_uuid` only — it MUST NOT suppress `web_mismatch`, `web_not_found` or any other web
-  finding in that file, which would silently violate FR-007. That is a **third** semantics for those
-  markers, narrower than the "removed from the darnlink graph entirely" the core gives them, and it
-  is declared here rather than left to the implementer. Today `web-check` honours only
-  `--ignore-block` and code fences, so 003 and 006 are new work here, not an existing guarantee (this
-  mirrors 015's FR-045).
-- **FR-015** The gate recipe MUST expose `own_web` (a list of owner names, or the string `origin`
-  meaning `--own-from-origin`) and `own_web_max` (int), passing them through as `--own` / 
-  `--own-from-origin` / `--own-max`. Because FR-003 and FR-012 make **exit 1 reachable from
-  configuration**, the recipe MUST treat exit 1 from `web-check` as a *tool/usage* error — its
-  existing fail-open-and-warn path — and MUST NOT report it as a repository verdict. Today the recipe
-  documents web-check's contract as "0/3/4, every non-zero fail-closed"; that contract is what this
-  requirement changes.
+  lower is a budget that never goes down. The run's outcome word MUST also reflect the budget: today
+  exit 0 prints `clean`, and printing `clean` with findings on screen is exactly the misreading this
+  project's consumers have already paid for — under budget it MUST say so instead.
+- **FR-014** The new finding MUST compose with the file-level opt-outs: a file carrying
+  `darnlink-ignore-file` (003) or `darnlink-ignore-links` (006) MUST NOT produce it. This is a filter
+  **by kind**, applied to `web_own_no_uuid` only — it MUST NOT suppress `web_mismatch`,
+  `web_not_found` or any other web finding in that file, which would silently violate FR-007. That is
+  a **third** semantics for those markers, narrower than the "removed from the darnlink graph
+  entirely" the core gives them, and it is declared here rather than left to the implementer. Today
+  `web-check` honours neither, so this is new work, not an existing guarantee (mirroring 015's
+  FR-045).
+- **FR-014b** `--ignore-block` is **out of FR-014 and unchanged**. It already suppresses the link
+  *before any finding exists* (`find_web_links` skips the span), so it emits nothing at all today.
+  Folding it into FR-014's by-kind rule would make links inside an ignored region start producing
+  `web_not_found` — a behaviour change FR-007 forbids. Stated because the natural reading of "compose
+  with the existing opt-outs" gets this backwards.
+- **FR-015** **Both** gate recipes — the bash `darnlink-gate` and its PowerShell twin, which carries
+  the same web pass and the same verbatim-exit-code contract — MUST expose `own_web` (a list of owner
+  names), `own_web_from_origin` (bool) and `own_web_max` (int), passing them through as `--own` /
+  `--own-from-origin` / `--own-max`. A single-surface implementation is how the two recipes have
+  already drifted (`dangling_max` exists in one and not the other).
+- **FR-016** Because FR-003 and FR-012 make **exit 1 reachable from a configuration typo**, the
+  recipes MUST treat exit 1 from `web-check` as a *usage* error and MUST NOT report it as a repository
+  verdict. It MUST NOT be routed to the recipe's `bail()` helper, which **exits the whole script**: a
+  forgotten `own_web` beside an `own_web_max` would then produce a green gate that also silently skips
+  the create-readme and dangling axes — the precise bug the recipe already documents and fixed once
+  with `RC_IS_FINAL`. The required shape is the create-readme axis's: warn, preserve any already
+  failing `rc`, and let every remaining axis run.
 
 ### Key Entities
 
@@ -357,6 +401,21 @@ convenience needs a named sentence in P-IV.
 - **`web_own_no_uuid`** — the **sixth** web finding kind (beside `web_ok`, `web_anchor`,
   `web_mismatch`, `web_not_found`, `web_unverifiable`): a destination *you control* that has not been
   given the `uuid` its inbound cross-repo link needs.
+- **`web_own_exempt`** — the **seventh**: a link whose FR-011 marker takes it out of the three
+  verdicts listed there. Reported, never silent, never part of the exit code, and included in
+  `--json` like any other kind (FR-010).
+
+### Precedence, when several rules apply to the same link
+
+Evaluated in this order, first match wins, so every combination has one answer:
+
+1. **`--ignore-block` / code fence** — the link is never seen (FR-014b).
+2. **FR-014's file markers** — `web_own_no_uuid` is filtered; other web kinds survive.
+3. **FR-011's exemption** — `web_own_exempt`. It wins over FR-005/FR-006, so an exempt link to a
+   `.py` or to a SHA-pinned path reports `web_own_exempt`, not `web_unverifiable`: the author said
+   "leave this link alone", which is the more specific statement.
+4. **FR-005 / FR-006** — `web_unverifiable`, unchanged.
+5. **FR-004** — `web_own_no_uuid`, subject to FR-012's budget.
 
 ## Acceptance
 
@@ -383,18 +442,26 @@ resolves through `git config`.
    emitted — **and the same with `--own explicit --own-from-origin`**, where the owner set would not
    be empty (FR-003).
 10. **No extra fetch.** The mocked fetcher is called exactly as many times as without any owner set.
-11. **Opt-out.** A link followed by `<!-- darnlink-own-exempt -->` reports under its tolerated kind and
-    does not affect the exit code; the same link without the marker is `web_own_no_uuid`, exit 4. An
-    exempt link whose destination **does** have a uuid is **not** reported `web_anchor` and is **not**
-    rewritten under `--write` (FR-011). With both markers present in the normative order, the anchor is
-    still recognised and the file is byte-identical after a `--write` run.
+11. **Opt-out.** A link followed by `<!-- darnlink-own-exempt -->` reports `web_own_exempt` and does
+    not affect the exit code; the same link without the marker is `web_own_no_uuid`, exit 4. An exempt
+    link whose destination **does** have a uuid is **not** reported `web_anchor` and is **not**
+    rewritten under `--write`; an exempt **anchored** link whose destination uuid has **changed** is
+    **not** `web_mismatch` (FR-011's third exemption, the one that makes the hatch escape). With both
+    markers in the normative order the anchor is still recognised and the file is byte-identical after
+    `--write`. **And the corruption case**: with the anchor written *after* the exemption, `--write`
+    must not append a second anchor — the file ends with exactly one.
+11b. **Exempt beats the other exclusions.** An exempt link to a `.py`, and an exempt link on a
+    SHA-pinned ref, both report `web_own_exempt` rather than `web_unverifiable` (§Precedence).
 12. **Owner case.** `--own OWNED` against a `owned/repo/…` URL is owned, and vice versa (FR-001).
-13. **Budget.** With two owned uuid-less destinations: `--own-max 2` → both reported, exit **0**, and
-    the report says to lower the budget to 2; `--own-max 1` → exit **4**; `--own-max 2` with an
-    additional real `web_not_found` → exit **4** (FR-012). `--own-max` with no owner set → exit 1.
-14. **Composition.** The same failing link is silent when its file carries `darnlink-ignore-file`,
-    when it carries `darnlink-ignore-links`, and when it sits inside an `--ignore-block` region — while
-    a `web_not_found` in that same file is **still reported** (FR-014's by-kind filter).
+13. **Budget.** With two owned uuid-less destinations: `--own-max 2` → both reported, exit **0**, the
+    outcome word is not `clean`, and the report says to lower the budget to 2; `--own-max 1` → exit
+    **4**; `--own-max 2` with an additional real `web_not_found` → exit **4** (FR-012). `--own-max`
+    with no owner set → exit 1. Two links in **different files** pointing at the **same** uuid-less
+    destination count as **2** (FR-012 counts findings, not destinations).
+14. **Composition.** The same failing link is silent when its file carries `darnlink-ignore-file` and
+    when it carries `darnlink-ignore-links`, while a `web_not_found` in that same file is **still
+    reported** (FR-014's by-kind filter). A link inside an `--ignore-block` region produces **nothing
+    at all**, as today — including no `web_not_found` (FR-014b).
 15. **JSON shape.** `--json` carries every `web_own_no_uuid` in `findings` with that literal `kind`,
     plus a `web_own_no_uuid` count in the summary object (FR-010).
 16. **The message does not lie.** The `web_own_no_uuid` text contains the owner, the repo, the path,
@@ -438,3 +505,14 @@ No other principle changes: the base rule is a pure textual predicate over data 
   PR so the amendment and the correction are reviewable apart.
 - **FR-009 of 013** should be restated to cover client-side validation errors, not only transport
   errors — see §Prerequisite.
+- **`_GITHUB_BLOB_RE` mis-parses a branch containing a slash.** `(?P<ref>[^/]+)` stops at the first
+  separator, so `blob/release/1.2/docs/a.md` yields `ref='release'` and `path='1.2/docs/a.md'` — the
+  wrong file, fetched and reported as `web_not_found`. Pre-existing in 013, but this spec makes `ref`
+  load-bearing (FR-006) and rests part of its case on *"every ref in the fleet is a branch"*, so it is
+  named here. Fixing it needs the ref/path split to be resolved against the repo's branch list, i.e.
+  the network — the same wall as the tag question, and the reason it stays a known limit rather than a
+  requirement.
+- **P-II is untouched by the letter of this spec but not by its spirit**: `--own-from-origin` makes
+  darnlink spawn an external process for the first time. Worth a sentence when the constitution is
+  amended for P-IV, along with the `safe.directory` failure mode (`git` refusing a repo it considers
+  dubiously owned), which FR-003 should list among its exit-1 reasons.

--- a/specs/016-own-repo-web-strictness/spec.md
+++ b/specs/016-own-repo-web-strictness/spec.md
@@ -112,8 +112,9 @@ the same false pass by a smaller door.
 
 ### What fails, and the two things that deliberately do not
 
-The new finding fires **only** for: destination fetched 200 · destination has no `uuid` · owner is in
-the owner set. Two exclusions:
+The new finding fires **only** for: destination fetched 200 · its frontmatter has no `uuid` and is not
+rejected by the reader · owner is in the owner set. Two exclusions on top of that (a third, free one —
+an href that cannot be sent has no owner at all — is in §Prerequisite):
 
 - **A destination that is not `.md`** (compared case-insensitively, as `iter_markdown_files` already
   does) never fails. It cannot carry frontmatter, so demanding a `uuid` is incoherent. This mirrors
@@ -128,7 +129,8 @@ identical**, so honouring it would require `GET /repos/{o}/{r}/git/refs` — a n
 FR-009 and against the "no extra fetch" acceptance — and its failure direction is the worst one: a
 maintenance branch (`v2`, `release-1.2`) would be excluded for *looking like* a tag, producing a
 false green, which is the exact failure this feature exists to remove. The rule is therefore
-`^[0-9a-f]{7,40}$` and nothing else. A tag-pinned link that genuinely cannot be fixed uses the FR-011
+`^[0-9a-fA-F]{7,40}$` and nothing else — case-folded, like FR-001 and FR-005. A tag-pinned link
+that genuinely cannot be fixed uses the FR-011
 marker, which is what it is for.
 
 That rule has its own small false-green — a branch named `deadbeef` — accepted knowingly: it is
@@ -232,20 +234,24 @@ the 003 and 006 file-level markers entirely (it only skips `--ignore-block` regi
 
 ---
 
-## Prerequisite (external to this spec)
+## Prerequisite — resolved upstream while this spec was in review
 
-`web-check --online` currently **crashes** — it does not fail, it raises — when a Markdown href
-contains whitespace: `_GITHUB_BLOB_RE` accepts spaces in its path group, and `http.client.InvalidURL`
-derives from `HTTPException`, not `OSError`, so it escapes `_fetch_once`'s `except` clause. Any
-repository that mirrors third-party content is liable to contain such an href.
+`web-check --online` used to **crash** — not fail, raise — on an href containing whitespace or a
+control character, and again on a non-ASCII path. **Fixed in `main`**: the href is now rejected before
+the parse, every URL field is percent-encoded, and a client-side URL error maps to its own
+non-retryable sentinel rather than escaping the `except` clause. This spec no longer waits on it.
 
-**And 013 does not actually forbid it — which is worse than a violation.** FR-008 covers an
-*unrecognised* URL shape, and this one **is** recognised: the regex matches it happily and the run
-dies later, at the fetch. FR-009 covers *"network/transport errors (timeout, DNS, connection reset)"*,
-and a client-side URL validation error is none of those. So the crash falls through the gap between
-two requirements that were each written assuming the other covered it. The fix therefore also wants
-FR-009 restated as *"no error raised by the fetch layer — transport **or** client-side validation —
-propagates as an exception"*. Fixed separately; this axis is not adoptable before it.
+Two things survive the fix and belong here:
+
+- **A third exclusion, free and already in place.** An href that cannot be sent yields no
+  `GithubUrl` at all, so it has no owner and can therefore never be `web_own_no_uuid`. It is not
+  listed beside FR-005 and FR-006 because it is not a rule this feature applies — it is a consequence
+  of the parser refusing the input — but an implementer should know why that path never reaches the
+  new finding.
+- **013's wording is still wrong**, even though its code is now right: FR-008 covers an *unrecognised*
+  URL shape (the regex accepted these) and FR-009 is worded for *transport* errors (this was
+  client-side validation), so the crash fell through the gap between two requirements each written
+  assuming the other covered it. See §Housekeeping.
 
 ---
 
@@ -328,7 +334,8 @@ convenience needs a named sentence in P-IV.
 - **FR-004** A link classified `web_unverifiable` **solely** because the fetched destination returned
   200 with **no frontmatter at all, or frontmatter without a `uuid`**, whose owner is owned, MUST
   instead be reported **`web_own_no_uuid`**, and MUST set the exit code to **4** (subject to FR-012).
-  A destination whose frontmatter is present but **invalid YAML** MUST NOT produce it — it stays
+  A destination whose frontmatter is present but **rejected by the canonical reader** — unparseable
+  YAML, or a `uuid` that is not a string scalar — MUST NOT produce it — it stays
   `web_unverifiable` — because telling someone to *add* a `uuid` to a file whose frontmatter does not
   parse is the wrong instruction for a different defect. Note where the work is: the frontmatter reader
   **already** distinguishes absent from invalid; it is the caller that throws the distinction away by
@@ -385,8 +392,9 @@ convenience needs a named sentence in P-IV.
   the same uuid-less file cost 2, and one edit at the destination clears both. `web_own_exempt` never
   counts. Other exit-4 causes are unaffected: one budgeted finding plus one real `web_not_found`
   still exits 4. The findings are always reported — the budget silences the *verdict*, never the
-  *finding*. Omitting the flag MUST be distinguishable from `--own-max 0` (default `None`), and
-  `--own-max` without any owner set MUST be a usage error (exit 1).
+  *finding*. Omitting the flag MUST be distinguishable from `--own-max 0` (default `None`); the observable
+  difference is FR-013's message, not the exit code, which is the same for both. `--own-max` without
+  any owner set MUST be a usage error (exit 1).
 - **FR-013** When the count is at or below a non-zero `--own-max`, the report MUST print the count and
   say that lowering the budget to that number keeps the ratchet; when the count reaches **zero** it
   MUST say to drop the flag entirely. Both nudges, as `dangling_max` gives. A budget nobody is told to
@@ -406,7 +414,10 @@ convenience needs a named sentence in P-IV.
   a **third** semantics for those markers, narrower than the "removed from the darnlink graph
   entirely" the core gives them, and it is declared here rather than left to the implementer. Today
   `web-check` honours neither, so this is new work, not an existing guarantee (mirroring 015's
-  FR-045).
+  FR-045). **And it goes no further than that:** FR-007 keeps `web_anchor` alive in such a file, so
+  `--write` still anchors its plain web links. That sits uneasily beside 006's FR-033 ("left untouched
+  by every operation"), and deliberately so — closing it is a change against 006's contract, not a
+  corner of this one, and it must not be smuggled in here.
 - **FR-015** `--ignore-block` is **out of FR-014 and unchanged**. It already suppresses the link
   *before any finding exists* (`find_web_links` skips the span), so it emits nothing at all today.
   Folding it into FR-014's by-kind rule would make links inside an ignored region start producing
@@ -447,7 +458,7 @@ layer that in fact decides most verdicts.
 
 **Axis 2 — classification, after the fetch. Status decides first:**
 
-3. Anything other than 200 — 401/403, the `-2` unreadable-repo sentinel, 404, a transport error —
+3. Anything other than 200 — 401/403, the `-2` unreadable-repo sentinel, the `-3` unsendable-URL sentinel, 404, a transport error —
    keeps **exactly** today's kind, for every link, exempt or not (FR-007). In particular an exempt
    link whose destination 404s is `web_not_found`, because a dead link is dead either way.
 4. On **200 only**: FR-011's exemption → `web_own_exempt`, which also covers the `web_mismatch` and
@@ -483,8 +494,9 @@ resolves through `git config`.
    anchors it (the existing path is untouched by ownership).
 5. **Owned, non-`.md` destination.** `owned/repo/blob/main/tool.py`, 200, no uuid → `web_unverifiable`,
    exit 0. And `owned/repo/blob/main/A.MD` **is** treated as Markdown (FR-005's case folding).
-6. **Owned, SHA-pinned.** `blob/<40-hex>/a.md` and `blob/<7-hex>/a.md`, 200 without uuid → both
-   `web_unverifiable`, exit 0. **And the negative that guards FR-006:** `blob/v1.2.3/a.md` — a ref
+6. **Owned, SHA-pinned.** `blob/<40-hex>/a.md`, `blob/<7-hex>/a.md` and the same 40-hex ref in
+   **UPPERCASE**, 200 without uuid → all three `web_unverifiable`, exit 0. The uppercase case is the
+   guard: a rule that did not fold case would make such a link an unfixable failure. **And the negative that guards FR-006:** `blob/v1.2.3/a.md` — a ref
    that looks like a tag — **does** produce `web_own_no_uuid`, exit 4. **And the carve-out is not a
    verdict:** the same SHA-pinned link whose destination *does* carry a uuid is still `web_anchor`,
    exit 3, and `--write` still anchors it.
@@ -495,7 +507,8 @@ resolves through `git config`.
 9. **`--own-from-origin` cannot resolve.** No `origin` → exit 1, message names the reason, no findings
    emitted — **and the same with `--own explicit --own-from-origin`**, where the owner set would not
    be empty (FR-003).
-10. **No extra fetch.** The mocked fetcher is called exactly as many times as without any owner set.
+10. **No extra fetch (FR-009).** The mocked fetcher is called exactly as many times as without any
+    owner set.
 11. **Opt-out.** A link followed by `<!-- darnlink-own-exempt -->` reports `web_own_exempt` and does
     not affect the exit code; the same link without the marker is `web_own_no_uuid`, exit 4. An exempt
     link whose destination **does** have a uuid is **not** reported `web_anchor` and is **not**
@@ -551,7 +564,7 @@ resolves through `git config`.
   Cut deliberately — see §Adoption. What this spec owes a gate is a CLI and an exit contract.
 - **`raw.githubusercontent.com` URLs.** 013's parser does not recognise that host at all (only
   `github.com/<owner>/<repo>/{blob,raw}/…`), so such a link never yields an owner and stays
-  `web_unverifiable`. The measurement above counts only what the parser recognises.
+  `web_unverifiable`. The measurement above counts only what the parser recognised at the time.
 - **Repository renames and transfers.** Ownership is the owner **written in the URL**, not the current
   owner after a transfer — and GitHub's redirect makes the divergence invisible, because the fetch
   still succeeds. A repo you transferred away keeps reading as yours (an unfixable finding); one

--- a/specs/016-own-repo-web-strictness/spec.md
+++ b/specs/016-own-repo-web-strictness/spec.md
@@ -70,11 +70,11 @@ Two secondary measurements shape the design:
 
 Two caveats stated rather than buried, because the whole case rests on these numbers:
 
-- **The snapshot is post-remediation.** On the day of measurement, 11 of these links were fixed by
-  hand — `uuid` added to 8 destination files, then anchored — precisely to keep the new axis's opening
-  budget small. An earlier count that day put the uuid-less bucket at 27, but under a **wider scope**
-  (it included vendored `clones/` and `mirrors/`), so the two figures are **not subtractable**; only
-  the 17 above is measured under the scope stated here.
+- **The snapshot is post-remediation.** Earlier the same day, 11 links that would otherwise sit in
+  this bucket were fixed by hand — `uuid` added to 8 destination files, then anchored — precisely to
+  keep the new axis's opening budget small. An earlier count that day is deliberately **not** quoted
+  here: it was taken under a different scope and the two numbers do not reconcile, and a figure that
+  invites a subtraction it does not support is worse than no figure.
 - **The 17 is a floor, not a total.** Seven more links point at repositories not checked out locally,
   so they could not be resolved offline; some of those destinations may also lack a `uuid`. The honest
   headline is *"17 confirmed, up to 24"*.
@@ -156,25 +156,27 @@ into it later.
 
 ### Adoption: a budget, not a cliff
 
-The gate recipe gains `own_web` (a list of owner names), `own_web_from_origin` (a boolean) and
-**`own_web_max`**: fail only above the budget, and print the "lower it to N" nudge when the count
-drops. The boolean is separate for the same reason the CLI has a separate flag and not an `auto`
-value — putting `origin` inside the list re-creates, one layer down, the sentinel collision this
-design rejected above. Without it, switching the axis
-on fails several repos at once on day one, and an axis that cannot be adopted incrementally gets
-turned off instead of obeyed — the lesson 015 already paid.
+The budget is **`--own-max N`**: fail only above it, and print the "lower it to N" nudge when the
+count drops. Without it, switching the axis on fails several repos at once on day one, and an axis
+that cannot be adopted incrementally gets turned off instead of obeyed — the lesson 015 already paid.
 
-**But the budget cannot be built the way `dangling_max` was, and that has to be said here or it will
-be discovered during implementation.** `dangling_max` works because the recipe re-counts the findings
-itself and computes the exit code. The web pass does the opposite: it runs `web-check` and takes its
-exit code verbatim, marking it final. And exit 4 is **shared** with `web_mismatch` / `web_not_found`,
-so from outside there is no way to tell a budgeted `web_own_no_uuid` from a genuinely dead link
-without re-running everything as `--json` and giving up the human-readable report.
+**The gate-recipe wiring is deliberately NOT in this spec.** Three review rounds spent their findings
+on it — on which config key shape avoids a sentinel collision, on what a `bail()` does to the axes
+after it, on the fact that the PowerShell recipe has drifted far enough that "both recipes" is not one
+requirement but two. None of that is about *this* feature: it is about how a gate consumes any
+darnlink exit code, it touches two shell surfaces this spec has no acceptance criteria for, and it is
+exactly how `dangling_max` was done — the axis landed first, the recipe key followed in its own change.
+Same here. What this spec owes the recipe is a CLI it can call and an exit contract it can trust;
+those are FR-012, FR-013 and FR-017.
 
-Therefore the budget lives in **darnlink**, not in the recipe: a `--own-max N` flag that suppresses
-`web_own_no_uuid`'s contribution to the exit code while the count is at or below `N` (the findings are
-still reported — a budget silences the *verdict*, never the *finding*). The recipe's keys are thin
-pass-throughs. See FR-012/FR-013/FR-015.
+**And the budget must live in darnlink, not in the gate — that part does belong here**, because it
+shapes the CLI. `dangling_max` could live in the recipe because the recipe re-counts those findings
+itself. The web pass cannot: it takes `web-check`'s exit code verbatim, and exit 4 is **shared** with
+`web_mismatch` / `web_not_found`, so from outside there is no way to tell a budgeted finding from a
+genuinely dead link without re-running everything as `--json` and giving up the human report. Hence a
+flag, not a key: `--own-max N` suppresses `web_own_no_uuid`'s contribution to the exit code while the
+count is at or below `N`, and the findings are still reported — a budget silences the *verdict*, never
+the *finding*. See FR-012/FR-013.
 
 ### Escape hatch (required, and it is not 005's)
 
@@ -262,9 +264,10 @@ Reviewed against `.specify/memory/constitution.md` v1.1.0.
 - **P-III Plain, Self-Contained:** nothing is stored in either repository **as a `uuid → path`
   index** — that, and only that, is what this principle forbids, and it is why 013 rejected the
   manifest. Two things this feature does put in a repo, and both are ordinary configuration the
-  principle has never covered: the owner list as the `own_web` key of the gate recipe's committed
-  config (FR-015), and the FR-011 exemption as a comment in the source Markdown. Neither is a location
-  database, neither rots into a stale index, and a darnlink-less repo still renders both. **Held.** ✅
+  principle has never covered: the FR-011 exemption is a comment in the source Markdown, and the owner
+  list will eventually be a key in a gate config (out of scope here — see §Adoption). Neither is a
+  location database, neither rots into a stale index, and a darnlink-less repo still renders the
+  Markdown unchanged. **Held.** ✅
 - **P-IV Deterministic:** with an explicit `--own`, output remains a function of *(tree + live
   responses)* — the same conditional determinism 013 already declared, with nothing added. With
   **`--own-from-origin` it also becomes a function of the clone's git configuration**: the same tree
@@ -291,11 +294,11 @@ convenience needs a named sentence in P-IV.
   what happens to be on disk.
 - **Exclude tags as well as SHAs from the failing rule.** Undecidable offline; rejected in
   §What fails above, with its failure direction.
-- **Fold it into `web: true`, with no key of its own.** Tempting, and it loses the one thing that
-  makes the rung adoptable: a **separate budget**. (Note what this alternative is *not* about:
-  reaching `mode: max` — the web pass already runs only inside the recipe's `max` branch, so
-  `own_web` is transitively mode=max-only whatever this bullet decides. The separate key buys the
-  budget, not the reachability.) Same shape as `dangling` beside `mode`.
+- **Make the rule unconditional whenever the web axis is on, with no way to budget it.** Tempting, and
+  it loses the one thing that makes the rung adoptable: a repo cannot cross from "several failures" to
+  zero in one step, so it turns the axis off instead. Hence `--own-max`. (What this is *not* about:
+  reaching the gate's `max` mode — the web pass already runs only there, so this rung inherits that
+  reachability whatever is decided here. The budget is the point.)
 
 ---
 
@@ -317,8 +320,11 @@ convenience needs a named sentence in P-IV.
   when explicit `--own` values were also given**, so the owner set would not have been empty. It is a
   request that either succeeds or is a usage error; it never silently narrows the question answered.
 - **FR-004** A link classified `web_unverifiable` **solely** because the fetched destination returned
-  200 with no frontmatter `uuid`, whose owner is owned, MUST instead be reported
-  **`web_own_no_uuid`**, and MUST set the exit code to **4** (subject to FR-012).
+  200 with **no frontmatter at all, or frontmatter without a `uuid`**, whose owner is owned, MUST
+  instead be reported **`web_own_no_uuid`**, and MUST set the exit code to **4** (subject to FR-012).
+  A destination whose frontmatter is present but **invalid YAML** MUST NOT produce it: today the
+  reader collapses "absent" and "invalid" into the same `None`, and telling someone to *add* a `uuid`
+  to a file whose frontmatter does not parse is the wrong instruction for a different defect.
 - **FR-005** FR-004 MUST NOT fire when the destination path does not end in `.md`, compared
   **case-insensitively** (`iter_markdown_files` already lowercases; `A.MD` is a Markdown file).
 - **FR-006** FR-004 MUST NOT fire when the URL's ref matches `^[0-9a-fA-F]{7,40}$` — a commit SHA,
@@ -353,7 +359,10 @@ convenience needs a named sentence in P-IV.
   `[text](url) <!-- web-uuid: X --> <!-- darnlink-own-exempt -->` — because both markers claim the
   position immediately after `)`. The link MUST still be reported, under the kind **`web_own_exempt`**,
   and MUST NOT contribute to the exit code: silently dropping it would hide the exemption from whoever
-  audits the repo later.
+  audits the repo later. The marker MUST be recognised **immediately after the `)`, or immediately
+  after a `web-uuid` anchor** — nowhere else. That is what makes the order enforceable rather than
+  decorative: an anchor written *after* the marker is not seen, the link reads as plain, and `--write`
+  appends a second one.
 - **FR-012** `web-check` MUST accept **`--own-max N`**. While the number of `web_own_no_uuid` findings
   is **at or below** `N`, they MUST NOT contribute to the exit code; above `N`, FR-004's exit 4
   applies. The count is of **findings, not destinations**: two links in different files pointing at
@@ -365,9 +374,11 @@ convenience needs a named sentence in P-IV.
 - **FR-013** When the count is at or below a non-zero `--own-max`, the report MUST print the count and
   say that lowering the budget to that number keeps the ratchet; when the count reaches **zero** it
   MUST say to drop the flag entirely. Both nudges, as `dangling_max` gives. A budget nobody is told to
-  lower is a budget that never goes down. The run's outcome word MUST also reflect the budget: today
-  exit 0 prints `clean`, and printing `clean` with findings on screen is exactly the misreading this
-  project's consumers have already paid for — under budget it MUST say so instead.
+  lower is a budget that never goes down. When the count is **above zero** and under budget, the run's
+  outcome word MUST also say so: today exit 0 prints `clean`, and printing `clean` with findings on
+  screen is exactly the misreading this project's consumers have already paid for. At **zero** it must
+  keep saying `clean` — an obsolete `--own-max 5` on an already-clean repo must not make a clean run
+  look qualified.
 - **FR-014** The new finding MUST compose with the file-level opt-outs: a file carrying
   `darnlink-ignore-file` (003) or `darnlink-ignore-links` (006) MUST NOT produce it. This is a filter
   **by kind**, applied to `web_own_no_uuid` only — it MUST NOT suppress `web_mismatch`,
@@ -376,23 +387,19 @@ convenience needs a named sentence in P-IV.
   entirely" the core gives them, and it is declared here rather than left to the implementer. Today
   `web-check` honours neither, so this is new work, not an existing guarantee (mirroring 015's
   FR-045).
-- **FR-014b** `--ignore-block` is **out of FR-014 and unchanged**. It already suppresses the link
+- **FR-015** `--ignore-block` is **out of FR-014 and unchanged**. It already suppresses the link
   *before any finding exists* (`find_web_links` skips the span), so it emits nothing at all today.
   Folding it into FR-014's by-kind rule would make links inside an ignored region start producing
   `web_not_found` — a behaviour change FR-007 forbids. Stated because the natural reading of "compose
   with the existing opt-outs" gets this backwards.
-- **FR-015** **Both** gate recipes — the bash `darnlink-gate` and its PowerShell twin, which carries
-  the same web pass and the same verbatim-exit-code contract — MUST expose `own_web` (a list of owner
-  names), `own_web_from_origin` (bool) and `own_web_max` (int), passing them through as `--own` /
-  `--own-from-origin` / `--own-max`. A single-surface implementation is how the two recipes have
-  already drifted (`dangling_max` exists in one and not the other).
-- **FR-016** Because FR-003 and FR-012 make **exit 1 reachable from a configuration typo**, the
-  recipes MUST treat exit 1 from `web-check` as a *usage* error and MUST NOT report it as a repository
-  verdict. It MUST NOT be routed to the recipe's `bail()` helper, which **exits the whole script**: a
-  forgotten `own_web` beside an `own_web_max` would then produce a green gate that also silently skips
-  the create-readme and dangling axes — the precise bug the recipe already documents and fixed once
-  with `RC_IS_FINAL`. The required shape is the create-readme axis's: warn, preserve any already
-  failing `rc`, and let every remaining axis run.
+- **FR-016** The **text report** — not only `--json` — MUST carry both new kinds: counted in the
+  summary line beside the existing five, and listed like any other actionable finding. FR-011's
+  promise ("never silent, so whoever audits the repo can see the exemption") is not kept by a JSON
+  mode nobody reads in a gate log.
+- **FR-017** `--own`, `--own-from-origin` or `--own-max` **without `--online`** MUST be a usage error
+  (exit 1), by the same argument as FR-003 and following the precedent `--write` already sets. The
+  offline branch ignores them entirely, so accepting them silently would report a green run that never
+  applied the rule it was asked for.
 
 ### Key Entities
 
@@ -407,15 +414,32 @@ convenience needs a named sentence in P-IV.
 
 ### Precedence, when several rules apply to the same link
 
-Evaluated in this order, first match wins, so every combination has one answer:
+**Two axes, not one.** An earlier draft of this section was a single "first match wins" list, and it
+was wrong in both directions: it made an exempt link whose destination 404s report `web_own_exempt`,
+which FR-011 forbids four lines earlier, and it left the entire status-based classification out — the
+layer that in fact decides most verdicts.
 
-1. **`--ignore-block` / code fence** — the link is never seen (FR-014b).
-2. **FR-014's file markers** — `web_own_no_uuid` is filtered; other web kinds survive.
-3. **FR-011's exemption** — `web_own_exempt`. It wins over FR-005/FR-006, so an exempt link to a
-   `.py` or to a SHA-pinned path reports `web_own_exempt`, not `web_unverifiable`: the author said
-   "leave this link alone", which is the more specific statement.
-4. **FR-005 / FR-006** — `web_unverifiable`, unchanged.
-5. **FR-004** — `web_own_no_uuid`, subject to FR-012's budget.
+**Axis 1 — visibility, before any fetch:**
+
+1. `--ignore-block` region or code fence → the link is **never seen**; nothing is emitted (FR-015).
+2. A file carrying `darnlink-ignore-file` / `darnlink-ignore-links` → the link is fetched and
+   classified as today, but `web_own_no_uuid` is filtered out of the result (FR-014).
+
+**Axis 2 — classification, after the fetch. Status decides first:**
+
+3. Anything other than 200 — 401/403, the `-2` unreadable-repo sentinel, 404, a transport error —
+   keeps **exactly** today's kind, for every link, exempt or not (FR-007). In particular an exempt
+   link whose destination 404s is `web_not_found`, because a dead link is dead either way.
+4. On **200 only**, in this order: FR-011's exemption → `web_own_exempt`, which also covers the
+   `web_mismatch` and `web_anchor` cases it lists; then FR-005/FR-006 → `web_unverifiable`; then
+   FR-004 → `web_own_no_uuid`, subject to FR-012's budget; otherwise today's `web_ok` / `web_anchor` /
+   `web_mismatch`.
+
+Two consequences worth stating because they are the ones a reader gets wrong: an exempt link that
+verifies fine (200, anchored, uuid matches) reports **`web_own_exempt`, not `web_ok`** — the marker
+describes the *link*, not the outcome of one run; and an exempt link to a `.py` or on a SHA-pinned ref
+also reports `web_own_exempt`, because the author's explicit "leave this alone" is the more specific
+statement.
 
 ## Acceptance
 
@@ -450,23 +474,26 @@ resolves through `git config`.
     markers in the normative order the anchor is still recognised and the file is byte-identical after
     `--write`. **And the corruption case**: with the anchor written *after* the exemption, `--write`
     must not append a second anchor — the file ends with exactly one.
-11b. **Exempt beats the other exclusions.** An exempt link to a `.py`, and an exempt link on a
-    SHA-pinned ref, both report `web_own_exempt` rather than `web_unverifiable` (§Precedence).
-12. **Owner case.** `--own OWNED` against a `owned/repo/…` URL is owned, and vice versa (FR-001).
-13. **Budget.** With two owned uuid-less destinations: `--own-max 2` → both reported, exit **0**, the
+12. **Exempt, and precedence.** An exempt link to a `.py` and one on a SHA-pinned ref both report
+    `web_own_exempt` rather than `web_unverifiable`; an exempt link that verifies cleanly reports
+    `web_own_exempt`, **not** `web_ok`; and an exempt link whose destination **404s** reports
+    `web_not_found`, exit 4 — status decides before the exemption (§Precedence).
+13. **Owner case.** `--own OWNED` against a `owned/repo/…` URL is owned, and vice versa (FR-001).
+14. **Budget.** With two owned uuid-less destinations: `--own-max 2` → both reported, exit **0**, the
     outcome word is not `clean`, and the report says to lower the budget to 2; `--own-max 1` → exit
     **4**; `--own-max 2` with an additional real `web_not_found` → exit **4** (FR-012). `--own-max`
     with no owner set → exit 1. Two links in **different files** pointing at the **same** uuid-less
     destination count as **2** (FR-012 counts findings, not destinations).
-14. **Composition.** The same failing link is silent when its file carries `darnlink-ignore-file` and
+15. **Composition.** The same failing link is silent when its file carries `darnlink-ignore-file` and
     when it carries `darnlink-ignore-links`, while a `web_not_found` in that same file is **still
     reported** (FR-014's by-kind filter). A link inside an `--ignore-block` region produces **nothing
-    at all**, as today — including no `web_not_found` (FR-014b).
-15. **JSON shape.** `--json` carries every `web_own_no_uuid` in `findings` with that literal `kind`,
-    plus a `web_own_no_uuid` count in the summary object (FR-010).
-16. **The message does not lie.** The `web_own_no_uuid` text contains the owner, the repo, the path,
+    at all**, as today — including no `web_not_found` (FR-015).
+16. **Both kinds surface.** `--json` carries every `web_own_no_uuid` **and** every
+    `web_own_exempt` in `findings` under those literal kinds, with a count of each in the summary
+    object (FR-010); the **text** report counts both in its summary line and lists them (FR-016).
+17. **The message does not lie.** The `web_own_no_uuid` text contains the owner, the repo, the path,
     and the word `frontmatter`, and does **not** contain `--write` (FR-008).
-17. **Other classifications untouched (FR-007).** With an owner set, an owned destination that returns
+18. **Other classifications untouched (FR-007).** With an owner set, an owned destination that returns
     401/403, one that returns the `-2` unreadable-repo sentinel, one that returns the transport-error
     sentinel, and a non-GitHub URL each keep exactly the kind and exit contribution they have today.
 

--- a/specs/016-own-repo-web-strictness/spec.md
+++ b/specs/016-own-repo-web-strictness/spec.md
@@ -26,15 +26,15 @@ message says what to add and where.
 
 | Situation | Today | Should be |
 |---|---|---|
-| 200, destination **has** a uuid, link plain | `web_anchor` (exit 3) | unchanged |
+| 200, destination **has** a uuid, link plain | `web_anchor` (exit 3 in dry-run; 0 under `--write`) | unchanged |
 | 200, destination has **no** uuid, destination **not yours** | `web_unverifiable` (exit 0) | unchanged — you cannot fix it |
 | 200, destination has **no** uuid, destination **yours** | `web_unverifiable` (exit 0) | **a failure**: add the uuid at the destination |
 | 404 (with token, readable repo) | `web_not_found` (exit 4) | unchanged |
 | 404 (no token) / repo unreadable | `web_unverifiable` (exit 0) | unchanged in this feature (see §The second rung) |
 
-The distinguishing datum — the destination's **owner** — is already parsed and sitting unused in
-`GithubUrl.owner`. Deciding ownership costs **no extra fetch**: it is a textual comparison on a value
-the run already has.
+The distinguishing datum — the destination's **owner** — is already parsed in `GithubUrl.owner` and
+already used to build requests; it has simply never been used for **classification**. Deciding
+ownership costs **no extra fetch**: it is a textual comparison on a value the run already has.
 
 ---
 
@@ -46,7 +46,9 @@ Measured 2026-08-11 across a nine-repository private fleet, all of which already
   same account as the linking repo. Cross-repo linking here is overwhelmingly *self*-linking.
 - Of the **46** own links still plain, resolving each destination against a local checkout:
   **27 point at a `.md` whose frontmatter has no `uuid`** — every one of them invisible to every
-  darnlink axis today. Only 7 would already be caught as `web_anchor`.
+  darnlink axis today. Only 7 would already be caught as `web_anchor`. The rest of the 46: 2 target a
+  non-`.md` file, 2 are pinned to a commit SHA, 1 target no longer exists, and for 9 the destination
+  repository was not checked out locally, so they could not be resolved offline at all.
 - Restricted to the repos that actually run the web axis today (`web: true`), the numbers are
   **11 links** blocked on **8 destination files** across 3 repositories. All 8 were hand-written
   documents; none was machine-generated.
@@ -81,16 +83,25 @@ organisation you push to whose name is not your login.
 to zero owned links would produce a green run that means nothing — the exact false pass this feature
 exists to remove (Principle II: never silent).
 
+**And that holds even when explicit `--own` values were also given** — `--own me --own auto` in a
+tarball with no `origin` still exits 1. The rule is about the *request*, not about whether the owner
+set ends up empty: the caller asked darnlink to discover an owner and it could not, so any verdict it
+prints afterwards is answering a narrower question than the one it was asked. Reporting green on a
+subset the user did not fully specify is the same false pass by a smaller door.
+
 ### What fails, and the two things that deliberately do not
 
 The new finding fires **only** for: destination fetched 200 · destination has no `uuid` · owner is in
 the `--own` list. Two exclusions, both from measured cases in the fleet:
 
-- **A destination that is not `.md`** never fails. It cannot carry frontmatter, so demanding a `uuid`
-  is incoherent. This mirrors 015's FR-044 (anchoring stays `.md`-only). Measured: 2 such links.
-- **A destination pinned to an immutable ref** (a full 40-hex commit SHA) never fails. You cannot add
-  frontmatter to a past commit, so the finding would be unfixable by construction. Measured: 2 such
-  links against 262 on moving refs (`main`/`master`/`HEAD`).
+- **A destination that is not `.md`** (compared case-insensitively, as `iter_markdown_files` already
+  does) never fails. It cannot carry frontmatter, so demanding a `uuid` is incoherent. This mirrors
+  015's FR-044 (anchoring stays `.md`-only). Measured: 2 such links.
+- **A destination pinned to an immutable ref** never fails. You cannot add frontmatter to a commit
+  that is already made, so the finding would be unfixable by construction. "Immutable" is **not** just
+  a 40-hex SHA: a **tag** and a **short SHA** are equally unfixable — re-tagging to plant a `uuid` is
+  not a thing anyone will do. The rule is therefore *"the ref must be a moving branch head"*, and
+  everything else is excluded. Measured: 2 SHA-pinned links against 262 on `main`/`master`/`HEAD`.
 
 ### The finding, and why exit 4 and not 3
 
@@ -114,20 +125,51 @@ into it later.
 
 ### Adoption: a budget, not a cliff
 
-The gate recipe gains `own_web` (off · on) and **`own_web_max` (int, default 0)**, the same ratchet
-shape as `dangling_max`: fail only above the budget, and print the "lower it to N" nudge when the
-count drops. Without it, switching the axis on fails several repos at once on day one, and an axis
-that cannot be adopted incrementally gets turned off instead of obeyed — the lesson 015 already paid.
+The gate recipe gains `own_web` (off · on) and **`own_web_max` (int, default 0)**: fail only above the
+budget, and print the "lower it to N" nudge when the count drops. Without it, switching the axis on
+fails several repos at once on day one, and an axis that cannot be adopted incrementally gets turned
+off instead of obeyed — the lesson 015 already paid.
+
+**But the budget cannot be built the way `dangling_max` was, and that has to be said here or it will
+be discovered during implementation.** `dangling_max` works because the recipe re-counts the findings
+itself and computes the exit code. The web pass does the opposite: it runs `web-check` and takes its
+exit code verbatim, marking it final. And exit 4 is **shared** with `web_mismatch` / `web_not_found`,
+so from outside there is no way to tell a budgeted `web_own_no_uuid` from a genuinely dead link
+without re-running everything as `--json` and giving up the human-readable report.
+
+Therefore the budget lives in **darnlink**, not in the recipe: a `--own-max N` flag that suppresses
+`web_own_no_uuid`'s contribution to the exit code while the count is at or below `N` (the findings are
+still reported — a budget silences the *verdict*, never the *finding*). The recipe's `own_web_max` is
+then a thin pass-through, and it can keep taking the exit code verbatim exactly as it does today. See
+FR-012/FR-013.
 
 ### Escape hatch (required, and it is not 005's)
 
 A destination may be **machine-regenerated**, where a `uuid` is futile: the next regeneration wipes it
-and the anchor points at nothing — strictly worse than a plain link. That is exactly the case 005
-handles with `--no-create-frontmatter-for`, but **005's deny-list cannot be reused here**: it matches
-basenames of targets *in your own tree*, and from the linking repo you cannot see whether a file in
-another repo is generated. Without an opt-out, such a link would be permanently un-greenable, and a
-permanently red axis gets disabled. The opt-out belongs in the **source** repo (where the knowledge
-is), not in the destination.
+and the anchor points at nothing — strictly worse than a plain link. Without an opt-out, such a link
+is permanently un-greenable, and a permanently red axis gets disabled rather than obeyed.
+
+**The marker is a trailing `<!-- darnlink-own-exempt -->` beside the link**, in the **source** repo —
+where the knowledge lives — with the same grammar and placement as the existing trailing markers:
+
+```
+See the [nightly export](https://github.com/owned/repo/blob/main/mirrors/export.md) <!-- darnlink-own-exempt -->
+```
+
+Why not each of the three opt-outs that already exist, in the order someone will suggest them:
+
+- **005's `--no-create-frontmatter-for`** matches *basenames of targets in your own tree*. From the
+  linking repo you cannot see whether a file in another repo is generated, and the real names are
+  unique per item (a mirrored message, a dated export), so there is no basename to deny.
+- **006's file-level `darnlink-ignore-links`** is too blunt: it disables link handling for the
+  **whole file**, including the core's intra-repo robustify. Exempting one cross-repo link must not
+  cost the file its local link healing.
+- **`--ignore-block`** works on regions, not links, and web-check already honours it — it is the right
+  tool for a generated *section*, and it stays available. It is not a per-link exemption.
+
+**Composition is a requirement, not a bonus** — and it is not free today: web-check currently ignores
+the 003 and 006 file-level markers entirely (it only skips `--ignore-block` regions and code fences).
+015 made the equivalent explicit as its FR-045; this spec does the same in FR-014.
 
 ---
 
@@ -135,10 +177,16 @@ is), not in the destination.
 
 `web-check --online` currently **crashes** — it does not fail, it raises — when a Markdown href
 contains whitespace: `_GITHUB_BLOB_RE` accepts spaces in its path group, and `http.client.InvalidURL`
-derives from `HTTPException`, not `OSError`, so it escapes `_fetch_once`'s `except` clause. This
-violates 013's FR-008 (an unrecognised URL shape is `web_unverifiable`, never a crash) and FR-009 (no
-transport error propagates as an exception). Any repository that mirrors third-party content is
-liable to contain such an href. Fixed separately; this axis is not adoptable before it.
+derives from `HTTPException`, not `OSError`, so it escapes `_fetch_once`'s `except` clause. Any
+repository that mirrors third-party content is liable to contain such an href.
+
+**And 013 does not actually forbid it — which is worse than a violation.** FR-008 covers an
+*unrecognised* URL shape, and this one **is** recognised: the regex matches it happily and the run
+dies later, at the fetch. FR-009 covers *"network/transport errors (timeout, DNS, connection reset)"*,
+and a client-side URL validation error is none of those. So the crash falls through the gap between
+two requirements that were each written assuming the other covered it. The fix therefore also wants
+FR-009 restated as *"no error raised by the fetch layer — transport **or** client-side validation —
+propagates as an exception"*. Fixed separately; this axis is not adoptable before it.
 
 ---
 
@@ -149,12 +197,20 @@ Reviewed against `.specify/memory/constitution.md` v1.1.0.
 - **P-I Single Responsibility:** the new competence is *comparing one string from a URL darnlink has
   already parsed*. No document semantics, no entity model. It stays inside the non-core `web-check`
   adjunct; the two core operations remain two. **Held.** ✅
+  ⚠️ True of `--own OWNER`, **not** of `--own auto`, which must find a repository root and read its
+  git configuration — I/O of a kind the package does nowhere else today (there is no `subprocess` and
+  no git access anywhere in `src/darnlink/`). Still no document semantics, so the principle holds,
+  but that new competence is the **second** reason `auto` is opt-in rather than the default.
 - **P-II Safe by Default:** the finding is report-only and, unlike every other web finding, is
   **unfixable by `--write` on purpose** — darnlink never writes to the destination repository. The
   feature adds no write path at all. **Held, and reinforced.** ✅
-- **P-III Plain, Self-Contained:** nothing is stored in either repository. The owner list is *tool
-  configuration* (a flag, or a key in the gate recipe alongside `mode`/`web`/`dangling`), not a
-  `uuid → path` index — it is not the manifest 013 rejected under this principle. **Held.** ✅
+- **P-III Plain, Self-Contained:** nothing is stored in either repository **as a `uuid → path`
+  index** — that, and only that, is what this principle forbids, and it is why 013 rejected the
+  manifest. Two things this feature does put in a repo, and both are ordinary configuration the
+  principle has never covered: the owner list may live as a key in the gate recipe's committed
+  `darnlink-gate.json`, and the FR-011 exemption is a comment in the source Markdown. Neither is a
+  location database, neither rots into a stale index, and a darnlink-less repo still renders both.
+  **Held.** ✅
 - **P-IV Deterministic:** with an explicit `--own`, output remains a function of *(tree + live
   responses)* — the same conditional determinism 013 already declared, with nothing added. With
   **`--own auto` it also becomes a function of the clone's git configuration**: the same tree yields
@@ -179,9 +235,11 @@ named sentence in P-IV.
 - **Infer "own" from the destination repo being cloned next to the source.** Revives the
   sibling-checkout coupling 013 already rejected as alternative (c), and makes the verdict depend on
   what happens to be on disk.
-- **Fold it into `mode: max`.** The web axis is already coupled to `mode=max` in the recipe; adding a
-  second coupling would make this rung unreachable for any repo that cannot pay the local ratchet.
-  It is a separate axis with a separate budget, like `dangling`.
+- **Fold it into `web: true`, with no key of its own.** Tempting, and it loses the one thing that
+  makes the rung adoptable: a **separate budget**. (Note what this alternative is *not* about:
+  reaching `mode: max` — the web pass already runs only inside the recipe's `max` branch, so
+  `own_web` is transitively mode=max-only whatever this bullet decides. The separate key buys the
+  budget, not the reachability.) Same shape as `dangling` beside `mode`.
 
 ---
 
@@ -196,13 +254,16 @@ named sentence in P-IV.
   accepting both the `https://github.com/<owner>/<repo>` and `git@github.com:<owner>/<repo>` forms.
   It MUST combine with explicit `--own` values (union).
 - **FR-003** If `--own auto` cannot resolve an owner (no repository, no `origin`, non-GitHub remote),
-  the run MUST exit **1** with a message naming the reason. It MUST NOT proceed with an empty owner
-  set.
+  the run MUST exit **1** with a message naming the reason — **including when explicit `--own` values
+  were also given**, so the owner set would not have been empty. `auto` is a request that either
+  succeeds or is a usage error; it never silently narrows the question being answered.
 - **FR-004** A link classified `web_unverifiable` **solely** because the fetched destination returned
   200 with no frontmatter `uuid`, whose owner is owned, MUST instead be reported
   **`web_own_no_uuid`**, and MUST set the exit code to **4**.
-- **FR-005** FR-004 MUST NOT fire when the destination path does not end in `.md`.
-- **FR-006** FR-004 MUST NOT fire when the URL's ref is an immutable full commit SHA (40 hex chars).
+- **FR-005** FR-004 MUST NOT fire when the destination path does not end in `.md`, compared
+  **case-insensitively** (`iter_markdown_files` already lowercases; `A.MD` is a Markdown file).
+- **FR-006** FR-004 MUST NOT fire when the URL's ref is **not a moving branch head** — a full or
+  short commit SHA, or a tag. Only a ref that can still receive a commit is fixable.
 - **FR-007** No other classification changes. In particular a 404 (with or without token), an
   unreadable repo, a non-GitHub URL and a transport error MUST keep today's kind and exit
   contribution, owned or not.
@@ -211,9 +272,22 @@ named sentence in P-IV.
 - **FR-009** Ownership MUST be decided without any additional network request.
 - **FR-010** `--json` MUST emit the new kind under its own `kind`, and include a `web_own_no_uuid`
   count in the summary object, so a gate can branch on it and apply a budget.
-- **FR-011** A per-link opt-out MUST exist for destinations that are machine-regenerated, expressed in
-  the **source** repository. A link carrying it MUST be reported as tolerated (never silently
-  dropped) and MUST NOT contribute to the exit code.
+- **FR-011** A link followed by **`<!-- darnlink-own-exempt -->`** (same grammar and placement as the
+  existing trailing markers, and combinable with a `web-uuid` anchor) MUST be exempt from FR-004. It
+  MUST still be reported, as its own tolerated kind, and MUST NOT contribute to the exit code —
+  silently dropping it would hide the exemption from whoever audits the repo later.
+- **FR-012** `web-check` MUST accept **`--own-max N`** (default 0). While the number of
+  `web_own_no_uuid` findings is **at or below** `N`, they MUST NOT contribute to the exit code; above
+  `N`, FR-004's exit 4 applies. The findings are always reported: the budget silences the *verdict*,
+  never the *finding*. `--own-max` without any `--own` MUST be a usage error (exit 1).
+- **FR-013** When the count is at or below a non-zero `--own-max`, the report MUST print the count and
+  say that lowering the budget to that number keeps the ratchet — the same nudge `dangling_max` gives.
+  A budget nobody is told to lower is a budget that never goes down.
+- **FR-014** The new finding MUST compose with the existing opt-outs: a file carrying
+  `darnlink-ignore-file` (003) or `darnlink-ignore-links` (006), and any region inside an
+  `--ignore-block` marker, MUST NOT produce it. Today `web-check` honours only `--ignore-block` and
+  code fences, so 003 and 006 are new work here, not an existing guarantee (this mirrors 015's
+  FR-045).
 
 ### Key Entities
 
@@ -232,14 +306,31 @@ named sentence in P-IV.
    anchors it (the existing path is untouched by ownership).
 5. **Owned, non-`.md` destination.** `owned/repo/blob/main/tool.py`, 200, no uuid → `web_unverifiable`,
    exit 0.
-6. **Owned, SHA-pinned.** `owned/repo/blob/<40-hex>/a.md`, 200, no uuid → `web_unverifiable`, exit 0.
+6. **Owned, immutable ref.** Three links, `blob/<40-hex>/a.md`, `blob/<7-hex>/a.md` and
+   `blob/v1.2.3/a.md`, all 200 without uuid → all three `web_unverifiable`, exit 0.
 7. **Owned, 404.** With and without token → `web_not_found` / `web_unverifiable` exactly as today.
 8. **`auto` resolves.** A tree whose `origin` is `git@github.com:owned/src.git` behaves as
    `--own owned`; both remote URL forms parse.
-9. **`auto` cannot resolve.** No `origin` → exit 1, message names the reason, no findings emitted.
+9. **`auto` cannot resolve.** No `origin` → exit 1, message names the reason, no findings emitted —
+   **and the same with `--own explicit --own auto`**, where the owner set would not be empty (FR-003).
 10. **No extra fetch.** The mocked fetcher is called exactly as many times as without `--own`.
-11. **Opt-out.** A link marked with the FR-011 opt-out reports as tolerated and does not affect the
-    exit code.
+11. **Opt-out.** A link followed by `<!-- darnlink-own-exempt -->` reports under its tolerated kind and
+    does not affect the exit code; the same link without the marker is `web_own_no_uuid`, exit 4.
+12. **Owner case.** `--own OWNED` against a `owned/repo/…` URL is owned, and vice versa (FR-001); the
+    parser preserves the case it found, so the comparison — not the parse — must fold it.
+13. **Budget.** With two owned uuid-less destinations: `--own-max 2` → both reported, exit **0**, and
+    the report says to lower the budget to 2; `--own-max 1` → exit **4**. `--own-max` with no `--own`
+    → exit 1.
+14. **Composition.** The same failing link is silent when its file carries `darnlink-ignore-file`,
+    when it carries `darnlink-ignore-links`, and when it sits inside an `--ignore-block` region
+    (FR-014).
+15. **JSON shape.** `--json` carries every `web_own_no_uuid` in `findings` with that literal `kind`,
+    plus a `web_own_no_uuid` count in the summary object (FR-010).
+16. **The message does not lie.** The `web_own_no_uuid` text contains the owner, the repo, the path,
+    and the word `frontmatter`, and does **not** contain `--write` (FR-008).
+17. **Other classifications untouched (FR-007).** With `--own owned` set, an owned destination that
+    returns 401/403, one that returns the transport-error sentinel, and a non-GitHub URL each keep
+    exactly the kind and exit contribution they have today.
 
 ## Out of scope
 
@@ -249,6 +340,15 @@ named sentence in P-IV.
   sibling. Principle II; also 013's rejected alternative (c).
 - **Non-GitHub forges** — ownership is parsed from the GitHub URL shape, as in 013.
 - **Push-permission-based ownership** — rejected above.
+- **`raw.githubusercontent.com` URLs.** 013's parser does not recognise that host at all (only
+  `github.com/<owner>/<repo>/{blob,raw}/…`), so such a link never yields an owner and stays
+  `web_unverifiable`. The 345-link measurement above counts only what the parser recognises.
+- **Repository renames and transfers.** Ownership is the owner **written in the URL**, not the current
+  owner after a transfer — and GitHub's redirect makes the divergence invisible, because the fetch
+  still succeeds. A repo you transferred away keeps reading as yours (an unfixable finding); one
+  transferred to you keeps reading as someone else's (a missed one). Following the redirect to learn
+  the current owner would cost a request per repo and reintroduce the credential-dependence that sank
+  the push-permission alternative.
 
 ## Amendments the Constitution needs
 
@@ -257,3 +357,12 @@ named sentence in P-IV.
   git configuration; the explicit `--own` form has no such dependency and is the primary mechanism."*
 
 No other principle changes: the base rule is a pure textual predicate over data the run already holds.
+
+## Housekeeping this spec touches but does not do
+
+- **013's header still says *"Status: Spike / EXPERIMENTAL … Do not merge to `main`"*** while the
+  feature has been in `main` for releases and is gated by the recipe. This spec amends a document
+  whose own status line is stale. Correcting it is a one-line change, deliberately left out of this
+  PR so the amendment and the correction are reviewable apart.
+- **FR-009 of 013** should be restated to cover client-side validation errors, not only transport
+  errors — see §Prerequisite.

--- a/specs/016-own-repo-web-strictness/spec.md
+++ b/specs/016-own-repo-web-strictness/spec.md
@@ -200,8 +200,10 @@ the exemption second.
 ```
 
 **Measured, because the obvious rationale for this is wrong and was written down once already.** With
-the exemption first and no anchor, `--write` inserts the anchor *before* the untouched exemption, so
-the line **self-heals into the normative order** — no corruption. The corruption is a different case:
+the exemption first and no anchor, today's `--write` inserts the anchor *before* the untouched
+exemption, so the line **self-heals into the normative order** — no corruption. (Once FR-011 ships
+that self-heal is no longer observable, because an exempt link is never anchored at all; the point
+survives as the reason the *other* order is the dangerous one.) The corruption is a different case:
 an anchor that already sits **after** the exemption,
 
 ```
@@ -308,23 +310,30 @@ convenience needs a named sentence in P-IV.
 
 - **FR-001** `web-check` MUST accept `--own OWNER`, repeatable. A destination whose parsed owner
   equals any given value (ASCII case-insensitive; the parser preserves the case it found, so the
-  comparison must fold it) is **owned**. With no owner set, behaviour MUST be byte-identical to today.
+  comparison must fold it) is **owned**. With no owner set, behaviour MUST be byte-identical to today
+  **for every link that does not carry the FR-011 marker** — see FR-011 for why that marker is the one
+  exception.
 - **FR-002** `web-check` MUST accept `--own-from-origin`, which adds the owner of the scanned
   repository's `origin` remote to the owner set, accepting both the
   `https://github.com/<owner>/<repo>` and `git@github.com:<owner>/<repo>` forms. It MUST compose with
   explicit `--own` values (union). Resolution MUST use `git config --get remote.origin.url` executed
   in the scanned root, **not** a hand parse of `.git/config`: in a worktree `.git` is a *file*, not a
   directory, so a naive parse fails in the project's own development environment.
-- **FR-003** If `--own-from-origin` cannot resolve an owner (no repository, no `origin`, non-GitHub
-  remote, `git` not on `PATH`), the run MUST exit **1** with a message naming the reason — **including
+- **FR-003** If `--own-from-origin` cannot resolve an owner — no repository, no `origin`, a
+  non-GitHub remote, `git` not on `PATH`, or `git` refusing the repository as dubiously owned
+  (`safe.directory`, the failure mode of any tool run over someone else's checkout) — the run MUST
+  exit **1** with a message naming the reason — **including
   when explicit `--own` values were also given**, so the owner set would not have been empty. It is a
   request that either succeeds or is a usage error; it never silently narrows the question answered.
 - **FR-004** A link classified `web_unverifiable` **solely** because the fetched destination returned
   200 with **no frontmatter at all, or frontmatter without a `uuid`**, whose owner is owned, MUST
   instead be reported **`web_own_no_uuid`**, and MUST set the exit code to **4** (subject to FR-012).
-  A destination whose frontmatter is present but **invalid YAML** MUST NOT produce it: today the
-  reader collapses "absent" and "invalid" into the same `None`, and telling someone to *add* a `uuid`
-  to a file whose frontmatter does not parse is the wrong instruction for a different defect.
+  A destination whose frontmatter is present but **invalid YAML** MUST NOT produce it — it stays
+  `web_unverifiable` — because telling someone to *add* a `uuid` to a file whose frontmatter does not
+  parse is the wrong instruction for a different defect. Note where the work is: the frontmatter reader
+  **already** distinguishes absent from invalid; it is the caller that throws the distinction away by
+  taking only the second element of its result. Keeping it is a one-character change, not a new
+  parser.
 - **FR-005** FR-004 MUST NOT fire when the destination path does not end in `.md`, compared
   **case-insensitively** (`iter_markdown_files` already lowercases; `A.MD` is a Markdown file).
 - **FR-006** FR-004 MUST NOT fire when the URL's ref matches `^[0-9a-fA-F]{7,40}$` — a commit SHA,
@@ -359,7 +368,14 @@ convenience needs a named sentence in P-IV.
   `[text](url) <!-- web-uuid: X --> <!-- darnlink-own-exempt -->` — because both markers claim the
   position immediately after `)`. The link MUST still be reported, under the kind **`web_own_exempt`**,
   and MUST NOT contribute to the exit code: silently dropping it would hide the exemption from whoever
-  audits the repo later. The marker MUST be recognised **immediately after the `)`, or immediately
+  audits the repo later.
+
+  **The marker is honoured whether or not an owner set was given, and whether or not the destination is
+  owned.** It states a property of the *link* — "this destination regenerates, never anchor it" —
+  not of the run's configuration, and a marker that stopped working when someone dropped `--own` would
+  let `--write` rewrite exactly the files it was placed to protect. This is the single, deliberate
+  exception to FR-001's "byte-identical with no owner set". The marker MUST be recognised
+  **immediately after the `)`, or immediately
   after a `web-uuid` anchor** — nowhere else. That is what makes the order enforceable rather than
   decorative: an anchor written *after* the marker is not seen, the link reads as plain, and `--write`
   appends a second one.
@@ -380,7 +396,11 @@ convenience needs a named sentence in P-IV.
   keep saying `clean` — an obsolete `--own-max 5` on an already-clean repo must not make a clean run
   look qualified.
 - **FR-014** The new finding MUST compose with the file-level opt-outs: a file carrying
-  `darnlink-ignore-file` (003) or `darnlink-ignore-links` (006) MUST NOT produce it. This is a filter
+  `darnlink-ignore-file` (003) or `darnlink-ignore-links` (006) MUST NOT produce it. The link is still
+  fetched and still reported — it degrades to `web_unverifiable`, it does not vanish — because
+  "never silent" is the same promise FR-011 makes, and a link that disappears from the report is one
+  nobody can audit. Filtered links do not count toward FR-012's budget: they are not findings of that
+  kind any more. This is a filter
   **by kind**, applied to `web_own_no_uuid` only — it MUST NOT suppress `web_mismatch`,
   `web_not_found` or any other web finding in that file, which would silently violate FR-007. That is
   a **third** semantics for those markers, narrower than the "removed from the darnlink graph
@@ -430,10 +450,18 @@ layer that in fact decides most verdicts.
 3. Anything other than 200 — 401/403, the `-2` unreadable-repo sentinel, 404, a transport error —
    keeps **exactly** today's kind, for every link, exempt or not (FR-007). In particular an exempt
    link whose destination 404s is `web_not_found`, because a dead link is dead either way.
-4. On **200 only**, in this order: FR-011's exemption → `web_own_exempt`, which also covers the
-   `web_mismatch` and `web_anchor` cases it lists; then FR-005/FR-006 → `web_unverifiable`; then
-   FR-004 → `web_own_no_uuid`, subject to FR-012's budget; otherwise today's `web_ok` / `web_anchor` /
-   `web_mismatch`.
+4. On **200 only**: FR-011's exemption → `web_own_exempt`, which also covers the `web_mismatch` and
+   `web_anchor` cases it lists. Otherwise FR-004 → `web_own_no_uuid` (subject to FR-012's budget) —
+   **but only when FR-005 and FR-006 both allow it**, and only when the destination's frontmatter is
+   absent or lacks a uuid rather than being invalid YAML. In every other case the verdict is today's,
+   unchanged: `web_ok`, `web_anchor`, `web_mismatch` or `web_unverifiable`.
+
+**FR-005 and FR-006 are carve-outs, never verdicts.** They say when FR-004 must *not* fire; they do
+not turn a link into `web_unverifiable`. An earlier draft of this section listed them as a producing
+step, which silently changed behaviour FR-007 forbids changing: a plain link on a SHA-pinned ref whose
+destination *does* carry a uuid is `web_anchor` today, exit 3, and `--write` anchors it — reading them
+as terminal made it `web_unverifiable`, exit 0, nothing written. Different kind, different exit,
+different file on disk.
 
 Two consequences worth stating because they are the ones a reader gets wrong: an exempt link that
 verifies fine (200, anchored, uuid matches) reports **`web_own_exempt`, not `web_ok`** — the marker
@@ -457,7 +485,9 @@ resolves through `git config`.
    exit 0. And `owned/repo/blob/main/A.MD` **is** treated as Markdown (FR-005's case folding).
 6. **Owned, SHA-pinned.** `blob/<40-hex>/a.md` and `blob/<7-hex>/a.md`, 200 without uuid → both
    `web_unverifiable`, exit 0. **And the negative that guards FR-006:** `blob/v1.2.3/a.md` — a ref
-   that looks like a tag — **does** produce `web_own_no_uuid`, exit 4.
+   that looks like a tag — **does** produce `web_own_no_uuid`, exit 4. **And the carve-out is not a
+   verdict:** the same SHA-pinned link whose destination *does* carry a uuid is still `web_anchor`,
+   exit 3, and `--write` still anchors it.
 7. **Owned, 404.** With and without token → `web_not_found` / `web_unverifiable` exactly as today.
 8. **`--own-from-origin` resolves.** A repo whose `origin` is `git@github.com:owned/src.git` behaves
    as `--own owned`; the `https://` form parses identically; and `--own other --own-from-origin`
@@ -484,7 +514,8 @@ resolves through `git config`.
     **4**; `--own-max 2` with an additional real `web_not_found` → exit **4** (FR-012). `--own-max`
     with no owner set → exit 1. Two links in **different files** pointing at the **same** uuid-less
     destination count as **2** (FR-012 counts findings, not destinations).
-15. **Composition.** The same failing link is silent when its file carries `darnlink-ignore-file` and
+15. **Composition.** The same failing link degrades to `web_unverifiable` — reported, not silent, and
+    not counted against the budget — when its file carries `darnlink-ignore-file` and
     when it carries `darnlink-ignore-links`, while a `web_not_found` in that same file is **still
     reported** (FR-014's by-kind filter). A link inside an `--ignore-block` region produces **nothing
     at all**, as today — including no `web_not_found` (FR-015).
@@ -497,6 +528,17 @@ resolves through `git config`.
     401/403, one that returns the `-2` unreadable-repo sentinel, one that returns the transport-error
     sentinel, and a non-GitHub URL each keep exactly the kind and exit contribution they have today.
 
+19. **Usage errors.** `--own o`, `--own-from-origin` and `--own-max 1`, each **without `--online`**,
+    exit 1 with no fetch (FR-017).
+20. **The budget at zero.** With no owned uuid-less destinations and `--own-max 5` still set: exit 0,
+    the outcome word is `clean`, and the report says to drop the flag (FR-013's zero clauses).
+21. **Invalid frontmatter is a different defect.** An owned destination returning 200 whose frontmatter
+    is present but unparseable → `web_unverifiable`, exit 0, and the message does **not** say to add a
+    `uuid` (FR-004).
+22. **The marker does not need an owner set.** A link carrying `<!-- darnlink-own-exempt -->` whose
+    destination has a uuid, run with **no `--own` at all**, is `web_own_exempt` and is **not**
+    rewritten by `--write` — the one deliberate exception to FR-001 (FR-011).
+
 ## Out of scope
 
 - **The second rung** (failing owned `web_unverifiable` for 404 / unreadable repo) — named above,
@@ -505,6 +547,8 @@ resolves through `git config`.
   sibling. Principle II; also 013's rejected alternative (c).
 - **Non-GitHub forges** — ownership is parsed from the GitHub URL shape, as in 013.
 - **Push-permission-based ownership** — rejected above.
+- **The gate-recipe wiring** (`own_web*` keys, and how a recipe should treat this feature's exit 1).
+  Cut deliberately — see §Adoption. What this spec owes a gate is a CLI and an exit contract.
 - **`raw.githubusercontent.com` URLs.** 013's parser does not recognise that host at all (only
   `github.com/<owner>/<repo>/{blob,raw}/…`), so such a link never yields an owner and stays
   `web_unverifiable`. The measurement above counts only what the parser recognises.
@@ -541,5 +585,4 @@ No other principle changes: the base rule is a pure textual predicate over data 
   requirement.
 - **P-II is untouched by the letter of this spec but not by its spirit**: `--own-from-origin` makes
   darnlink spawn an external process for the first time. Worth a sentence when the constitution is
-  amended for P-IV, along with the `safe.directory` failure mode (`git` refusing a repo it considers
-  dubiously owned), which FR-003 should list among its exit-1 reasons.
+  amended for P-IV.


### PR DESCRIPTION
## What

Specification only — no implementation in this PR.

The web axis (feature 013) is forgiving by design: a destination that fetches 200 but carries no `uuid` is reported `web_unverifiable` and the run still exits 0. That is correct when the destination lives in someone else's repository, and wrong when it is **yours** — there it is not an external limitation, it is a missing two-line edit in a repo you control, and nothing ever tells you so.

This spec adds an opt-in `--own OWNER` (repeatable, plus a separate `--own-from-origin`), a new `web_own_no_uuid` finding at **exit 4**, a `web_own_exempt` escape hatch, and a `--own-max` budget so the axis can be adopted before a repo reaches zero.

## Why exit 4 and not 3

Exit 3 promises "re-run with `--write`". darnlink **cannot** fix this one: the edit belongs to the destination repository, and Principle II forbids writing there.

## Two exclusions, and the one that was got wrong twice

- A destination that is **not `.md`** can never carry frontmatter.
- A destination pinned to a **commit SHA** (`^[0-9a-fA-F]{7,40}$`, case-folded) can never be given one retroactively.

The exclusion is **textual** and stops there. An earlier revision widened it to "any ref that is not a moving branch head", to cover tags — wrong, and the spec now records why: a tag `v1.2.3` and a branch `v1.2.3` are textually identical, so honouring it needs a network call, and its failure direction is the bad one (a maintenance branch excluded for *looking* like a tag = a false green, the exact failure this feature exists to remove).

## The budget could not be built the obvious way

`--own-max` lives in **darnlink**, not in a gate config. A recipe re-counts `dangling` findings itself and computes its own exit code; the web pass takes `web-check`'s verbatim, and exit 4 is *shared* with `web_mismatch`/`web_not_found` — so a gate cannot tell a budgeted finding from a genuinely dead link. **The gate wiring is deliberately out of scope**: three review rounds spent their findings on it, it is about how a gate consumes any darnlink exit code, and it is how `dangling_max` was done — axis first, recipe key in its own change.

## Evidence

Measured across a nine-repository fleet, in one stated scope: **255** GitHub `blob`/`raw` links, **228 (89%)** pointing at repos owned by the same account, **193 already anchored**. Of the 35 still plain, **17 point at a `.md` whose frontmatter has no `uuid`** — invisible to every axis today.

Two caveats stated rather than buried: the snapshot is **post-remediation** (11 links were fixed by hand that day so the axis can open with a small budget), and **every ref in the fleet is a branch** — so the immutable-ref exclusion is reasoning, not measurement, and the spec says so instead of claiming both exclusions were measured.

## Constitution

The explicit `--own` form costs **nothing**: a textual predicate over data the run already holds, no extra fetch, nothing stored as an index. Only `--own-from-origin` needs a named sentence in P-IV, because it reads the clone's git configuration.

## Review

Copilot returned an empty review (quota) on every push. **Seven independent adversarial passes** were run instead; every verdict and everything applied is in the PR comments. They caught, among others, a correction that had *broken* the rule it was fixing, an escape hatch that did not escape, and a marker whose behaviour contradicted the spec's own "byte-identical" promise. The seventh found no high-severity issue, which is the agreed bar for merging.

The prerequisite this spec was blocked on — `web-check` crashing on an href it cannot send — **landed in `main` as #55** while this was in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)