### PR TITLE
web-check: an href it cannot send no longer kills the run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ All notable changes to darnlink are documented here. The format is based on
   `web_not_found` in a blocking gate is worse than the crash it replaces. Recovering the links this
   rejects is deliberately left to a separate change.
 
+  **The one true regression, stated plainly:** an href whose offending character sits at or after the
+  first `#` or `?` — `…/a.md#a b`, `…/a.md#s "Title"`, `…/a.md?plain=1 "Title"` — used to verify,
+  because the path group stops there and the URL that went on the wire was clean. It is now
+  `web_unverifiable`. Everything else this rejects **crashed** before, so it is not a regression.
+  And `web_unverifiable` cannot fail a gate, so the change can turn a green run into a quieter one,
+  never into a red one.
+
   Client-side URL errors get their own sentinel, kept out of the retry set: retrying a deterministic
   rejection spends real sleeps and can never succeed, and folding it into the network sentinel would
   bury darnlink's own defect under "network error". Strictly, 013 forbade neither crash — FR-008

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **`web-check --online` no longer dies on an href it cannot send.** Two routes took the whole run
+  down, and each escaped `_fetch_once`'s `except (URLError, TimeoutError, OSError)` by a different
+  door: **whitespace or control characters in the href** — mirrored third-party content carries two
+  truncated URLs with a space between them, and `http.client.InvalidURL` descends from
+  `HTTPException`, not `OSError` — and **a non-ASCII path**, where `http.client` encodes the request
+  line as ASCII and raises `UnicodeEncodeError`, a `ValueError`. An accented filename was enough.
+
+  Every URL field is now percent-encoded (`safe="/%"` on the path, so an href already written with
+  `%20` is left alone), and an href carrying a character the client would refuse is reported
+  `web_unverifiable` instead of being sent.
+
+  **The conservative half is the point.** The tempting alternative — forbid those characters only
+  *inside* the parsed groups, so more links can still be resolved — truncates the path at the first
+  offending character, fetches a *different* file, and reports its 404 as a real break. A false
+  `web_not_found` in a blocking gate is worse than the crash it replaces. Recovering the links this
+  rejects is deliberately left to a separate change.
+
+  Client-side URL errors get their own sentinel, kept out of the retry set: retrying a deterministic
+  rejection spends real sleeps and can never succeed, and folding it into the network sentinel would
+  bury darnlink's own defect under "network error". Strictly, 013 forbade neither crash — FR-008
+  covers an *unrecognised* URL shape (this one the regex accepts) and FR-009 is worded for *transport*
+  errors — so they fell through the gap between two requirements each written assuming the other
+  covered it.
+
 ## [0.20.4] — 2026-08-10
 
 ### Added

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -18,10 +18,12 @@ here. No new dependencies: `urllib` (stdlib). The fetcher is injected so tests n
 """
 from __future__ import annotations
 
+import http.client
 import os
 import re
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from functools import lru_cache
@@ -51,6 +53,15 @@ _GITHUB_BLOB_RE = re.compile(
 )
 
 
+#: Exactly what `http.client` refuses to put on the wire (`_contains_disallowed_url_pchar_re`). An
+#: href carrying any of these is not a URL: mirrored third-party content arrives with two truncated
+#: URLs separated by a space, with control characters from OCR, with a CommonMark title glued on by
+#: `MD_LINK_RE`. Matching http.client's own set rather than the narrower `\s` is deliberate — anything
+#: that slips past here reaches the fetch layer and takes a different route to a different verdict for
+#: the same defect.
+_DISALLOWED_URL_CHARS_RE = re.compile(r"[\x00-\x20\x7f]")
+
+
 @dataclass(frozen=True)
 class GithubUrl:
     owner: str
@@ -60,14 +71,33 @@ class GithubUrl:
 
     def contents_api_url(self) -> str:
         """GitHub Contents API URL for this file. With `Accept: application/vnd.github.raw` it returns
-        the raw bytes and works for BOTH public (no token) and private (token) repos — one code path."""
-        return f"https://api.github.com/repos/{self.owner}/{self.repo}/contents/{self.path}?ref={self.ref}"
+        the raw bytes and works for BOTH public (no token) and private (token) repos — one code path.
+
+        Every field is percent-encoded, because `http.client` encodes the request line as ASCII and
+        raises `UnicodeEncodeError` on anything else: without this an ordinary accented filename killed
+        the whole run. All four, not just the path — an owner or a repo can carry non-ASCII as easily.
+        `safe="/%"` on the path leaves an href that is already encoded alone, so a link written with
+        `%20` does not become `%2520`."""
+        q = urllib.parse.quote
+        return (f"https://api.github.com/repos/{q(self.owner, safe='%')}/{q(self.repo, safe='%')}"
+                f"/contents/{q(self.path, safe='/%')}?ref={q(self.ref, safe='%')}")
 
 
 def parse_github_url(url: str) -> Optional[GithubUrl]:
     """Pure textual parse of a GitHub blob/raw URL into (owner, repo, ref, path). No network (FR-007).
-    Returns None for any unrecognised shape — the caller reports it `web_unverifiable`, never crashes."""
-    m = _GITHUB_BLOB_RE.match(url.strip())
+    Returns None for any unrecognised shape — the caller reports it `web_unverifiable`, never crashes.
+
+    **An href carrying a character `http.client` would refuse is rejected outright**, which is the
+    conservative half of this fix and the reason it is safe. The tempting alternative — forbid those
+    characters only INSIDE the regex groups, so more links can still be resolved — silently truncates
+    the path at the first offending character, fetches a DIFFERENT file, and reports its 404 as a real
+    break. A false `web_not_found` in a blocking gate is worse than the crash this replaces, and worse
+    than admitting the link could not be verified. Recovering the links this rejects (a CommonMark
+    title glued to the href, a space inside a `#fragment`) is a separate, riskier change."""
+    url = url.strip()
+    if _DISALLOWED_URL_CHARS_RE.search(url):
+        return None
+    m = _GITHUB_BLOB_RE.match(url)
     if not m:
         return None
     return GithubUrl(m["owner"], m["repo"], m["ref"], m["path"].rstrip("/"))
@@ -131,7 +161,21 @@ def _fetch_once(gu: GithubUrl, token: Optional[str]) -> Tuple[int, Optional[str]
             return (resp.status, resp.read().decode("utf-8", errors="replace"))
     except urllib.error.HTTPError as e:
         return (e.code, None)
-    except (urllib.error.URLError, TimeoutError, OSError):
+    except (http.client.InvalidURL, ValueError):
+        # A URL WE built and urllib refuses to send: a darnlink defect, not the network's fault. Its
+        # own sentinel, deliberately OUTSIDE `_TRANSIENT_STATUSES` — retrying a deterministic
+        # client-side rejection spends real sleeps and can never succeed, and folding it into the
+        # network sentinel would bury our own bug under "network error" forever. Two clauses because
+        # they escape by two different doors: `InvalidURL` descends from `HTTPException`, and
+        # `UnicodeEncodeError` from `ValueError`; neither is an `OSError`.
+        return (-3, None)
+    except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException):
+        # `HTTPException` covers the genuine transport failures (BadStatusLine, IncompleteRead,
+        # RemoteDisconnected, …). It descends from Exception, NOT OSError, so it escaped this clause
+        # entirely and propagated. Note 013 forbids that only by implication: FR-008 covers an
+        # *unrecognised* URL shape, and FR-009 is worded for *transport* errors — a client-side
+        # validation error is neither, so the crash fell through the gap between two requirements each
+        # written assuming the other covered it.
         return (-1, None)
 
 
@@ -142,7 +186,9 @@ def _repo_accessible(owner: str, repo: str, token: Optional[str]) -> bool:
     a client org our RO PAT has no access to) — there a file 404 is ambiguous, not a break. Cached per
     (owner, repo, token) so a repo linked N times is probed once. On a network blip, returns True
     (fall back to the plain 404=broken behaviour rather than hide a real break). Never raises."""
-    req = urllib.request.Request(f"https://api.github.com/repos/{owner}/{repo}", headers={
+    url = (f"https://api.github.com/repos/{urllib.parse.quote(owner, safe='%')}"
+           f"/{urllib.parse.quote(repo, safe='%')}")
+    req = urllib.request.Request(url, headers={
         "Accept": "application/vnd.github+json",
         "User-Agent": "darnlink-web-check",
     })
@@ -155,7 +201,7 @@ def _repo_accessible(owner: str, repo: str, token: Optional[str]) -> bool:
         if e.code in (403, 404):
             return False  # genuinely not readable with this token (private cross-org repo)
         return True       # 5xx/429/other: an outage/throttle, NOT inaccessible -> fall back to 404-is-broken
-    except (urllib.error.URLError, TimeoutError, OSError):
+    except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException, ValueError):
         return True   # network blip: don't downgrade a persistent 404 to unverifiable on a transient error
 
 
@@ -226,6 +272,10 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
                               "cannot see, not necessarily moved); a token is needed to call it broken")
         return WebFinding("web_not_found", f, link.href,
                           "destination URL 404s; darnlink does not search where it moved (LLM layer's job)")
+    if status == -3:
+        return WebFinding("web_unverifiable", f, link.href,
+                          "malformed URL — the client refused to send it; nothing was fetched, and it "
+                          "was not retried because a client-side rejection cannot clear on a retry")
     if status != 200:
         return WebFinding("web_unverifiable", f, link.href, f"fetch failed (status {status})")
     # status 200: we have the destination content and its uuid (may be None)

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -7,6 +7,7 @@ an anchored one, fail on mismatch/404, stay honest (web_unverifiable) on a priva
 and never fire in the core / offline mode.
 """
 import hashlib
+import http.client
 import json
 from pathlib import Path
 
@@ -179,6 +180,110 @@ def test_online_network_error_is_unverifiable(tmp_path):
     fetch = _fetcher({URL: (-1, None)})  # URLError/timeout mapped to -1
     findings, _ = check_web_links_online(tmp_path, None, fetch)
     assert findings[0].kind == "web_unverifiable"
+
+
+# --- an href we cannot send: rejected, never fetched, never a crash ---
+
+#: The real shape, from a scraped report mirrored into a docs repo: the "href" is two truncated URLs
+#: with a space between them. It reached urllib and raised http.client.InvalidURL.
+_SPACED_HREF = ("https://github.com/cli/cli/blob/30066b0042d0c5928d959e288144300cb28196c9/"
+                "internal/codespaces/rpc/inv... https://github.com/cli/cli/blob/"
+                "30066b0042d0c5928d959e288144300cb28196c9/internal/codespaces/rpc/invoker.go")
+
+
+def test_parse_rejects_an_href_the_client_would_refuse():
+    """The second assert is the one that matters: forbidding these characters only INSIDE the regex
+    groups would parse this into a TRUNCATED path (`…/rpc/inv...`), whose 404 is then reported as a
+    real break. A false `web_not_found` is worse than an honest `web_unverifiable`.
+
+    The set is http.client's own, not the narrower whitespace class: scraped and OCR'd content carries
+    0x7f and C0 characters, and any of them slipping past here reaches the fetch layer and produces a
+    different verdict for the same defect."""
+    assert parse_github_url(_SPACED_HREF) is None
+    assert parse_github_url("https://github.com/o/r/blob/main/a b.md") is None
+    for ch in ("\x7f", "\x01", "\x0e", "\t"):
+        assert parse_github_url(f"https://github.com/o/r/blob/main/a{ch}b.md") is None
+
+
+def test_online_unsendable_href_is_unverifiable_and_never_fetched(tmp_path):
+    _w(tmp_path / "mirror" / "report.md", f"GitHub CLI [retrieves details]( {_SPACED_HREF})\n")
+
+    def exploding_fetcher(gu, token):
+        raise AssertionError(f"fetched an href we cannot send: {gu!r}")
+
+    findings, edits = check_web_links_online(tmp_path, None, exploding_fetcher)
+    assert [f.kind for f in findings] == ["web_unverifiable"]
+    assert edits == {}
+
+
+def test_contents_api_url_encodes_all_four_fields():
+    """Not just the path: an owner or repo can carry non-ASCII as easily. http.client encodes the
+    request line as ASCII and raises UnicodeEncodeError -- a ValueError, which escapes even an
+    HTTPException belt -- so an ordinary accented filename killed the run."""
+    url = GithubUrl("\xf3wner", "r\xe9po", "m\xe1in", "d\xf3cs/x.md").contents_api_url()
+    url.encode("ascii")  # would raise before
+    assert "%C3%B3wner" in url and "r%C3%A9po" in url
+
+
+def test_already_encoded_path_is_not_double_encoded():
+    """safe='/%' — a link written with %20 must not become %2520."""
+    assert "a%20b.md" in GithubUrl("o", "r", "main", "a%20b.md").contents_api_url()
+
+
+@pytest.mark.parametrize("exc", [
+    http.client.InvalidURL("bad"),
+    UnicodeEncodeError("ascii", "x", 0, 1, "ordinal not in range"),
+])
+def test_fetch_once_never_propagates_a_client_side_url_error(monkeypatch, exc):
+    """Both escape `except (URLError, TimeoutError, OSError)` by a different route -- InvalidURL from
+    HTTPException, UnicodeEncodeError from ValueError -- and both used to propagate and kill the run.
+    Injected rather than provoked: with the URL encoded, provoking it would make the request VALID and
+    this test would hit the network, which no test here may do."""
+    from darnlink.weblinks import _fetch_once
+    monkeypatch.setattr("urllib.request.urlopen", lambda *a, **k: (_ for _ in ()).throw(exc))
+    assert _fetch_once(GithubUrl("o", "r", "main", "a.md"), None) == (-3, None)
+
+
+def test_a_client_side_url_error_is_not_retried(monkeypatch):
+    """Deterministic: retrying spends real sleeps and can never succeed. -3 must stay OUT of
+    _TRANSIENT_STATUSES -- that separation is the sentinel's whole purpose."""
+    from darnlink.weblinks import _TRANSIENT_STATUSES, default_fetcher
+    assert -3 not in _TRANSIENT_STATUSES
+    monkeypatch.setattr("urllib.request.urlopen",
+                        lambda *a, **k: (_ for _ in ()).throw(http.client.InvalidURL("bad")))
+    slept = []
+    assert default_fetcher(GithubUrl("o", "r", "main", "a.md"), None,
+                           attempts=3, sleep=slept.append) == (-3, None)
+    assert slept == []
+
+
+def test_fetch_once_maps_a_transport_http_exception_to_the_network_sentinel(monkeypatch):
+    """The other half of the widened except: a genuine transport HTTPException must still be -1, the
+    RETRYABLE sentinel. If the two ever collapse, a flaky connection stops being retried or a
+    malformed URL starts being."""
+    from darnlink.weblinks import _TRANSIENT_STATUSES, _fetch_once
+    monkeypatch.setattr("urllib.request.urlopen",
+                        lambda *a, **k: (_ for _ in ()).throw(http.client.BadStatusLine("")))
+    assert _fetch_once(GithubUrl("o", "r", "main", "a.md"), None) == (-1, None)
+    assert -1 in _TRANSIENT_STATUSES
+
+
+def test_repo_accessible_encodes_and_never_raises(monkeypatch):
+    """Its twin was the one that crashed, so this one was left unencoded and its own docstring's
+    'never raises' was false. Its real body runs in no other test in the suite."""
+    from darnlink.weblinks import _repo_accessible
+    seen = {}
+
+    def capture(req, timeout=None):
+        seen["url"] = req.full_url
+        raise http.client.BadStatusLine("")
+
+    _repo_accessible.cache_clear()
+    monkeypatch.setattr("urllib.request.urlopen", capture)
+    assert _repo_accessible("\xf3wner", "r\xe9po", None) is True
+    _repo_accessible.cache_clear()
+    seen["url"].encode("ascii")  # would raise before
+    assert "%C3%B3wner" in seen["url"]
 
 
 def test_online_unparseable_url_is_unverifiable(tmp_path):


### PR DESCRIPTION
Split out of #54, which grew four review rounds' worth of *recovery* heuristics on top of a small crash fix. This PR is the crash fix alone; #54 keeps the heuristics and is rebased on top of this.

## The bug — two routes, two different doors

Both escaped `_fetch_once`'s `except (URLError, TimeoutError, OSError)`:

- **whitespace or control characters in the href.** Mirrored third-party content carries `[t]( https://…/inv... https://…)` — two truncated URLs with a space between them. `http.client.InvalidURL` descends from `HTTPException`, **not** `OSError`.
- **a non-ASCII path.** `http.client` encodes the request line as ASCII and raises `UnicodeEncodeError`, a **`ValueError`**, so it escaped even a widened `HTTPException` belt. An accented filename was enough, through the plainest pipeline there is.

Strictly, **013 forbade neither**: FR-008 covers an *unrecognised* URL shape and the regex accepts this one (it dies later, at the fetch); FR-009 is worded for *"network/transport errors (timeout, DNS, connection reset)"*, and client-side URL validation is none of those. The crash fell through the gap between two requirements each written assuming the other covered it. Worth restating FR-009 when 013 is next touched.

## The fix, and why it is deliberately conservative

Every URL field is percent-encoded — all four, since an owner or repo can carry non-ASCII as easily as a path — with `safe="/%"` so an href already written with `%20` is not turned into `%2520`. And an href carrying a character the client would refuse is reported `web_unverifiable` instead of being sent.

**Encoding alone would have been unsafe**, which is the reason the second half is here: a space would become `%20`, the request would succeed, and the resulting 404 would be reported as a *real break*. The same trap sits behind the tempting refinement — forbid those characters only *inside* the parsed groups, so more links can still be resolved. It truncates the path at the first offending character, fetches a **different** file, and turns its 404 into a hard failure. **A false `web_not_found` in a blocking gate is worse than the crash it replaces.** A test asserts this, so the shortcut cannot return by accident.

What this rejects and does not try to recover: a CommonMark title glued to the href by `MD_LINK_RE` (`[t](url "Title")`), and a space inside a `#fragment`. Both are links that *could* be verified with more cleverness. That cleverness is #54, where it can be reviewed on its own risk.

Client-side URL errors get their own sentinel, kept out of `_TRANSIENT_STATUSES`: retrying a deterministic rejection spends real sleeps and can never succeed, and folding it into the network sentinel would bury darnlink's own defect under "network error" forever.

## Tests

221 passing, and **verified by mutation**: with `src/` from `main`, 8 fail. Two build the `GithubUrl` by hand to bypass the parser, so the `except` clauses are verified independently of the guard in front of them; one covers `_repo_accessible`, whose real body no other test in the suite ever executed and whose docstring claimed "never raises" while it raised.

## Provenance

Copilot's review came back empty (quota). Four independent adversarial passes were run instead, on the combined change. Every finding in this PR's scope is applied; the findings about the recovery heuristics stay with them in #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)