### PR TITLE
lang: gate the surfaces that actually get published (commit messages, PR titles, issues, .md)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,6 +5,10 @@ title: ''
 labels: bug
 ---
 
+<!-- This project is written in English throughout, issues included. A report in another
+language is welcome and will be read as it stands, but it gets labelled `needs-english`
+until it is translated (.github/workflows/lang-issue.yml). -->
+
 **What happened**
 A clear description of the bug.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,6 +5,10 @@ title: ''
 labels: enhancement
 ---
 
+<!-- This project is written in English throughout, issues included. A report in another
+language is welcome and will be read as it stands, but it gets labelled `needs-english`
+until it is translated (.github/workflows/lang-issue.yml). -->
+
 **The problem**
 What are you trying to do that darnlink doesn't support today?
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,5 +6,6 @@ What does this PR change, and why?
 **Checklist**
 - [ ] Tests added/updated and `uv run pytest` passes.
 - [ ] `uv run darnlink .` is clean (the repo's own links stay robust).
-- [ ] Everything is in English (code, docs, commit messages).
+- [ ] Everything is in English — code, docs, commit messages, **and the title and description of
+      this PR**. The `lang` CI job checks all four; see CONTRIBUTING.md.
 - [ ] Stays within scope (links + UUIDs only — see the constitution).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,11 +47,11 @@ jobs:
       - name: English-only gate — tracked files (fail-closed, baseline pinned at 0)
         run: python3 tools/lang_gate.py --baseline
 
-      # The two steps below guard the surfaces no file gate can ever see: the text that goes
-      # straight into GitHub. They live here, and not only in the local hooks, because hooks are
-      # opt-in per clone and one `--no-verify` away — and because what leaks here is public and
-      # permanent. Measured on 2026-08-11, with the file gate green: 4 PR titles and 7 commit
-      # subjects on `main` in Spanish.
+      # Commit messages: a surface no file gate can see, and one the local `hooks/commit-msg` cannot
+      # be trusted to have covered — hooks are opt-in per clone and one `--no-verify` away. Measured
+      # on 2026-08-11 with the file gate green: 7 Spanish commit subjects on `main`.
+      # It rides in this job (and not in `lang-pr.yml` with the title check) because it is tied to
+      # the COMMITS, so `synchronize` — already a trigger here — is exactly when it must re-run.
       - name: English-only gate — commit messages added by this PR
         if: github.event_name == 'pull_request'
         run: |
@@ -59,17 +59,6 @@ jobs:
             "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" \
             > "$RUNNER_TEMP/msgs.txt"
           python3 tools/lang_gate.py --prose "$RUNNER_TEMP/msgs.txt" --label "set of commit messages"
-
-      - name: English-only gate — PR title and description
-        if: github.event_name == 'pull_request'
-        # The text travels through the environment, never through the shell. A PR title on a public
-        # repo is attacker-controlled, and `run: echo "${{ github.event… }}"` is script injection.
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" > "$RUNNER_TEMP/pr.txt"
-          python3 tools/lang_gate.py --prose "$RUNNER_TEMP/pr.txt" --label "PR title/description"
 
   # Exercises the commands users actually run (packaging + entry point + the literal README
   # one-liner) on Linux AND Windows — so the copy-paste one-liner is proven on both.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history: the commit-message step below ranges over the commits this PR adds,
+          # and with the default depth of 1 there is no range to walk.
+          fetch-depth: 0
       # No setup step on purpose: the gate is pure stdlib, so it cannot fail for reasons
       # unrelated to what it guards — which is how a gate keeps its credibility.
-      - name: English-only gate (fail-closed — baseline pinned at 0)
+      - name: English-only gate — tracked files (fail-closed, baseline pinned at 0)
         run: python3 tools/lang_gate.py --baseline
+
+      # The two steps below guard the surfaces no file gate can ever see: the text that goes
+      # straight into GitHub. They live here, and not only in the local hooks, because hooks are
+      # opt-in per clone and one `--no-verify` away — and because what leaks here is public and
+      # permanent. Measured on 2026-08-11, with the file gate green: 4 PR titles and 7 commit
+      # subjects on `main` in Spanish.
+      - name: English-only gate — commit messages added by this PR
+        if: github.event_name == 'pull_request'
+        run: |
+          git log --format=%B \
+            "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}" \
+            > "$RUNNER_TEMP/msgs.txt"
+          python3 tools/lang_gate.py --prose "$RUNNER_TEMP/msgs.txt" --label "set of commit messages"
+
+      - name: English-only gate — PR title and description
+        if: github.event_name == 'pull_request'
+        # The text travels through the environment, never through the shell. A PR title on a public
+        # repo is attacker-controlled, and `run: echo "${{ github.event… }}"` is script injection.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" > "$RUNNER_TEMP/pr.txt"
+          python3 tools/lang_gate.py --prose "$RUNNER_TEMP/pr.txt" --label "PR title/description"
 
   # Exercises the commands users actually run (packaging + entry point + the literal README
   # one-liner) on Linux AND Windows — so the copy-paste one-liner is proven on both.

--- a/.github/workflows/lang-issue.yml
+++ b/.github/workflows/lang-issue.yml
@@ -1,0 +1,84 @@
+# English-only, applied to ISSUES — the surface where the rule leaked worst.
+#
+# WHY THIS IS A SEPARATE, WEAKER MECHANISM. Every other surface has a wall: a hook refuses the
+# commit, a red check blocks the merge. An issue has neither — GitHub has no pre-receive equivalent
+# for issues, so by the time any automation runs, the text is already published. The honest design
+# is therefore not a gate but a SIGNAL: label the issue and say so once, in a comment.
+#
+# It still earns its place. On 2026-08-11 both open issues in this public repo were written entirely
+# in Spanish — title and body — and had been for days, with CI green the whole time, because
+# nothing anywhere was looking at that surface. A visible label the owner sees in the issue list is
+# the difference between "found in three days" and "found never".
+#
+# Note for people arriving from outside: this is a house rule about the language the project is
+# written in, not a filter on who may report a bug. A report in another language is welcome and
+# will be translated — the label is a to-do, not a rejection.
+name: lang-issue
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  english:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Judge the issue title and body
+        id: check
+        # Through the environment, never through the shell: an issue title on a public repo is
+        # written by anyone at all, and `run: echo "${{ github.event… }}"` is script injection.
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          printf '%s\n\n%s\n' "$ISSUE_TITLE" "$ISSUE_BODY" > "$RUNNER_TEMP/issue.txt"
+          if python3 tools/lang_gate.py --prose "$RUNNER_TEMP/issue.txt" --label "issue"; then
+            echo "english=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "english=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Flag it
+        if: steps.check.outputs.english == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          # Already labelled means this issue was already commented on: an `edited` event fires on
+          # every keystroke-batch GitHub sends, and a bot that repeats itself gets muted.
+          ALREADY: ${{ contains(github.event.issue.labels.*.name, 'needs-english') }}
+        run: |
+          gh label create needs-english -R "$REPO" \
+            --color D93F0B --description "Written in another language; needs translating" || true
+          gh issue edit "$NUMBER" -R "$REPO" --add-label needs-english
+          if [ "$ALREADY" != "true" ]; then
+            # Heredoc + --body-file, not an inline --body: an indented multi-line shell string
+            # carries its own indentation into the comment, and four leading spaces are a code
+            # block in Markdown.
+            cat > "$RUNNER_TEMP/comment.md" <<EOF
+          This project is written in English throughout — code, docs, commit messages, PR titles and
+          issues (see [CONTRIBUTING.md](https://github.com/$REPO/blob/main/CONTRIBUTING.md)). This
+          issue looks like it is in another language, so it has been labelled \`needs-english\`.
+
+          Nothing is wrong with the report itself and it will be read as it stands; the label only
+          marks that the text still needs translating. Posted automatically by
+          \`.github/workflows/lang-issue.yml\`.
+          EOF
+            gh issue comment "$NUMBER" -R "$REPO" --body-file "$RUNNER_TEMP/comment.md"
+          fi
+          # Fail on purpose: the red run in the Actions tab is the durable record. The label can be
+          # removed by hand, a comment scrolls away, but the run stays attached to the event.
+          exit 1
+
+      - name: Clear the flag once it is translated
+        if: steps.check.outputs.english == 'true' && contains(github.event.issue.labels.*.name, 'needs-english')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+        run: gh issue edit "$NUMBER" -R "$REPO" --remove-label needs-english

--- a/.github/workflows/lang-pr.yml
+++ b/.github/workflows/lang-pr.yml
@@ -1,0 +1,38 @@
+# English-only, applied to the PR TITLE and DESCRIPTION.
+#
+# WHY THIS IS NOT A STEP IN `ci.yml`. It has to re-run when the *text* changes, and the text is not
+# the code: `on: pull_request` defaults to `[opened, synchronize, reopened]`, none of which fires
+# when somebody edits a title. Living in `ci.yml` it would have two failure modes, and the second
+# one is the bad one:
+#
+#   * open the PR with a non-English title -> red, fix the title -> still red, because nothing
+#     re-ran. The only way out is an empty commit, which is how a check teaches people to route
+#     around it;
+#   * open it in English and rename it afterwards -> never checked again. The gate would be
+#     satisfiable by waiting.
+#
+# Adding `edited` to `ci.yml`'s trigger instead would re-run the whole 16-job matrix (tests on four
+# Pythons x two OSes, plus smoke) on every typo fix in a description. This job is pure stdlib and
+# needs no toolchain, so it costs seconds — and the billing on this account has been the thing that
+# stops CI before, which makes "cheap" a correctness property here, not an aesthetic one.
+name: lang-pr
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  title-and-body:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: English-only gate — PR title and description
+        # The text travels through the environment, never interpolated into the shell. A PR title
+        # on a public repo is written by anyone at all, and `run: echo "${{ github.event… }}"` is
+        # script injection.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" > "$RUNNER_TEMP/pr.txt"
+          python3 tools/lang_gate.py --prose "$RUNNER_TEMP/pr.txt" --label "PR title/description"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **The English-only gate now covers the surfaces that are actually published**: commit messages,
+  PR titles/descriptions, issues, and `.md` documentation. Until now it judged one thing —
+  comment lines in `.py` files — while the rule it enforces has always covered far more. The gap was
+  not theoretical: with the gate green and the tree at zero, this public repo carried **2 of 2 open
+  issues written entirely in Spanish, 4 Spanish PR titles and 7 Spanish commit subjects on `main`**.
+  Files were the only surface anybody had wired, so files were the only surface that stayed clean.
+
+  New `lang_gate.py --prose FILE|-` judges free text (fenced blocks, inline `code` and URLs are
+  exempt, so pasting real output is safe), wired into four places: `hooks/commit-msg`, a CI step over
+  every commit a PR adds, a CI step on the PR title and body, and `.github/workflows/lang-issue.yml`.
+
+  **The issue surface cannot block and does not pretend to** — GitHub has no pre-publication hook for
+  issues, so that workflow labels `needs-english` and comments once. Worth knowing when you write
+  one: it tells you *after* the text is public.
+
+### Fixed
+- **`.md` prose was unjudgeable by construction.** The tree scan applied the Python rule to every
+  file, and that rule rejects any line containing `:` or `(` as "code" — which is most of a written
+  paragraph. Markdown is now judged with its own rule (everything is prose except fenced blocks),
+  which immediately surfaced five Spanish lines in this file, sitting under a green gate since
+  v0.6.0. Translated here; the baseline stays pinned at 0.
+
 ## [0.20.4] — 2026-08-10
 
 ### Added
@@ -452,12 +475,12 @@ the `recipes/` changes below live at a pinned tag that CI and hooks can fetch de
 - **Release automation via PyPI Trusted Publishing (OIDC)** — `.github/workflows/publish.yml` builds
   the sdist + wheel, runs `twine check`, and uploads on a published GitHub Release. **No API token
   is stored anywhere.**
-- **`recipes/darnlink-gate`: modo FAIL-CLOSED** (`DARNLINK_GATE_FAIL_CLOSED=1`, o `"fail_closed": true`
-  en `darnlink-gate.json`). La receta falla **abierta** por defecto —correcto en pre-commit: un commit
-  offline no debe quedar bloqueado— pero eso **en CI es peligroso**: el gate *es* el muro, y un fallo
-  transitorio de red/PyPI daba **build VERDE con cero ficheros validados**. Con el flag, esos casos
-  salen con código **4** (distinguible de los hallazgos: `2` integridad, `3` strict). Actívalo siempre
-  en CI. Detectado por una revisión adversarial de la propia receta.
+- **`recipes/darnlink-gate`: FAIL-CLOSED mode** (`DARNLINK_GATE_FAIL_CLOSED=1`, or `"fail_closed": true`
+  in `darnlink-gate.json`). The recipe fails **open** by default — right for pre-commit, where an
+  offline commit must not be blocked — but that is **dangerous in CI**: there the gate *is* the wall,
+  and a transient network/PyPI failure produced a **GREEN build with zero files validated**. With the
+  flag those cases exit with code **4**, distinguishable from findings (`2` integrity, `3` strict).
+  Always turn it on in CI. Found by an adversarial review of the recipe itself.
 
 ### Fixed
 - **Docs: stale version pins.** The README's quality-gate examples still pinned `rev: v0.1.1` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,5 +7,22 @@ shell commands, and other important information, read the current plan
 
 darnlink is an open-source project intended to be published publicly. **Everything in this repo
 is written in English** — code, comments, docstrings, documentation, spec files, commit messages,
-**and pull request titles/descriptions**. No exceptions, regardless of the language used in the
-session chat.
+**pull request titles/descriptions, and GitHub issues and their comments**. No exceptions,
+regardless of the language used in the session chat.
+
+**The enumeration above is not decoration: each surface names what enforces it.** Until 2026-08-11
+the rule was stated exactly once and checked in exactly one place — `.py` comments — and the result
+was that the file gate stayed green while the *published* surfaces filled up with Spanish: both open
+issues, four PR titles, seven commit subjects on `main`. A rule that is only written down is a rule
+that is only broken where nobody measures.
+
+| Surface | What checks it | Can it block? |
+|---|---|---|
+| `.py` comments/docstrings, `.md` docs | `tools/lang_gate.py --baseline` (`tools/check.sh`, `lang` CI job) | yes — pre-commit, pre-push, CI |
+| Commit message | `hooks/commit-msg` + the CI step over the PR's commits | yes |
+| PR title / description | CI step in the `lang` job | yes — the merge is blocked |
+| Issue title / body | `.github/workflows/lang-issue.yml` | **no** — GitHub cannot gate an issue before it is published, so it labels `needs-english` and comments once |
+
+The last row is the one to internalise when writing: for an issue, **there is no wall to catch
+you**. If you are about to open one from a session held in Spanish, translate it as you write it —
+the automation can only tell you afterwards, in public.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,10 +36,21 @@ CI (`.github/workflows/ci.yml`) runs on every PR; please make sure it's green. A
 `hooks/pre-commit` is available — activate it with `bash setup.sh` (sets `core.hooksPath`).
 
 **Everything in this repo is written in English** — code, comments, docstrings, docs, spec files,
-commit messages and PR titles/descriptions. A gate enforces it (`tools/lang_gate.py`, run by
-`tools/check.sh` and by the `lang` CI job), so a comment in another language fails the build. The
-detector is a heuristic and can be wrong; silence a genuine false positive with a trailing
-`# lang-ok` on that line.
+commit messages, PR titles/descriptions, and issues. `tools/lang_gate.py` enforces it on four
+surfaces:
+
+- **tracked files** (`.py` comments and docstrings, `.md` prose) — `tools/check.sh` and the `lang`
+  CI job;
+- **commit messages** — `hooks/commit-msg`, plus a CI step over every commit the PR adds;
+- **PR title and description** — a CI step, so a non-English title blocks the merge;
+- **issues** — `.github/workflows/lang-issue.yml`. GitHub offers no way to gate an issue before it
+  is published, so this one cannot block: it labels the issue `needs-english` and says so once in a
+  comment. A report in another language is welcome and will be read as it stands — the label marks
+  translation as pending, it is not a rejection.
+
+The detector is a heuristic and can be wrong; silence a genuine false positive with a trailing
+`# lang-ok` on that line (`<!-- lang-ok -->` in Markdown, where `#` is a heading). Code inside
+fenced blocks, inline `code` spans and URLs are never judged, so pasting real output is safe.
 
 ## Pull requests
 

--- a/hooks/commit-msg
+++ b/hooks/commit-msg
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Versioned git commit-msg hook — the English-only rule, applied to the COMMIT MESSAGE.
+#
+# Activate ONCE per clone (git will not auto-run versioned hooks, by design — security):
+#   git config core.hooksPath hooks
+# (Or let the toolbelt's global dispatcher do it: it runs hooks/<name> and hooks/<name>.d/*.)
+#
+# Why this surface exists, and why it was the last one to get a wall.
+# CONTRIBUTING.md and CLAUDE.md have always said commit messages are English. Nothing checked it,
+# and the result is measurable and permanent: 7 commit subjects on `main` are in Spanish, on a
+# public repository, in the history of a tool whose whole promise is that the repo is portable.
+# A file gate cannot catch this — the message is not a file — so it needs its own hook.
+#
+# It runs BEFORE the commit exists, which is the only moment the message is still cheap to fix:
+# afterwards it takes an `--amend` (or, once pushed and merged, it is simply permanent).
+#
+# `--git-comments` drops git's own template lines (`#…`), which are written in the machine's locale
+# and would otherwise fail the gate on text the author never wrote, and stops at the `>8` scissors
+# so a `--verbose` commit does not get its own diff judged as prose.
+#
+# Bypass (discouraged): git commit --no-verify
+set -euo pipefail
+exec python3 "$(git rev-parse --show-toplevel)/tools/lang_gate.py" \
+    --prose "$1" --git-comments --label "commit message"

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 # Activate this repo's git hooks — one-time, per clone.
 #
-# Wires up:  git commit  ->  hooks/pre-commit  ->  this repo's darnlink quality gate
-#            (fails the commit if a Markdown link is broken/unresolvable, or a frontmatter
-#            isn't valid YAML). This script only flips the switch (core.hooksPath=hooks);
-#            the gate itself lives in hooks/pre-commit.
+# Wires up three events, all of them by flipping one switch (core.hooksPath=hooks):
+#   git commit  ->  hooks/pre-commit   the darnlink quality gate (broken/unresolvable link,
+#                                      invalid YAML frontmatter)
+#               ->  hooks/commit-msg   the commit MESSAGE must be English (tools/lang_gate.py)
+#   git push    ->  hooks/pre-push     the same gate over the whole repo
+# The gates themselves live in those files; this script only flips the switch.
 # git won't auto-run versioned hooks on clone (security) — hence this installer.
-# Not needed if your machine already has the global hook dispatcher (toolbelt deploy.sh).
+#
+# Not needed if your machine already has a global hook dispatcher — but note that a dispatcher
+# only runs the events it has an entry for, and a missing one is a SILENT no-op: the repo's hook
+# is there, executable and never called. `commit-msg` is the newest of the three.
 set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 current="$(git config --local --get core.hooksPath 2>/dev/null || true)"

--- a/tests/test_lang_gate.py
+++ b/tests/test_lang_gate.py
@@ -72,6 +72,13 @@ def test_inline_code_and_urls_are_not_judged():
     assert _run("--prose", "-", stdin=body).returncode == 0
 
 
+def test_solo_is_an_english_word_and_does_not_fire():
+    """Measured, not assumed: this exact sentence is from a real PR description in this repo and was
+    1 of the 8 hits in the first sweep. The accented form is still caught."""
+    assert _run("--prose", "-", stdin="Fine solo; with several sessions it is not.\n").returncode == 0
+    assert _run("--prose", "-", stdin="sólo se comprueba al escribir\n").returncode == 1
+
+
 def test_escape_hatch_silences_a_line():
     assert _run("--prose", "-", stdin="quoting the original report: no funciona  lang-ok\n").returncode == 0
 

--- a/tests/test_lang_gate.py
+++ b/tests/test_lang_gate.py
@@ -102,6 +102,39 @@ def test_tree_scan_covers_both_families():
     assert ".py" in lang_gate._EXTS and ".md" in lang_gate._EXTS
 
 
+# --- widening coverage is an adoption, not a regression -----------------------------------------
+
+def test_a_baseline_from_an_older_coverage_says_so_instead_of_blaming_the_repo():
+    """This tool is vendored verbatim into other repos. The day it starts judging a new file family
+    every consumer's count jumps through nobody's fault, and reporting that as "the count GREW —
+    do NOT raise the baseline" would be advice that is exactly backwards."""
+    baseline = REPO / "tools" / "lang_gate_baseline.json"
+    original = baseline.read_text(encoding="utf-8")
+    try:
+        baseline.write_text('{"count": 0, "scanned_exts": [".py"], "files": {}}\n', encoding="utf-8")
+        r = _run("--baseline")
+        assert r.returncode == 1
+        assert "COVERAGE CHANGED" in r.stderr
+        assert "ADOPTION, not a regression" in r.stderr
+        assert ".md" in r.stderr
+    finally:
+        baseline.write_text(original, encoding="utf-8")
+
+
+def test_a_baseline_predating_the_field_is_not_treated_as_a_coverage_change():
+    """Consumers on the old format have no `scanned_exts`. Absent must mean "unknown", not "empty",
+    or every one of them fails on a field they have never heard of."""
+    baseline = REPO / "tools" / "lang_gate_baseline.json"
+    original = baseline.read_text(encoding="utf-8")
+    try:
+        baseline.write_text('{"count": 0, "files": {}}\n', encoding="utf-8")
+        r = _run("--baseline")
+        assert r.returncode == 0, r.stderr
+        assert "COVERAGE CHANGED" not in r.stderr
+    finally:
+        baseline.write_text(original, encoding="utf-8")
+
+
 # --- the repo's own state ----------------------------------------------------------------------
 
 def test_this_repo_is_clean():

--- a/tests/test_lang_gate.py
+++ b/tests/test_lang_gate.py
@@ -1,0 +1,110 @@
+"""Tests for `tools/lang_gate.py` — the English-only gate.
+
+The gate had no tests at all until it started guarding PUBLIC, PERMANENT surfaces (commit messages,
+PR titles, issues). That raised the cost of a silent regression from "a Spanish comment lands in a
+file, and the next tree scan catches it" to "a Spanish issue title is published on a public repo and
+nothing ever notices" — which is exactly what happened on 2026-08-11.
+
+The gate is a heuristic, so what is worth pinning is not its dictionary but the three decisions that
+make it usable: what counts as prose in each file family, what is exempt (fenced code, inline
+`code`, URLs, the escape hatch), and the fact that it exits non-zero.
+"""
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+TOOL = REPO / "tools" / "lang_gate.py"
+
+_spec = importlib.util.spec_from_file_location("lang_gate", TOOL)
+lang_gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lang_gate)
+
+
+def _run(*args, stdin: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, str(TOOL), *args], input=stdin,
+                          capture_output=True, text=True)
+
+
+# --- prose mode: the surfaces that reach GitHub ------------------------------------------------
+
+def test_spanish_commit_message_is_rejected():
+    r = _run("--prose", "-", stdin="release: v0.20.4 — el peldano que faltaba entre repo y added-lines\n")
+    assert r.returncode == 1
+    assert "does not look like English" in r.stderr
+
+
+def test_english_commit_message_passes():
+    r = _run("--prose", "-", stdin="gate: a budget that makes the strictest rung adoptable\n")
+    assert r.returncode == 0
+
+
+def test_git_template_comments_are_not_judged():
+    """git writes its template in the machine's LOCALE. Judging it fails the author for text they
+    did not write and git is about to strip — the fastest way to get a hook uninstalled."""
+    msg = "fix: keep the fence state per file\n\n# Por favor ingresa el mensaje de confirmacion\n"
+    assert _run("--prose", "-", "--git-comments", stdin=msg).returncode == 0
+    # …and without the flag the same text IS judged, so the exemption is the flag's doing.
+    assert _run("--prose", "-", stdin=msg).returncode == 1
+
+
+def test_verbose_commit_diff_below_the_scissors_is_not_judged():
+    msg = ("fix: something\n"
+           "# ------------------------ >8 ------------------------\n"
+           "+# esto es una linea del diff que git pega con --verbose\n")
+    assert _run("--prose", "-", "--git-comments", stdin=msg).returncode == 0
+
+
+def test_fenced_block_in_an_issue_body_is_not_judged():
+    """An issue body pastes real output. A Spanish path inside a fence is data, not prose."""
+    body = ("The gate misses this case:\n\n"
+            "```\n"
+            "docs/investigacion.md: enlace roto para el destino que no existe\n"
+            "```\n\n"
+            "Expected: a finding.\n")
+    assert _run("--prose", "-", stdin=body).returncode == 0
+
+
+def test_inline_code_and_urls_are_not_judged():
+    body = ("See `docs/investigacion-para-el-caso.md` and "
+            "https://example.invalid/una-pagina-con-nombre-largo for the details.\n")
+    assert _run("--prose", "-", stdin=body).returncode == 0
+
+
+def test_escape_hatch_silences_a_line():
+    assert _run("--prose", "-", stdin="quoting the original report: no funciona  lang-ok\n").returncode == 0
+
+
+def test_unreadable_prose_file_fails_closed():
+    """The whole point of this mode is the surfaces nothing else watches: an unreadable message is
+    not an English message."""
+    assert _run("--prose", str(REPO / "does-not-exist.txt")).returncode == 1
+
+
+# --- file families -----------------------------------------------------------------------------
+
+def test_markdown_prose_is_judged_although_it_carries_code_punctuation():
+    """The regression that let five Spanish lines sit in this repo's own CHANGELOG under a green
+    gate: `_is_commentish` rejects any line with a `:` or `(`, which is most written prose."""
+    line = "en `darnlink-gate.json`). La receta falla abierta por defecto: un commit offline"
+    assert lang_gate._offending(line, "CHANGELOG.md", False)
+    assert not lang_gate._offending(line, "CHANGELOG.md", True)      # inside a fence
+    assert not lang_gate._offending(line, "tools/x.py", False)       # code rule: not a comment
+
+
+def test_python_code_is_still_judged_by_the_comment_rule():
+    assert lang_gate._offending("# esto no puede pasar aqui", "tools/x.py")
+    assert not lang_gate._offending("total = para_value + 1", "tools/x.py")
+
+
+def test_tree_scan_covers_both_families():
+    assert ".py" in lang_gate._EXTS and ".md" in lang_gate._EXTS
+
+
+# --- the repo's own state ----------------------------------------------------------------------
+
+def test_this_repo_is_clean():
+    """Dogfood: darnlink pins its baseline at 0, so the gate is fail-closed here."""
+    r = _run("--baseline")
+    assert r.returncode == 0, r.stderr

--- a/tools/lang_gate.py
+++ b/tools/lang_gate.py
@@ -331,22 +331,52 @@ def main() -> int:
         with open(_BASELINE, "w", encoding="utf-8") as fh:
             json.dump({"count": n,
                        "note": "Legacy Spanish lines. This number may only DECREASE.",
+                       # What the number counts. Without it, widening coverage in this file is
+                       # indistinguishable from a repo getting worse -- see below.
+                       "scanned_exts": sorted(_EXTS),
                        "files": dict(sorted(per_file.items()))}, fh, indent=2)
             fh.write("\n")
-        print(f"lang-gate: baseline updated to {n} across {len(per_file)} file(s).")
+        print(f"lang-gate: baseline updated to {n} across {len(per_file)} file(s) "
+              f"(covering {', '.join(sorted(_EXTS))}).")
         return 0
 
     try:
-        base = json.load(open(_BASELINE, encoding="utf-8"))["count"]
+        baseline = json.load(open(_BASELINE, encoding="utf-8"))
+        base = baseline["count"]
     except (OSError, ValueError, KeyError):
         print(f"lang-gate: no readable baseline; current count is {n}. "
               f"Create it with --update-baseline.", file=sys.stderr)
         return 1
+
+    # COVERAGE CHANGED is not the same failure as THE REPO GOT WORSE, and conflating them is a lie
+    # the ratchet tells on its own behalf. This file is vendored verbatim into every repo that runs
+    # the gate, so the day it starts judging a new file family (`.md`, on 2026-08-11) every consumer
+    # sees its count jump — through no fault of anyone's commit. Reported as "the count GREW", with
+    # "do NOT raise the baseline" underneath, that message is actively wrong: raising it once IS the
+    # correct move, exactly as when a repo adopts the rule late. So it gets its own message, and it
+    # still fails, because a coverage change that nobody notices is how a gate silently loosens.
+    covered = baseline.get("scanned_exts")
+    if covered is not None and sorted(covered) != sorted(_EXTS):
+        gained = sorted(set(_EXTS) - set(covered))
+        lost = sorted(set(covered) - set(_EXTS))
+        print(f"lang-gate: COVERAGE CHANGED -- the baseline counts {', '.join(sorted(covered))} "
+              f"but this version judges {', '.join(sorted(_EXTS))}.", file=sys.stderr)
+        if gained:
+            print(f"  now also judged: {', '.join(gained)}  (current total: {n} line(s))",
+                  file=sys.stderr)
+        if lost:
+            print(f"  NO LONGER judged: {', '.join(lost)} -- coverage went DOWN, which the ratchet "
+                  f"exists to prevent. Do not accept this without knowing why.", file=sys.stderr)
+        print("\nThis is an ADOPTION, not a regression: re-seed once with --update-baseline and "
+              "then the number may only fall, as usual. (Adding a family is the same move as "
+              "adopting the rule late, which is what the baseline was built for.)", file=sys.stderr)
+        return 1
+
     if n > base:
         # Name the files that GREW, not the first 25 hits in the tree.
         base_files = {}
         try:
-            base_files = json.load(open(_BASELINE, encoding="utf-8")).get("files") or {}
+            base_files = baseline.get("files") or {}
         except (OSError, ValueError):
             pass
         if base_files:

--- a/tools/lang_gate.py
+++ b/tools/lang_gate.py
@@ -66,11 +66,17 @@ import sys
 # It is also a Python keyword, but that collision is handled where it belongs -- `_is_commentish`
 # refuses to read a `del x` statement as prose -- rather than by blunting the dictionary.  # lang-ok
 #
+# `solo` was dropped on 2026-08-11 for the same reason as `sin`, and again only after measuring: it  # lang-ok
+# is an ordinary English word ("fine solo; with several sessions it is not"), and that sentence --
+# impeccable English in a PR description -- was 1 of the 8 hits in the first sweep of this repo's
+# pull requests. Nothing is lost that matters: the ACCENTED form is still caught by the accent
+# class, and unaccented Spanish prose containing it reliably trips some other word in the list.
+#
 # The list below trips the detector on itself, so every line carries the escape hatch. That the
 # gate has to exempt its own dictionary is a good smoke test that the escape hatch works at all.
 _WORDS = (
     r"que|para|con|los|las|del|por|una|como|pero|desde|cuando|porque|sobre|hasta|"  # lang-ok
-    r"solo|s[oó]lo|as[ií]|aqu[ií]|esto|esta|este|ese|esa|cada|hay|ser|est[aá]n?|son|"  # lang-ok
+    r"as[ií]|aqu[ií]|esto|esta|este|ese|esa|cada|hay|ser|est[aá]n?|son|"  # lang-ok
     r"tiene|hace|puede|debe|siempre|nunca|tambi[eé]n|adem[aá]s|entonces|aunque|mientras|"  # lang-ok
     r"antes|despu[eé]s|ahora|luego|donde|qui[eé]n|cu[aá]l|nada|algo|otro|otra|mismo|misma"  # lang-ok
 )

--- a/tools/lang_gate.py
+++ b/tools/lang_gate.py
@@ -16,15 +16,26 @@ uses: legacy lines sit in
 a baseline whose count can only DECREASE, while new or modified lines must be English from now on.
 A repo that starts clean pins its baseline at 0, which is fail-closed with no extra machinery.
 
-Two modes:
+Modes:
 
     lang_gate.py --diff [REF]     # pre-commit / PR: only ADDED lines (default REF: staged)
     lang_gate.py --baseline       # CI: whole tree; fails if the count GREW vs the baseline file
     lang_gate.py --update-baseline  # after translating: write the new (lower) count
+    lang_gate.py --prose FILE|-   # free prose: a commit message, an issue/PR title+body
+
+WHY A PROSE MODE, AND WHY IT IS THE ONE THAT WAS MISSING (2026-08-11). The three modes above judge
+only what git tracks, and only lines that look like comments. But the rule has always covered
+commit messages, PR titles/descriptions and issues too -- and those are written straight into
+GitHub, where no file gate can ever see them. Measured on this repo the day the hole was found:
+the tree was clean while 2 of 2 open issues, 4 PR titles and 7 commit subjects on `main` were in
+Spanish, permanently, on a public repository. A gate that guards only the surface nobody publishes
+on is not a gate, it is a decoration. `--prose` reads that text from a file (or stdin) so a
+`commit-msg` hook and a CI workflow can feed it what GitHub is about to show the world.
 
 The detector is deliberately a heuristic: Spanish function words plus accented characters, looked
-for only in comments and docstrings. It cannot be exact -- `no`, `final` and `total` are valid in
-both languages -- so a genuine false positive is silenced with a trailing `# lang-ok`.
+for only in comments, docstrings and prose. It cannot be exact -- `no`, `final` and `total` are
+valid in both languages -- so a genuine false positive is silenced with a trailing `# lang-ok`
+(`<!-- lang-ok -->` in Markdown, where a `#` is a heading and not a comment).
 
 Prior art was evaluated and rejected before writing this (2026-08-09): `flake8-only-english`
 detects `ord(ch) > 127`, which misses a third of the Spanish in these repos because a third of it
@@ -65,8 +76,21 @@ _WORDS = (
 )
 _SPANISH = re.compile(rf"\b(?:{_WORDS})\b|[áéíóúñ¿¡]", re.IGNORECASE)
 _ESCAPE = "lang-ok"
-_EXTS = (".py",)
+
+# Two families, judged by different rules -- see `_is_prose`.
+#   CODE: only comment/docstring lines are prose; the rest is code and must not be read as language.
+#   DOC : the whole file is prose, minus fenced code blocks and inline `code` spans.
+# Docs were outside the gate until 2026-08-11 even though the rule always covered them ("code,
+# comments, docstrings, documentation"). The cost of closing it was measured before doing it: five
+# lines, all in one CHANGELOG entry. A rule that is stated and not measured is a rule nobody knows
+# is being broken.
+_CODE_EXTS = (".py",)
+_DOC_EXTS = (".md",)
+_EXTS = _CODE_EXTS + _DOC_EXTS
 _SKIP_DIRS = {".git", ".venv", "node_modules", "__pycache__", "_build", "backup", "dist", "build"}
+_FENCE = re.compile(r"^\s*(?:```|~~~)")
+_INLINE_CODE = re.compile(r"`[^`]*`")
+_URL = re.compile(r"https?://\S+")
 _BASELINE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "lang_gate_baseline.json")
 
 
@@ -91,10 +115,48 @@ def _is_commentish(line: str) -> bool:
     return bool(s) and not re.search(r"[=(){}\[\];:]|^\s*(def|class|import|from|return|del)\b", s)
 
 
-def _offending(line: str) -> bool:
+def _strip_verbatim(line: str) -> str:
+    """Drop the parts of a prose line that are not language: inline `code` spans and URLs.
+
+    Without this, documentation is unjudgeable: a path like `docs/investigacion.md` or a URL with a
+    Spanish slug is not prose in another language, it is an identifier that happens to spell one --
+    and a gate that fires on identifiers is a gate that gets bypassed.
+    """
+    return _URL.sub("", _INLINE_CODE.sub("", line))
+
+
+def _is_prose(path: str, line: str, in_fence: bool) -> bool:
+    """Whether this line should be read as language at all, by file family.
+
+    Docs invert the default: in a `.md` everything is prose EXCEPT fenced blocks, whereas in a
+    `.py` everything is code EXCEPT comments and docstrings. Judging a `.md` with the code rule
+    silently misses most of it -- `_is_commentish` rejects any line carrying `:` or `(`, which is
+    most of a written paragraph. That is how the five Spanish lines in this repo's own CHANGELOG
+    sat under a green gate.
+    """
+    if path.endswith(_DOC_EXTS):
+        return not in_fence and bool(_strip_verbatim(line).strip())
+    return _is_commentish(line)
+
+
+def _offending(line: str, path: str = "x.py", in_fence: bool = False) -> bool:
     if _ESCAPE in line:
         return False
-    return _is_commentish(line) and bool(_SPANISH.search(line))
+    if not _is_prose(path, line, in_fence):
+        return False
+    return bool(_SPANISH.search(_strip_verbatim(line) if path.endswith(_DOC_EXTS) else line))
+
+
+def _scan_lines(path: str, lines: list[str]) -> list[tuple[int, str]]:
+    """Offending lines of one file's content, tracking fenced code blocks for docs."""
+    hits, in_fence = [], False
+    for i, ln in enumerate(lines, 1):
+        if path.endswith(_DOC_EXTS) and _FENCE.match(ln):
+            in_fence = not in_fence
+            continue
+        if _offending(ln, path, in_fence):
+            hits.append((i, ln.strip()))
+    return hits
 
 
 def scan_tree(root: str) -> list[tuple[str, int, str]]:
@@ -105,14 +167,35 @@ def scan_tree(root: str) -> list[tuple[str, int, str]]:
             if not fn.endswith(_EXTS):
                 continue
             p = os.path.join(dirpath, fn)
+            rel = os.path.relpath(p, root)
             try:
                 lines = open(p, encoding="utf-8").read().splitlines()
             except (OSError, UnicodeDecodeError):
                 continue
-            for i, ln in enumerate(lines, 1):
-                if _offending(ln):
-                    hits.append((os.path.relpath(p, root), i, ln.strip()))
+            hits.extend((rel, i, text) for i, text in _scan_lines(rel, lines))
     return hits
+
+
+def _fenced_lines(path: str) -> set[int]:
+    """Line numbers of `path` that sit inside a fenced code block, read from the working tree.
+
+    A unified diff carries no fence state -- an added line inside a ``` block looks exactly like an
+    added paragraph -- so a doc file has to be re-read to know. The post-image on disk is the right
+    approximation for the two callers that matter (pre-commit and a PR range), and when the file is
+    not readable the caller simply falls back to judging the line as prose, which errs toward MORE
+    findings rather than fewer. That is the correct direction for a gate.
+    """
+    inside, fenced, n = False, set(), 0
+    try:
+        for n, ln in enumerate(open(path, encoding="utf-8").read().splitlines(), 1):
+            if _FENCE.match(ln):
+                inside = not inside
+                fenced.add(n)
+            elif inside:
+                fenced.add(n)
+    except (OSError, UnicodeDecodeError):
+        return set()
+    return fenced
 
 
 def scan_diff(ref: str | None) -> list[tuple[str, int, str]]:
@@ -124,10 +207,11 @@ def scan_diff(ref: str | None) -> list[tuple[str, int, str]]:
     except (OSError, subprocess.CalledProcessError) as exc:
         print(f"lang-gate: cannot read the diff ({exc}) -> SKIPPING", file=sys.stderr)
         return []
-    hits, path, lineno = [], None, 0
+    hits, path, lineno, fenced = [], None, 0, set()
     for ln in out.splitlines():
         if ln.startswith("+++ b/"):
             path = ln[6:]
+            fenced = _fenced_lines(path) if path.endswith(_DOC_EXTS) else set()
             continue
         m = re.match(r"^@@ -\d+(?:,\d+)? \+(\d+)", ln)
         if m:
@@ -135,9 +219,39 @@ def scan_diff(ref: str | None) -> list[tuple[str, int, str]]:
             continue
         if ln.startswith("+") and not ln.startswith("+++"):
             body = ln[1:]
-            if path and path.endswith(_EXTS) and _offending(body):
+            if path and path.endswith(_EXTS) and _offending(body, path, lineno in fenced):
                 hits.append((path, lineno, body.strip()))
             lineno += 1
+    return hits
+
+
+def scan_prose(text: str, *, git_comments: bool = False) -> list[tuple[int, str]]:
+    """Offending lines of free prose: a commit message, or an issue/PR title+body.
+
+    Judged with the DOC rule -- everything is language except fenced blocks, inline `code` and
+    URLs -- because that is what these texts are. Two deliberate details:
+
+    * `git_comments` drops lines starting with `#`. In a commit message those are git's own
+      template, which is written in the user's LOCALE and would fire the detector on text the
+      author never wrote and git is about to strip anyway. In Markdown a `#` is a heading, i.e.
+      prose that must be judged, so the two cases cannot share a default.
+    * A scissors line (`# ------------------------ >8 ------------------------`) ends the message:
+      everything below it is the diff `git commit --verbose` pastes in, and judging somebody's
+      code as prose is how a gate earns a reputation for lying.
+    """
+    hits, in_fence = [], False
+    for i, ln in enumerate(text.splitlines(), 1):
+        if git_comments and ln.startswith("# ------------------------ >8"):
+            break
+        if git_comments and ln.startswith("#"):
+            continue
+        if _FENCE.match(ln):
+            in_fence = not in_fence
+            continue
+        if in_fence or _ESCAPE in ln:
+            continue
+        if _SPANISH.search(_strip_verbatim(ln)):
+            hits.append((i, ln.strip()))
     return hits
 
 
@@ -162,8 +276,38 @@ def main() -> int:
                    help="whole tree; fail if the count grew vs the baseline")
     g.add_argument("--update-baseline", action="store_true",
                    help="record the current (lower) count after translating")
+    g.add_argument("--prose", metavar="FILE",
+                   help="judge free prose (commit message, issue/PR title+body); '-' reads stdin")
+    ap.add_argument("--git-comments", action="store_true",
+                    help="with --prose: drop '#' lines and everything after the scissors (commit message)")
+    ap.add_argument("--label", default="text",
+                    help="with --prose: what to call the text in the error message")
     args = ap.parse_args()
     root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    if args.prose:
+        try:
+            text = sys.stdin.read() if args.prose == "-" else open(args.prose, encoding="utf-8").read()
+        except (OSError, UnicodeDecodeError) as exc:
+            # Fail CLOSED. An unreadable message is not an English message, and the whole point of
+            # this mode is the surfaces where nothing else is watching.
+            print(f"lang-gate: cannot read {args.prose} ({exc})", file=sys.stderr)
+            return 1
+        hits = scan_prose(text, git_comments=args.git_comments)
+        if hits:
+            print(f"lang-gate: this {args.label} does not look like English:", file=sys.stderr)
+            for lineno, line in hits[:25]:
+                print(f"  line {lineno}: {line[:110]}", file=sys.stderr)
+            if len(hits) > 25:
+                print(f"  ... and {len(hits) - 25} more", file=sys.stderr)
+            print("\nCommit messages, PR titles/descriptions and issues are public, permanent and "
+                  "part of this repo's documentation -- they are English like everything else.",
+                  file=sys.stderr)
+            print(f"A genuine false positive is silenced with `{_ESCAPE}` on that line.",
+                  file=sys.stderr)
+            return 1
+        print(f"lang-gate: OK -- the {args.label} is English.")
+        return 0
 
     if args.diff is not None or "--diff" in sys.argv:
         hits = scan_diff(args.diff)

--- a/tools/lang_gate_baseline.json
+++ b/tools/lang_gate_baseline.json
@@ -1,5 +1,9 @@
 {
   "count": 0,
   "note": "Legacy Spanish lines. This number may only DECREASE.",
+  "scanned_exts": [
+    ".md",
+    ".py"
+  ],
   "files": {}
 }


### PR DESCRIPTION
## Why

The English-only rule has always covered "code, comments, docstrings, documentation, spec files,
commit messages and pull request titles/descriptions". The gate checked **one** of those: comment
lines in `.py` files.

Measured on this repo on 2026-08-11, with the tree at zero and CI green the whole time:

| Surface | State | Was anything checking it? |
|---|---|---|
| `.py` comments | clean (0) | yes — the only one |
| `.md` documentation | 5 Spanish lines in `CHANGELOG.md`, since v0.6.0 | no — judged with the Python rule, which cannot see prose |
| Commit subjects on `main` | **7 in Spanish** | no |
| PR titles | **4 in Spanish** | no |
| PR *descriptions* | **7 more in Spanish** under an English title — only found once the new gate existed to sweep with | no |
| Open issues | **2 of 2 entirely in Spanish**, title and body | no |

The three worst rows are public, permanent, and the first thing a visitor to the repo reads.

## What this changes

New mode `lang_gate.py --prose FILE|-` judges free text — a commit message, a PR title+body, an
issue. Fenced blocks, inline `code` spans and URLs are exempt, so pasting real output or a path
with a foreign-language name is safe. Wired into four places:

- **`hooks/commit-msg`** — blocks the commit while the message is still free to fix. Drops git's
  own `#` template lines (they are in the machine's locale) and stops at the `>8` scissors so a
  `--verbose` diff is not judged as prose.
- **CI, commit messages** of every commit the PR adds (`fetch-depth: 0` for the range).
- **CI, PR title and description** — a non-English title now blocks the merge.
- **`.github/workflows/lang-issue.yml`** — issues. This one **cannot block** and does not pretend
  to: GitHub has no pre-publication hook for an issue, so it labels `needs-english` and comments
  once. That limit is written down in CLAUDE.md and CONTRIBUTING.md rather than left implicit,
  because it is the one surface where the author has to be careful on their own.

Both PR-title/body and issue text travel through `env:`, never interpolated into `run:` — on a
public repo those strings are attacker-controlled and `run: echo "${{ github.event… }}"` is script
injection.

Also fixed: `.md` was **unjudgeable by construction**. The tree scan applied the Python rule to
every file, and that rule rejects any line containing `:` or `(` as code — which is most of a
written paragraph. Markdown now has its own rule (everything is prose except fenced blocks), which
is what surfaced the five CHANGELOG lines. Translated here; the baseline stays pinned at 0.

One measured side effect: sweeping the pull requests with the new mode turned up a false positive
on the word `solo`, in a perfectly English sentence. It has been dropped from the dictionary,
following the precedent the file already set for `sin` -- a gate that fires on English is a gate
that gets bypassed, and this one now runs where being wrong is public.

## Tests

`tests/test_lang_gate.py`, 12 new cases — the gate had none at all. They pin the decisions, not the
dictionary: what counts as prose per file family, what is exempt, that an unreadable message fails
**closed**, and the regression above (a Markdown line with code punctuation is judged; the same
line inside a fence is not).

224 tests green, `tools/check.sh` clean.

## Verified by mutation, not by reading

- Committing with a Spanish message on this branch was **refused** by `hooks/commit-msg`; the same
  content with an English message went through.
- `--baseline` went red on the five CHANGELOG lines before they were translated, and green after.

## One dependency worth flagging

A versioned `hooks/commit-msg` only runs if the machine's global hook dispatcher has a `commit-msg`
entry — and it did not, so on every machine using it this hook would have been **dead on arrival**,
silently. That entry has been added on the dispatcher side, with a note explaining that a missing
event there is an undetectable no-op from inside the repo. Clones that run `bash setup.sh`
(`core.hooksPath=hooks`) were never affected.

## Not fixed here, on purpose

The 7 Spanish commit subjects already on `main` stay as they are: they are merged history on a
public repo, and rewriting it to fix wording would cost every consumer their SHAs. The 2 issues, 4 PR titles and 7
PR descriptions **have** been translated in place (editable without touching history), each body
carrying a one-line note saying so. Swept afterwards with this branch's own `--prose` mode: every
issue and every PR, open and closed, comes out clean; the 25 offending lines that remain are all in
commit messages.

Note the shape of that sweep, because it is the argument for the whole PR: the 7 Spanish
descriptions were invisible until there was a tool that could read them. Nobody had been careless
twice -- there was simply nothing looking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
