### PR TITLE
web-check: recover the links the conservative guard turns down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,29 @@ All notable changes to darnlink are documented here. The format is based on
   errors — so they fell through the gap between two requirements each written assuming the other
   covered it.
 
+- **`web-check --online` verifies links it used to merely survive.** The conservative rejection above
+  is safe but blunt: it also turns down hrefs that are perfectly resolvable. Three are recovered here.
+
+  - **A CommonMark link title** — `[t](url "Title")` — arrives glued to the href, because `MD_LINK_RE`
+    captures everything up to the closing paren. This was the most banal trigger of the crash, and it
+    has nothing to do with mirrored content. The title is stripped, so the link is **verified** again.
+  - **A space inside `#fragment` or `?query`.** Only `owner`/`repo`/`ref`/`path` go on the wire, so
+    judging the raw href rejected links over a character that is never sent. The character guard is
+    applied to the parsed groups instead.
+  - Neither of those may reopen the false `web_not_found`, so a **wreckage rule** runs first: a
+    disallowed separator followed anywhere later by a second scheme. It is stated as a *cause* rather
+    than a list of shapes, after an earlier draft enumerated two and let seven others through (a
+    `0x7f` separator, an angle bracket or emphasis marker between the space and the scheme, …).
+
+  One cost is accepted knowingly: a *legitimate* titled link whose title happens to be a URL becomes
+  unverifiable. No textual rule separates it from the wreckage, and the two directions are not
+  symmetric — unverifiable is a link this run could not confirm, a false break is an accusation
+  against a file that is fine.
+
+### Changed
+- `web-check`'s text report lists parse/URL failures **before** the environmental `web_unverifiable`
+  entries, so the ones you can actually fix are not truncated away by the preview cut.
+
 ## [0.20.4] — 2026-08-10
 
 ### Added

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -422,6 +422,12 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
             print(f"  [web_not_found] {x.file}: {x.detail} ({x.href})")
         for x in anchors:
             print(f"  [web_anchor] {x.file}: {x.detail}")
+        # Parse/URL failures first: those are a defect in THIS repo's own content, deterministic and
+        # fixable locally, while the rest are environmental (no token, private cross-org repo) with
+        # nothing to fix. Without this sort the actionable ones fall past the preview cut and are
+        # never seen, because the environmental ones outnumber them by orders of magnitude.
+        _actionable = ("not a recognised", "malformed URL")
+        unverifiable.sort(key=lambda x: 0 if x.detail.startswith(_actionable) else 1)
         for x in unverifiable[:UNVERIFIABLE_PREVIEW]:
             print(f"  [web_unverifiable] {x.file}: {x.detail} ({x.href})")
         if len(unverifiable) > UNVERIFIABLE_PREVIEW:

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -53,13 +53,54 @@ _GITHUB_BLOB_RE = re.compile(
 )
 
 
-#: Exactly what `http.client` refuses to put on the wire (`_contains_disallowed_url_pchar_re`). An
-#: href carrying any of these is not a URL: mirrored third-party content arrives with two truncated
-#: URLs separated by a space, with control characters from OCR, with a CommonMark title glued on by
-#: `MD_LINK_RE`. Matching http.client's own set rather than the narrower `\s` is deliberate — anything
-#: that slips past here reaches the fetch layer and takes a different route to a different verdict for
-#: the same defect.
+#: Exactly what `http.client` refuses to put on the wire (`_contains_disallowed_url_pchar_re`).
+#: Matching its set rather than `\s` is the point: 0x7f and the C0 range passed a `\s` guard, reached the
+#: fetch layer, and produced a DIFFERENT verdict for the same defect.
 _DISALLOWED_URL_CHARS_RE = re.compile(r"[\x00-\x20\x7f]")
+
+#: CommonMark link title: `[text](url "Title")`. `MD_LINK_RE` hands it to us glued to the href, so it
+#: must come off before the href is judged or parsed. The `(…)` form CommonMark also allows is absent
+#: on purpose: `MD_LINK_RE`'s href is `[^)]+`, so a captured href can never end in `)` and the
+#: alternative would be unreachable code pretending to be coverage.
+_LINK_TITLE_RE = re.compile(r"""\s+("[^"]*"|'[^']*')$""")
+
+#: Scraped wreckage: a separator `http.client` would refuse, followed ANYWHERE LATER by a second
+#: scheme. It must be caught BEFORE the regex runs, because the path group stops at the first `?` or
+#: `#`: a wreckage whose first URL carries a query or a fragment parses to a TRUNCATED path, fetches a
+#: different file, and reports its 404 as a hard break -- a false `web_not_found` in a blocking gate,
+#: which is what this parser promises never to produce.
+#:
+#: An earlier version enumerated the SHAPE (whitespace, an optional quote, a scheme) and closed only
+#: two of them: with a 0x7f or C0 separator, or with anything at all between the space and the scheme
+#: (an angle bracket, a paren, emphasis markers, an HTML entity), the wreckage sailed through.
+#: Enumerating shapes of malformed input is a losing game, so this matches the CAUSE instead -- and
+#: over the same character set as the guard below, rather than the narrower one the module elsewhere
+#: argues against.
+_WRECKAGE_RE = re.compile(r"[\x00-\x20\x7f].*?https?://", re.IGNORECASE | re.DOTALL)
+
+
+def _strip_link_title(href: str) -> str:
+    """Remove a trailing CommonMark title — UNLESS its contents are themselves a URL.
+
+    `[t]( https://…/inv... "https://…/invoker.go")` is not a titled link: it is the scraped
+    two-URL wreckage this module exists to survive, wearing quotes. Stripping it would leave a
+    TRUNCATED path that fetches a different file and reports its 404 as a real break — the precise
+    false `web_not_found` that `parse_github_url` refuses to produce. So a "title" that starts with a
+    scheme is left attached, the guards then reject the href, and the honest `web_unverifiable`
+    survives.
+
+    **Known cost, accepted deliberately.** A *legitimate* titled link whose title happens to be a URL
+    (`[t](…/a.md#L10 "https://example.com/doc")`) is now unverifiable, where it used to resolve. The
+    truncation argument does not apply to it — its path is already cut at the `#` — but no textual
+    rule separates it from the wreckage above, and the two failure directions are not symmetric:
+    unverifiable is a link this run could not confirm, while the alternative is a hard break reported
+    against a file that is perfectly fine. Measured at zero occurrences across the fleet."""
+    m = _LINK_TITLE_RE.search(href)
+    if not m:
+        return href
+    if m.group(1)[1:].lstrip().lower().startswith(("http://", "https://")):
+        return href
+    return href[: m.start()]
 
 
 @dataclass(frozen=True)
@@ -73,32 +114,55 @@ class GithubUrl:
         """GitHub Contents API URL for this file. With `Accept: application/vnd.github.raw` it returns
         the raw bytes and works for BOTH public (no token) and private (token) repos — one code path.
 
-        Every field is percent-encoded, because `http.client` encodes the request line as ASCII and
-        raises `UnicodeEncodeError` on anything else: without this an ordinary accented filename killed
-        the whole run. All four, not just the path — an owner or a repo can carry non-ASCII as easily.
-        `safe="/%"` on the path leaves an href that is already encoded alone, so a link written with
-        `%20` does not become `%2520`."""
-        q = urllib.parse.quote
-        return (f"https://api.github.com/repos/{q(self.owner, safe='%')}/{q(self.repo, safe='%')}"
-                f"/contents/{q(self.path, safe='/%')}?ref={q(self.ref, safe='%')}")
+        Path and ref are percent-encoded because `http.client` encodes the request line as ASCII and
+        raises `UnicodeEncodeError` on anything else: without this a perfectly ordinary file with
+        an accented filename (`documentaci%C3%B3n.md` once encoded) killed the run — the same crash
+        arriving by a route that guard cannot see. `safe="/%"` leaves an already-encoded href alone,
+        so a link written with `%20` does not become `%2520`. All four fields are encoded, not just
+        two: an owner or repo can carry non-ASCII as easily as a path can."""
+        q = lambda s, safe="%": urllib.parse.quote(s, safe=safe)  # noqa: E731
+        return (f"https://api.github.com/repos/{q(self.owner)}/{q(self.repo)}"
+                f"/contents/{q(self.path, '/%')}?ref={q(self.ref)}")
 
 
 def parse_github_url(url: str) -> Optional[GithubUrl]:
     """Pure textual parse of a GitHub blob/raw URL into (owner, repo, ref, path). No network (FR-007).
     Returns None for any unrecognised shape — the caller reports it `web_unverifiable`, never crashes.
 
-    **An href carrying a character `http.client` would refuse is rejected outright**, which is the
-    conservative half of this fix and the reason it is safe. The tempting alternative — forbid those
-    characters only INSIDE the regex groups, so more links can still be resolved — silently truncates
-    the path at the first offending character, fetches a DIFFERENT file, and reports its 404 as a real
-    break. A false `web_not_found` in a blocking gate is worse than the crash this replaces, and worse
-    than admitting the link could not be verified. Recovering the links this rejects (a CommonMark
-    title glued to the href, a space inside a `#fragment`) is a separate, riskier change."""
-    url = url.strip()
-    if _DISALLOWED_URL_CHARS_RE.search(url):
+    A CommonMark **link title** — `[text](url "Title")` — is stripped first: `MD_LINK_RE` captures
+    everything up to the closing paren, so the title arrives glued to the href. Without this, a
+    perfectly ordinary titled link was unverifiable at best (and, before the guard below, a crash).
+
+    An href carrying a CONTROL CHARACTER OR SPACE is then rejected outright, because it is not a URL.
+    Mirrored third-party content (a scraped report, a ticket attachment) can carry
+    `[text]( https://…/inv... https://…)`, where the "href" is really two truncated URLs with a space
+    between them. Both obvious treatments end badly, and both were observed: letting it through
+    reached `urllib` and raised `http.client.InvalidURL`, killing the whole run; and merely forbidding
+    whitespace INSIDE the regex groups would have silently truncated the path at the space and fetched
+    a DIFFERENT file, whose 404 is then reported as a real break (`web_not_found`) — a false failure,
+    which is worse than saying we could not verify it. `web_unverifiable` is the honest verdict.
+
+    The rejected set is `[\\x00-\\x20\\x7f]`, matching `http.client`'s own rule exactly rather than the
+    narrower `\\s`. Scraped content carries 0x7f and C0 characters, not only spaces, and any of them
+    that slips past here reaches the fetch layer and takes a different code path to a different
+    verdict for the same defect.
+
+    Two guards run, in this order, and the distinction matters:
+
+    1. `_WRECKAGE_RE` over the **whole href** — a disallowed separator followed anywhere later by a
+       second scheme. It must see the raw href, because the wreckage it detects is precisely what the
+       parse would truncate.
+    2. `_DISALLOWED_URL_CHARS_RE` over the **four parsed groups**, because only those go on the wire:
+       `#fragment` and `?query` are dropped by the regex, so judging the raw href there made
+       `…/a.md#my anchor` unverifiable over a space that is never sent."""
+    url = _strip_link_title(url.strip()).strip()
+    if _WRECKAGE_RE.search(url):
         return None
     m = _GITHUB_BLOB_RE.match(url)
     if not m:
+        return None
+    parts = (m["owner"], m["repo"], m["ref"], m["path"])
+    if any(_DISALLOWED_URL_CHARS_RE.search(p) for p in parts):
         return None
     return GithubUrl(m["owner"], m["repo"], m["ref"], m["path"].rstrip("/"))
 
@@ -162,20 +226,26 @@ def _fetch_once(gu: GithubUrl, token: Optional[str]) -> Tuple[int, Optional[str]
     except urllib.error.HTTPError as e:
         return (e.code, None)
     except (http.client.InvalidURL, ValueError):
-        # A URL WE built and urllib refuses to send: a darnlink defect, not the network's fault. Its
-        # own sentinel, deliberately OUTSIDE `_TRANSIENT_STATUSES` — retrying a deterministic
-        # client-side rejection spends real sleeps and can never succeed, and folding it into the
-        # network sentinel would bury our own bug under "network error" forever. Two clauses because
-        # they escape by two different doors: `InvalidURL` descends from `HTTPException`, and
-        # `UnicodeEncodeError` from `ValueError`; neither is an `OSError`.
+        # A URL WE built and urllib refuses to send: a darnlink defect, not the network's fault. It
+        # gets its own sentinel, deliberately OUTSIDE `_TRANSIENT_STATUSES`, for two reasons: retrying
+        # a deterministic client-side rejection buys 1.5s of sleeps per malformed href and can never
+        # succeed; and folding it into the network sentinel would bury our own bug under "network
+        # error" forever. Every OTHER HTTPException subclass really is transport (BadStatusLine,
+        # IncompleteRead, RemoteDisconnected, LineTooLong, the ImproperConnectionState family), so -1
+        # is right for them.
+        #
+        # `ValueError` rides here for the same reason and is NOT redundant: `InvalidURL` does not
+        # descend from it, and http.client encodes the request line as ASCII, so a non-ASCII path
+        # raises UnicodeEncodeError (a ValueError) from a completely different line. Percent-encoding
+        # in `contents_api_url` means neither should reach here any more — which is exactly why this
+        # is a belt, kept and unit-tested rather than trusted.
         return (-3, None)
     except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException):
-        # `HTTPException` covers the genuine transport failures (BadStatusLine, IncompleteRead,
-        # RemoteDisconnected, …). It descends from Exception, NOT OSError, so it escaped this clause
-        # entirely and propagated. Note 013 forbids that only by implication: FR-008 covers an
-        # *unrecognised* URL shape, and FR-009 is worded for *transport* errors — a client-side
-        # validation error is neither, so the crash fell through the gap between two requirements each
-        # written assuming the other covered it.
+        # `http.client.HTTPException` is the belt to `parse_github_url`'s braces: it descends from
+        # Exception, NOT from OSError, so it escaped this clause entirely and propagated — a crash.
+        # Note 013 forbids that only by implication: FR-008 covers an *unrecognised* URL shape (this
+        # one the regex accepted), and FR-009 covers *transport* errors (this one is client-side
+        # validation). The crash fell through the gap between them.
         return (-1, None)
 
 
@@ -274,8 +344,8 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
                           "destination URL 404s; darnlink does not search where it moved (LLM layer's job)")
     if status == -3:
         return WebFinding("web_unverifiable", f, link.href,
-                          "malformed URL — the client refused to send it; nothing was fetched, and it "
-                          "was not retried because a client-side rejection cannot clear on a retry")
+                          "malformed URL — the client refused to send it (control character or space "
+                          "in the href); nothing was fetched and it was not retried")
     if status != 200:
         return WebFinding("web_unverifiable", f, link.href, f"fetch failed (status {status})")
     # status 200: we have the destination content and its uuid (may be None)

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -61,6 +61,15 @@ def test_contents_api_url():
         "https://api.github.com/repos/example-org/handbook/contents/docs/x.md?ref=main"
 
 
+def test_contents_api_url_encodes_all_four_fields():
+    """Not just path and ref: an owner or a repo can carry non-ASCII as easily as a path can, and an
+    unencoded one reaches http.client and raises. Encoding only two fields survived the whole suite,
+    which is why this asserts the field the earlier version left raw."""
+    url = GithubUrl("\xf3wner", "r\xe9po", "m\xe1in", "d\xf3cs/x.md").contents_api_url()
+    url.encode("ascii")  # would raise before
+    assert "%C3%B3wner" in url and "r%C3%A9po" in url
+
+
 # --- link finder: robust vs plain web links, code fences ignored ---
 
 def test_find_web_links_plain_and_anchored():
@@ -182,7 +191,13 @@ def test_online_network_error_is_unverifiable(tmp_path):
     assert findings[0].kind == "web_unverifiable"
 
 
-# --- an href we cannot send: rejected, never fetched, never a crash ---
+def test_online_unparseable_url_is_unverifiable(tmp_path):
+    _w(tmp_path / "conta.md", f"see [x](https://example.com/whatever) <!-- web-uuid: {UUID} -->\n")
+    findings, _ = check_web_links_online(tmp_path, None, _fetcher({}))
+    assert findings[0].kind == "web_unverifiable"
+
+
+# --- malformed href with whitespace (regression: it used to CRASH the whole run) ---
 
 #: The real shape, from a scraped report mirrored into a docs repo: the "href" is two truncated URLs
 #: with a space between them. It reached urllib and raised http.client.InvalidURL.
@@ -191,105 +206,222 @@ _SPACED_HREF = ("https://github.com/cli/cli/blob/30066b0042d0c5928d959e288144300
                 "30066b0042d0c5928d959e288144300cb28196c9/internal/codespaces/rpc/invoker.go")
 
 
-def test_parse_rejects_an_href_the_client_would_refuse():
-    """The second assert is the one that matters: forbidding these characters only INSIDE the regex
-    groups would parse this into a TRUNCATED path (`…/rpc/inv...`), whose 404 is then reported as a
-    real break. A false `web_not_found` is worse than an honest `web_unverifiable`.
+def test_parse_strips_a_commonmark_link_title():
+    """`[t](url "Title")` is ordinary Markdown, and MD_LINK_RE hands the title over glued to the href.
+    Before the title was stripped this link CRASHED the run; stripping makes it verifiable again
+    instead of merely non-fatal."""
+    assert parse_github_url('https://github.com/o/r/blob/main/a.md "Handbook"') == \
+        GithubUrl("o", "r", "main", "a.md")
+    assert parse_github_url("https://github.com/o/r/blob/main/a.md 'H'") == \
+        GithubUrl("o", "r", "main", "a.md")
 
-    The set is http.client's own, not the narrower whitespace class: scraped and OCR'd content carries
-    0x7f and C0 characters, and any of them slipping past here reaches the fetch layer and produces a
-    different verdict for the same defect."""
-    assert parse_github_url(_SPACED_HREF) is None
-    assert parse_github_url("https://github.com/o/r/blob/main/a b.md") is None
-    for ch in ("\x7f", "\x01", "\x0e", "\t"):
+
+def test_parse_rejects_control_characters_not_only_spaces():
+    """The guard must match what http.client itself refuses ([\\x00-\\x20\\x7f]), not the narrower \\s.
+    A 0x7f or C0 character passed a \\s guard, reached the fetch layer, and produced a different
+    verdict ('fetch failed') for the very same defect."""
+    for ch in ("\x7f", "\x01", "\x0e"):
         assert parse_github_url(f"https://github.com/o/r/blob/main/a{ch}b.md") is None
 
 
-def test_online_unsendable_href_is_unverifiable_and_never_fetched(tmp_path):
+def test_parse_url_with_whitespace_is_none():
+    """FR-008: an unrecognised shape is None (-> web_unverifiable), never a crash and never a guess.
+
+    The second assert is the one that matters: forbidding whitespace only INSIDE the regex groups
+    would have parsed this into a TRUNCATED path (`…/rpc/inv...`), whose 404 is then reported as a
+    real break. A false `web_not_found` is worse than an honest `web_unverifiable`."""
+    assert parse_github_url(_SPACED_HREF) is None
+    assert parse_github_url("https://github.com/o/r/blob/main/a b.md") is None
+
+
+def test_online_href_with_whitespace_is_unverifiable_not_a_crash(tmp_path):
+    """End to end: a mirrored document carrying such an href must not take the run down with it."""
     _w(tmp_path / "mirror" / "report.md", f"GitHub CLI [retrieves details]( {_SPACED_HREF})\n")
 
-    def exploding_fetcher(gu, token):
-        raise AssertionError(f"fetched an href we cannot send: {gu!r}")
+    def exploding_fetcher(gu, token):  # must never be reached for this link
+        raise AssertionError(f"fetched a malformed href: {gu!r}")
 
     findings, edits = check_web_links_online(tmp_path, None, exploding_fetcher)
     assert [f.kind for f in findings] == ["web_unverifiable"]
     assert edits == {}
 
 
-def test_contents_api_url_encodes_all_four_fields():
-    """Not just the path: an owner or repo can carry non-ASCII as easily. http.client encodes the
-    request line as ASCII and raises UnicodeEncodeError -- a ValueError, which escapes even an
-    HTTPException belt -- so an ordinary accented filename killed the run."""
-    url = GithubUrl("\xf3wner", "r\xe9po", "m\xe1in", "d\xf3cs/x.md").contents_api_url()
-    url.encode("ascii")  # would raise before
-    assert "%C3%B3wner" in url and "r%C3%A9po" in url
-
-
-def test_already_encoded_path_is_not_double_encoded():
-    """safe='/%' — a link written with %20 must not become %2520."""
-    assert "a%20b.md" in GithubUrl("o", "r", "main", "a%20b.md").contents_api_url()
-
-
 @pytest.mark.parametrize("exc", [
-    http.client.InvalidURL("bad"),
-    UnicodeEncodeError("ascii", "x", 0, 1, "ordinal not in range"),
+    http.client.InvalidURL("bad"),                                  # HTTPException, not OSError
+    UnicodeEncodeError("ascii", "x", 0, 1, "ordinal not in range"),  # ValueError, not either
 ])
 def test_fetch_once_never_propagates_a_client_side_url_error(monkeypatch, exc):
-    """Both escape `except (URLError, TimeoutError, OSError)` by a different route -- InvalidURL from
-    HTTPException, UnicodeEncodeError from ValueError -- and both used to propagate and kill the run.
-    Injected rather than provoked: with the URL encoded, provoking it would make the request VALID and
-    this test would hit the network, which no test here may do."""
+    """Belt as well as braces. Both escape `except (URLError, TimeoutError, OSError)` by a different
+    route — InvalidURL descends from HTTPException, UnicodeEncodeError from ValueError — and both used
+    to propagate and kill the run. Injected rather than provoked with a real malformed URL: since the
+    path is percent-encoded, provoking it would make the request VALID and this test would hit the
+    network, which no test here may do."""
     from darnlink.weblinks import _fetch_once
-    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: (_ for _ in ()).throw(exc))
+
+    def boom(*a, **k):
+        raise exc
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
     assert _fetch_once(GithubUrl("o", "r", "main", "a.md"), None) == (-3, None)
 
 
-def test_a_client_side_url_error_is_not_retried(monkeypatch):
-    """Deterministic: retrying spends real sleeps and can never succeed. -3 must stay OUT of
-    _TRANSIENT_STATUSES -- that separation is the sentinel's whole purpose."""
+def test_malformed_url_is_not_retried(monkeypatch):
+    """A client-side rejection is deterministic: retrying costs real sleeps and can never succeed.
+    -3 must therefore stay OUT of _TRANSIENT_STATUSES — this asserts the sentinel's whole purpose."""
     from darnlink.weblinks import _TRANSIENT_STATUSES, default_fetcher
     assert -3 not in _TRANSIENT_STATUSES
-    monkeypatch.setattr("urllib.request.urlopen",
-                        lambda *a, **k: (_ for _ in ()).throw(http.client.InvalidURL("bad")))
+
+    def boom(*a, **k):
+        raise http.client.InvalidURL("bad")
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
     slept = []
-    assert default_fetcher(GithubUrl("o", "r", "main", "a.md"), None,
-                           attempts=3, sleep=slept.append) == (-3, None)
-    assert slept == []
+    status, _ = default_fetcher(GithubUrl("o", "r", "main", "a.md"), None,
+                                attempts=3, sleep=slept.append)
+    assert (status, slept) == (-3, [])
 
 
 def test_fetch_once_maps_a_transport_http_exception_to_the_network_sentinel(monkeypatch):
     """The other half of the widened except: a genuine transport HTTPException must still be -1, the
-    RETRYABLE sentinel. If the two ever collapse, a flaky connection stops being retried or a
-    malformed URL starts being."""
+    RETRYABLE sentinel — not -3. If these two ever collapse into one, a flaky connection stops being
+    retried or a malformed URL starts being."""
     from darnlink.weblinks import _TRANSIENT_STATUSES, _fetch_once
-    monkeypatch.setattr("urllib.request.urlopen",
-                        lambda *a, **k: (_ for _ in ()).throw(http.client.BadStatusLine("")))
+
+    def boom(*a, **k):
+        raise http.client.BadStatusLine("")
+
+    monkeypatch.setattr("urllib.request.urlopen", boom)
     assert _fetch_once(GithubUrl("o", "r", "main", "a.md"), None) == (-1, None)
     assert -1 in _TRANSIENT_STATUSES
 
 
-def test_repo_accessible_encodes_and_never_raises(monkeypatch):
-    """Its twin was the one that crashed, so this one was left unencoded and its own docstring's
-    'never raises' was false. Its real body runs in no other test in the suite."""
-    from darnlink.weblinks import _repo_accessible
+def test_actionable_unverifiable_are_listed_before_the_environmental_ones(tmp_path, capsys):
+    """The preview truncates at UNVERIFIABLE_PREVIEW. Content defects in your own repo are fixable and
+    rare; the environmental ones (no token, private cross-org) are unfixable and thousands. Unsorted,
+    the actionable ones fall past the cut and are never seen.
+
+    The filler must be GENUINELY environmental: an earlier version of this test used example.com URLs,
+    which land in the SAME actionable bucket ('not a recognised…'), so every entry sorted to key 0 and
+    the assertion held with the sort deleted. It passed while proving nothing — the very defect this
+    file documents two tests above."""
+    _w(tmp_path / "z_bad.md", "see [x](https://github.com/o/r/blob/main/a b.md)\n")
+    for i in range(UNVERIFIABLE_PREVIEW + 5):  # real GitHub URLs, 404 with no token -> environmental
+        _w(tmp_path / f"doc{i}.md", f"see [x](https://github.com/o/r/blob/main/env{i}.md)\n")
+    _run_web_check_cli([str(tmp_path), "--online"], fetcher=_fetcher({}))
+    shown = [l for l in capsys.readouterr().out.splitlines() if "[web_unverifiable]" in l]
+    assert len(shown) == UNVERIFIABLE_PREVIEW
+    assert "not a recognised" in shown[0]
+    assert all("no token" in l for l in shown[1:])
+
+
+def test_wreckage_with_a_query_or_fragment_is_never_fetched(tmp_path):
+    """The regression this round introduced and then removed. The path group stops at the first `?`
+    or `#`, so guarding only the PARSED groups let a wreckage whose first URL carries one through as a
+    TRUNCATED path — fetched, 404, reported as a hard break. A false web_not_found in a blocking gate
+    is worse than the crash this PR started from, so all four shapes must reach nobody."""
+    base = "https://github.com/cli/cli/blob/abc1234/internal/inv..."
+    second = "https://github.com/cli/cli/blob/abc1234/internal/invoker.go"
+    # The separator is NOT always a space and the scheme is NOT always adjacent: scraped content
+    # arrives with control characters, angle brackets, parens, emphasis markers and HTML entities in
+    # between. An earlier guard enumerated two shapes and let seven others through.
+    joiners = [" ", ' "', " <", " (", " [", " **", "\x7f", "\x01", " &lt;", "\t'"]
+    for first in (base, base + "?x=1", base + "#frag"):
+        for mid in joiners:
+            assert parse_github_url(first + mid + second) is None, repr(first + mid + second)
+
+
+def test_repo_accessible_encodes_owner_and_repo(monkeypatch):
+    """Its twin was fixed and it was not, so a non-ASCII owner raised UnicodeEncodeError here and the
+    new `except ValueError` swallowed it as a "network blip" -- returning True, which promotes the
+    destination's 404 to a hard break. Burying our own defect under "network error" is the very thing
+    the sibling function's comment calls unacceptable."""
     seen = {}
 
     def capture(req, timeout=None):
         seen["url"] = req.full_url
         raise http.client.BadStatusLine("")
 
+    from darnlink.weblinks import _repo_accessible
     _repo_accessible.cache_clear()
     monkeypatch.setattr("urllib.request.urlopen", capture)
-    assert _repo_accessible("\xf3wner", "r\xe9po", None) is True
+    _repo_accessible("\xf3wner", "r\xe9po", None)
     _repo_accessible.cache_clear()
     seen["url"].encode("ascii")  # would raise before
     assert "%C3%B3wner" in seen["url"]
 
 
-def test_online_unparseable_url_is_unverifiable(tmp_path):
-    _w(tmp_path / "conta.md", f"see [x](https://example.com/whatever) <!-- web-uuid: {UUID} -->\n")
-    findings, _ = check_web_links_online(tmp_path, None, _fetcher({}))
-    assert findings[0].kind == "web_unverifiable"
+def test_repo_accessible_survives_an_http_exception(monkeypatch):
+    """The one line of the fix with no coverage otherwise: _repo_accessible's body never runs in the
+    suite (every other test patches it out). A transport-level HTTPException must leave it True, so a
+    persistent 404 is not downgraded to unverifiable by a blip."""
+    import http.client as _http
+    from darnlink.weblinks import _repo_accessible
+
+    def boom(*a, **k):
+        raise _http.BadStatusLine("")
+
+    _repo_accessible.cache_clear()
+    monkeypatch.setattr("urllib.request.urlopen", boom)
+    assert _repo_accessible("o", "r", None) is True
+    _repo_accessible.cache_clear()
+
+
+def test_online_malformed_href_is_stopped_by_the_parser_not_by_the_fetcher(tmp_path):
+    """The guard intercepts first, so the finding is the PARSE one — not the -3 sentinel. Asserted on
+    the detail, because an earlier version of this test claimed to cover -3 while never reaching it:
+    it checked only `kind`, so it passed and proved nothing."""
+    _w(tmp_path / "doc.md", "see [x](https://github.com/o/r/blob/main/a b.md)\n")
+
+    def exploding_fetcher(gu, token):
+        raise AssertionError("must not fetch a malformed href")
+
+    findings, _ = check_web_links_online(tmp_path, None, exploding_fetcher)
+    assert [(f.kind, f.detail) for f in findings] == \
+        [("web_unverifiable", "not a recognised GitHub blob/raw URL")]
+
+
+def test_classify_reports_the_minus_3_sentinel(tmp_path):
+    """The -3 branch is a belt: with the guard in front and percent-encoding underneath, nothing in
+    production should reach it. Unit-tested directly so 'unreachable' never quietly becomes 'wrong'."""
+    from darnlink.weblinks import WebLink, _classify
+    link = WebLink("t", URL, None, 0, 0)
+    f = _classify(link, parse_github_url(URL), -3, None, False, Path("x.md"))
+    assert f.kind == "web_unverifiable" and "malformed URL" in f.detail
+
+
+def test_non_ascii_path_is_percent_encoded_and_does_not_crash():
+    """An accented filename is not hypothetical here. http.client encodes the request line as ASCII and
+    raises UnicodeEncodeError — a ValueError, so it escaped even the HTTPException belt. Encoding the
+    path fixes it at the source; the link VERIFIES instead of merely not crashing."""
+    gu = parse_github_url("https://github.com/o/r/blob/main/docs/documentación.md")
+    assert gu is not None
+    url = gu.contents_api_url()
+    assert "documentaci%C3%B3n.md" in url
+    url.encode("ascii")  # would raise before
+
+
+def test_already_encoded_path_is_not_double_encoded():
+    """safe='/%' — a link written with %20 must not become %2520."""
+    gu = parse_github_url("https://github.com/o/r/blob/main/a%20b.md")
+    assert "a%20b.md" in gu.contents_api_url()
+
+
+def test_a_quoted_second_url_is_not_treated_as_a_title():
+    """The scraped two-URL wreckage, wearing quotes. Stripping the 'title' would leave a TRUNCATED
+    path, fetch a different file, and report its 404 as a real break — the false web_not_found this
+    module refuses to produce."""
+    href = ('https://github.com/cli/cli/blob/abc1234/internal/inv... '
+            '"https://github.com/cli/cli/blob/abc1234/internal/invoker.go"')
+    assert parse_github_url(href) is None
+
+
+def test_space_in_fragment_or_query_still_verifies():
+    """Only owner/repo/ref/path go on the wire; #fragment and ?query are dropped by the regex. Judging
+    the raw href made these unverifiable over a space that is never sent."""
+    assert parse_github_url("https://github.com/o/r/blob/main/a.md#my anchor") == \
+        GithubUrl("o", "r", "main", "a.md")
+    assert parse_github_url("https://github.com/o/r/blob/main/a.md?plain=1&x=a b") == \
+        GithubUrl("o", "r", "main", "a.md")
 
 
 def test_many_unverifiable_are_summarised_not_listed_one_by_one(tmp_path, capsys):


### PR DESCRIPTION
**Stacked on #55**, which is the crash fix. Merge that first; this PR's diff is only the *recovery* part.

## Why this is a separate PR

Four adversarial review rounds ran over the combined change. Every single finding — eight of them, three being regressions introduced while fixing the previous round — landed in **this** half. The crash fix underneath was never touched by any of them. Enumerating the shapes of malformed scraped input is a losing game; keeping it away from the fix that unblocks the axis is the point of the split.

## What it recovers

#55 rejects any href carrying a character `http.client` would refuse. That is safe and blunt: it also turns down links that are perfectly resolvable. Three are recovered here.

- **A CommonMark link title** — `[t](url "Title")` — arrives glued to the href, because `MD_LINK_RE` captures everything up to the closing paren. This was the most banal trigger of the original crash, and it has nothing to do with mirrored content. Stripped, so the link is **verified** rather than merely non-fatal.
- **A space inside `#fragment` or `?query`.** Only `owner`/`repo`/`ref`/`path` go on the wire, so judging the raw href rejected links over a character that is never sent. The character guard moves to the parsed groups.
- Neither may reopen the **false `web_not_found`** that #55 exists to avoid, so a **wreckage rule** runs first: a disallowed separator followed anywhere later by a second scheme. It is stated as a *cause*, not a list of shapes — an earlier draft enumerated two shapes and a reviewer got seven more past it (a `0x7f` separator, an angle bracket or emphasis marker between the space and the scheme, an HTML entity…).

Plus: the text report lists parse failures **before** the environmental `web_unverifiable` entries, so the fixable ones are not truncated away by the preview cut.

## The cost, stated rather than argued away

A *legitimate* titled link whose title happens to be a URL becomes unverifiable, where it used to resolve. No textual rule separates it from the wreckage, and the two directions are not symmetric: unverifiable is a link this run could not confirm, while a false break is an accusation against a file that is fine. Measured at zero occurrences across the fleet.

## Tests

231 passing. **Each guard verified by mutation** — reverting it fails its own test — including the ordering test, whose first version was vacuous (its filler landed in the same bucket it claimed to distinguish, so it passed with the sort deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)