### PR TITLE
016: fail on web links to repos you own whose destination has no uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **`web-check --online` can fail on a destination *you own* that has no `uuid`** — feature 016,
+  opt-in (`specs/016-own-repo-web-strictness/spec.md`). The web axis is forgiving by design: a
+  destination that fetches 200 without a `uuid` is `web_unverifiable` and the run still exits 0,
+  because the file lives in someone else's repository and cannot be fixed from here. When it is
+  **yours** that is not an external limitation — it is a missing two-line edit in a repo you control,
+  and nothing ever said so.
+
+  - **`--own OWNER`** (repeatable, stripped and case-folded) names the owners you control.
+    **`--own-from-origin`** adds this repo's `origin` owner — a separate flag rather than a magic
+    `--own auto`, so an owner literally called `auto` stays expressible. If it cannot resolve, the run
+    is a **usage error**, even when explicit owners were given: it is a request, not a fallback.
+  - **`web_own_no_uuid`** at exit **4**, not 3 — 3 promises "re-run with `--write`", and darnlink
+    cannot fix this one. The message names owner, repo and path, and never suggests `--write`.
+  - **`--own-max N`** budgets it so a repo can adopt the rule before reaching zero. The budget
+    silences the *verdict*, never the *finding*, and never shields another exit-4 cause. The report
+    says where the count stands in all four cases — including **over** the budget, because a budget
+    that goes silent exactly when it is exceeded is the one moment its number is worth reading.
+  - **`<!-- darnlink-own-exempt -->`** exempts a link whose destination is machine-regenerated, where
+    a `uuid` is futile — from the new finding, from anchoring, and from `web_mismatch`, since a
+    regenerating destination is precisely one whose uuid drifts. Honoured **with or without an owner
+    set**: it states a property of the link, not of the run.
+
+  Two exclusions, textual and offline: a destination that is not `.md` can never carry frontmatter,
+  and one pinned to a **commit SHA** can never be given one retroactively. Tags are deliberately not
+  excluded — a tag is textually indistinguishable from a branch of the same name.
+
+  With no owner set, behaviour is unchanged byte for byte in the **text report, the exit code and the
+  files on disk**, with two named departures: the exemption marker, and two zero counters that
+  `--json` gains unconditionally so a consumer can tell the axis ran.
+
 ## [0.20.5] — 2026-08-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,9 @@ All notable changes to darnlink are documented here. The format is based on
   excluded — a tag is textually indistinguishable from a branch of the same name.
 
   With no owner set, behaviour is unchanged byte for byte in the **text report, the exit code and the
-  files on disk**, with two named departures: the exemption marker, and two zero counters that
-  `--json` gains unconditionally so a consumer can tell the axis ran.
+  files on disk**, with two named departures: the exemption marker, and three keys that
+  `--json` gains unconditionally — the two new counters at zero, and `own_max` — so a consumer can
+  tell both that the axis ran and what budget it ran under.
 
 ## [0.20.5] — 2026-08-13
 

--- a/specs/016-own-repo-web-strictness/spec.md
+++ b/specs/016-own-repo-web-strictness/spec.md
@@ -158,8 +158,8 @@ into it later.
 
 ### Adoption: a budget, not a cliff
 
-The budget is **`--own-max N`**: fail only above it, and print the "lower it to N" nudge when the
-count drops. Without it, switching the axis on fails several repos at once on day one, and an axis
+The budget is **`--own-max N`**: fail only above it, and say where the count stands relative to it —
+in all four cases, not only when it drops (FR-013). Without it, switching the axis on fails several repos at once on day one, and an axis
 that cannot be adopted incrementally gets turned off instead of obeyed — the lesson 015 already paid.
 
 **The gate-recipe wiring is deliberately NOT in this spec.** Three review rounds spent their findings
@@ -395,14 +395,24 @@ convenience needs a named sentence in P-IV.
   *finding*. Omitting the flag MUST be distinguishable from `--own-max 0` (default `None`); the observable
   difference is FR-013's message, not the exit code, which is the same for both. `--own-max` without
   any owner set MUST be a usage error (exit 1).
-- **FR-013** When the count is at or below a non-zero `--own-max`, the report MUST print the count and
-  say that lowering the budget to that number keeps the ratchet; when the count reaches **zero** it
-  MUST say to drop the flag entirely. Both nudges, as `dangling_max` gives. A budget nobody is told to
-  lower is a budget that never goes down. When the count is **above zero** and under budget, the run's
-  outcome word MUST also say so: today exit 0 prints `clean`, and printing `clean` with findings on
-  screen is exactly the misreading this project's consumers have already paid for. At **zero** it must
-  keep saying `clean` — an obsolete `--own-max 5` on an already-clean repo must not make a clean run
-  look qualified.
+- **FR-013** The report MUST always say where the count stands relative to the budget, in **four**
+  branches — the shape the `dangling` precedent actually has, which an earlier draft of this
+  requirement got wrong by naming only two:
+  - **zero** → say to drop the flag entirely; the rule is a rule again.
+  - **strictly below** a non-zero budget → say that lowering it to the count keeps the ratchet.
+  - **exactly at** the budget → say so, and point at the next step (fix one, lower it by one).
+    *"Lower the budget to 2" when the budget is already 2 instructs nobody*, and this is the state a
+    repo sits in for most of an adoption, so it is the message printed most often.
+  - **over** the budget → say so too. The run already fails on its own, but a budget that goes silent
+    exactly when it is exceeded is the one moment its number is most worth reading.
+
+  A budget nobody is told to lower is a budget that never goes down, which is why all four branches
+  speak. Separately, when the count is **above zero** and within budget the run's **outcome word**
+  MUST say so: today exit 0 prints `clean`, and printing `clean` with findings on screen is exactly
+  the misreading this project's consumers have already paid for. At **zero** it must keep saying
+  `clean` — an obsolete `--own-max 5` on an already-clean repo must not make a clean run look
+  qualified. Unlike the four branches, this clause is conditioned on the exit code, because it is the
+  word that reports it.
 - **FR-014** The new finding MUST compose with the file-level opt-outs: a file carrying
   `darnlink-ignore-file` (003) or `darnlink-ignore-links` (006) MUST NOT produce it. The link is still
   fetched and still reported — it degrades to `web_unverifiable`, it does not vanish — because
@@ -523,8 +533,9 @@ resolves through `git config`.
     `web_not_found`, exit 4 — status decides before the exemption (§Precedence).
 13. **Owner case.** `--own OWNED` against a `owned/repo/…` URL is owned, and vice versa (FR-001).
 14. **Budget.** With two owned uuid-less destinations: `--own-max 2` → both reported, exit **0**, the
-    outcome word is not `clean`, and the report says to lower the budget to 2; `--own-max 1` → exit
-    **4**; `--own-max 2` with an additional real `web_not_found` → exit **4** (FR-012). `--own-max`
+    outcome word is not `clean`, and the report says the count is **exactly at** the budget and to fix
+    one and lower it to 1 — not "lower it to 2", which would be a no-op; `--own-max 3` → the
+    lower-it-to-2 nudge; `--own-max 1` → exit **4**, and the report still says where the count stands; `--own-max 2` with an additional real `web_not_found` → exit **4** (FR-012). `--own-max`
     with no owner set → exit 1. Two links in **different files** pointing at the **same** uuid-less
     destination count as **2** (FR-012 counts findings, not destinations).
 15. **Composition.** The same failing link degrades to `web_unverifiable` — reported, not silent, and

--- a/specs/016-own-repo-web-strictness/spec.md
+++ b/specs/016-own-repo-web-strictness/spec.md
@@ -392,8 +392,10 @@ convenience needs a named sentence in P-IV.
   the same uuid-less file cost 2, and one edit at the destination clears both. `web_own_exempt` never
   counts. Other exit-4 causes are unaffected: one budgeted finding plus one real `web_not_found`
   still exits 4. The findings are always reported — the budget silences the *verdict*, never the
-  *finding*. Omitting the flag MUST be distinguishable from `--own-max 0` (default `None`); the observable
-  difference is FR-013's message, not the exit code, which is the same for both. `--own-max` without
+  *finding*. Omitting the flag MUST be distinguishable from `--own-max 0` (default `None`) **on both
+  surfaces**: in the text report through FR-013's message, and in `--json` through an **`own_max` key
+  carrying the budget's own value** — the nudges live in the text branch and never reach the payload,
+  so without that key the two runs are byte-identical there. The exit code is the same for both. `--own-max` without
   any owner set MUST be a usage error (exit 1).
 - **FR-013** The report MUST always say where the count stands relative to the budget, in **four**
   branches — the shape the `dangling` precedent actually has, which an earlier draft of this

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -251,7 +251,6 @@ def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple,
         # every finding for a consumer that wants them, and the gate recipe prints them when its
         # dangling axis is switched on.
         print(f"  -> exit {code} ({outcome})")
-
     return code
 
 
@@ -342,6 +341,18 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
                         help="directory-name glob to skip (fnmatch, case-sensitive; a plain name matches "
                              "exactly) (repeatable). Exclude vendored clones of foreign repos so their "
                              "internal web links aren't fetched/anchored.")
+    parser.add_argument("--own", action="append", default=[], metavar="OWNER",
+                        help="feature 016: a GitHub owner you control (repeatable). A destination "
+                             "owned by one of these whose .md has no uuid becomes a FAILURE — it is "
+                             "not an external limitation, it is a missing edit in a repo you control.")
+    parser.add_argument("--own-from-origin", action="store_true",
+                        help="also treat the owner of this repo's `origin` remote as yours. A separate "
+                             "flag rather than a magic --own value, so an owner literally called "
+                             "'auto' stays expressible.")
+    parser.add_argument("--own-max", type=int, default=None, metavar="N",
+                        help="budget: while there are N or fewer owned-without-uuid findings they are "
+                             "reported but do not fail the exit. Lets the axis be adopted before a "
+                             "repo reaches zero.")
     parser.add_argument("--json", action="store_true", help="machine-readable output")
     args = parser.parse_args(argv)
 
@@ -351,6 +362,39 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
         return 1
     if args.write and not args.online:
         print("error: --write requires --online (there is nothing to anchor without fetching)", file=sys.stderr)
+        return 1
+    # FR-017: the offline branch ignores these entirely, so accepting them silently would report a
+    # green run that never applied the rule it was asked for. Same argument as --write, above.
+    if (args.own or args.own_from_origin or args.own_max is not None) and not args.online:
+        print("error: --own/--own-from-origin/--own-max require --online (ownership is decided on a "
+              "fetched destination)", file=sys.stderr)
+        return 1
+    if args.own_max is not None and args.own_max < 0:
+        print("error: --own-max must be >= 0; a negative budget cannot be met and its messages would "
+              "arithmetically lie", file=sys.stderr)
+        return 1
+    # Stripped BEFORE folding, not merely tested: `--own " owned "` used to pass the emptiness check
+    # and then match nothing, so the run went green AND said the budget was stale — the false green
+    # this feature exists to remove, produced by a stray space.
+    owners = frozenset(s for s in (o.strip().casefold() for o in args.own) if s)
+    if args.own and not owners:
+        print("error: --own needs a non-empty owner name; an empty one owns nothing and would satisfy "
+              "the --own-max guard without switching any rule on", file=sys.stderr)
+        return 1
+    if args.own_from_origin:
+        # FR-002/FR-003. Through `git config`, not a hand parse of .git/config: in a worktree `.git`
+        # is a FILE, so a naive parse fails in this project's own development environment.
+        origin_owner = _github_owner_from_origin(root)
+        if origin_owner is None:
+            print("error: --own-from-origin could not resolve an owner (no repository, no 'origin', a "
+                  "non-GitHub remote, git not on PATH, or git refusing the repo as dubiously owned). "
+                  "It is a request, not a fallback: answering a narrower question than the one asked "
+                  "would be the false pass this flag exists to prevent.", file=sys.stderr)
+            return 1
+        owners = owners | {origin_owner.casefold()}
+    if args.own_max is not None and not owners:
+        print("error: --own-max needs an owner set (--own / --own-from-origin); budgeting a rule that "
+              "is not switched on is a no-op that reads like protection", file=sys.stderr)
         return 1
 
     block_markers = tuple(args.ignore_block)
@@ -386,12 +430,15 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
         return 0
 
     token = os.environ.get("GITHUB_TOKEN") or None
-    findings, edits = check_web_links_online(root, token, fetcher or default_fetcher, block_markers, excludes)
+    findings, edits = check_web_links_online(root, token, fetcher or default_fetcher, block_markers,
+                                             excludes, owners)
     ok = [x for x in findings if x.kind == "web_ok"]
     anchors = [x for x in findings if x.kind == "web_anchor"]
     mismatch = [x for x in findings if x.kind == "web_mismatch"]
     notfound = [x for x in findings if x.kind == "web_not_found"]
     unverifiable = [x for x in findings if x.kind == "web_unverifiable"]
+    own_no_uuid = [x for x in findings if x.kind == "web_own_no_uuid"]
+    own_exempt = [x for x in findings if x.kind == "web_own_exempt"]
 
     wrote = 0
     if args.write and edits:
@@ -400,7 +447,10 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
             write_text_keep_newlines(path, content)
             wrote += 1
 
-    integrity_fail = bool(mismatch or notfound)
+    # FR-012: the budget silences the VERDICT, never the finding. Other exit-4 causes are untouched,
+    # so one budgeted finding plus one real web_not_found still exits 4.
+    budgeted = args.own_max is not None and len(own_no_uuid) <= args.own_max
+    integrity_fail = bool(mismatch or notfound) or (bool(own_no_uuid) and not budgeted)
     anchors_pending = bool(anchors) and not args.write
     code = 4 if integrity_fail else (3 if anchors_pending else 0)
 
@@ -409,13 +459,25 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
             "web_check": True, "online": True, "exit_code": code, "wrote": wrote, "applied": args.write,
             "web_ok": len(ok), "web_anchor": len(anchors), "web_mismatch": len(mismatch),
             "web_not_found": len(notfound), "web_unverifiable": len(unverifiable),
+            "web_own_no_uuid": len(own_no_uuid), "web_own_exempt": len(own_exempt),
+            # FR-012 makes omitting the flag observably different from `--own-max 0`; without this key
+            # the two payloads were byte-identical, so the machine surface could not tell them apart.
+            "own_max": args.own_max,
             "findings": [{"kind": x.kind, "file": str(x.file), "href": x.href,
                           "detail": x.detail, "anchored_uuid": x.anchored_uuid} for x in findings],
         }, indent=2))
     else:
         print(f"darnlink web-check (EXPERIMENTAL, online) — root: {root}")
+        # FR-016: both new kinds are counted and listed in the TEXT report too. Printed only when
+        # non-zero, so a run without an owner set keeps today's line byte-for-byte (FR-001).
+        extra = (f" | own-no-uuid {len(own_no_uuid)} | own-exempt {len(own_exempt)}"
+                 if (own_no_uuid or own_exempt) else "")
         print(f"  ok {len(ok)} | anchor {len(anchors)} | mismatch {len(mismatch)} | "
-              f"not-found {len(notfound)} | unverifiable {len(unverifiable)}")
+              f"not-found {len(notfound)} | unverifiable {len(unverifiable)}{extra}")
+        for x in own_no_uuid:
+            print(f"  [web_own_no_uuid] {x.file}: {x.detail} ({x.href})")
+        for x in own_exempt:
+            print(f"  [web_own_exempt] {x.file}: {x.detail} ({x.href})")
         for x in mismatch:
             print(f"  [web_mismatch] {x.file}: {x.detail} ({x.href})")
         for x in notfound:
@@ -437,19 +499,78 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
         # axis went unnoticed for months. And it is not merely a missing measurement: an un-anchored
         # web link is only discoverable if the destination can be READ, so the same tree can exit 0
         # without a token and 3 with one. Say what was not looked at, right where the verdict is read.
+        at_ceiling = budgeted and args.own_max is not None and len(own_no_uuid) == args.own_max
         outcome = {0: "clean", 3: "anchors pending", 4: "integrity failure"}[code]
+        if code == 0 and own_no_uuid:
+            # FR-013. Two qualifiers can be true of the same exit 0 — findings held under budget, and
+            # links that could not be read at all — and they are about different things. Composing
+            # them is deliberate: keeping only one would silently revert the other's fix, and both
+            # exist for the same reason, that "clean" must never be printed over something unexamined.
+            where = "at the budget" if at_ceiling else "under budget"
+            outcome = f"{len(own_no_uuid)} owned finding(s), {where}"
         if code == 0 and unverifiable:
             # Only offer the token when the token would actually change something. `web_unverifiable`
             # has seven causes and credentials fix two; suggesting it over a non-GitHub URL or a
             # destination with no uuid is advice that cannot be taken, and advice that cannot be taken
             # is how this line becomes the next thing everyone scrolls past.
             fixable = sum(1 for x in unverifiable if x.token_would_help)
-            outcome = f"clean of what could be READ — {len(unverifiable)} unverifiable, NOT verified"
+            read_note = f"clean of what could be READ — {len(unverifiable)} unverifiable, NOT verified"
+            outcome = f"{outcome}; {read_note}" if own_no_uuid else read_note
             if fixable:
                 outcome += f"; {fixable} of them would resolve with GITHUB_TOKEN — export it"
         print(f"  -> exit {code} ({outcome})")
+        if args.own_max is not None:
+            # Four branches (FR-013). An earlier version had two; the third it then grew told you to
+            # lower the budget to the number it already was; and the fourth exists because a budget
+            # that goes silent exactly when it is exceeded is the one moment its number is worth
+            # reading. The nudges carry no exit-code condition — FR-013 attaches one only to the
+            # outcome word — because the runs most likely to be read are the failing ones.
+            n = len(own_no_uuid)
+            if not own_no_uuid:
+                tail = "so the rule is a rule again" if args.own_max else "it is doing nothing"
+                print(f"  no owned findings left — drop --own-max (still {args.own_max}), {tail}.")
+            elif n > args.own_max:
+                # No causal claim here: with a web_not_found alongside, "that is why this run fails"
+                # would name a cause that is not sufficient, and fixing the count would not go green.
+                print(f"  {n} owned finding(s), OVER the budget of {args.own_max} — "
+                      f"{n - args.own_max} more than allowed.")
+            elif at_ceiling:
+                print(f"  {n} owned finding(s) — exactly at the budget (--own-max {args.own_max}). "
+                      f"Fix one and lower it to {n - 1}.")
+            else:
+                print(f"  {n} owned finding(s), under the budget of {args.own_max} — "
+                      f"lower --own-max to {n} to keep the ratchet.")
+
 
     return code
+
+
+def _github_owner_from_origin(root: Path) -> Optional[str]:
+    """FR-002. The owner of `origin`, via `git config` — the only reading that survives a worktree,
+    where `.git` is a file rather than a directory. Returns None for every failure mode, which FR-003
+    turns into a usage error rather than a silent narrowing of the question."""
+    import os as _os
+    import re as _re
+    import subprocess
+    # `git` hooks export GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE, and the gate runs darnlink FROM a
+    # hook. Inherited, they override `-C` and answer about the hook's repository instead of the
+    # scanned one — silently, and with a plausible owner.
+    env = {k: v for k, v in _os.environ.items()
+           if k not in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR")}
+    try:
+        out = subprocess.run(["git", "-C", str(root), "config", "--get", "remote.origin.url"],
+                             capture_output=True, text=True, timeout=10, env=env)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    # `_re.ASCII` matters: without it IGNORECASE folds U+0131 to `i`, so `gıthub.com/evil` resolved
+    # to owner `evil`. `ssh.github.com` and an explicit port are GitHub's own documented forms for
+    # networks that block 22; rejecting them printed "a non-GitHub remote", which was false.
+    m = _re.match(r"(?:(?:https?|ssh)://(?:[^/@]*@)?(?:www\.|ssh\.)?github\.com(?::\d+)?/"
+                  r"|(?:[^/@]*@)?github\.com:)(?P<owner>[^/]+)/",
+                  out.stdout.strip(), _re.IGNORECASE | _re.ASCII)
+    return m["owner"] if m else None
 
 
 def _make_stdio_encoding_safe() -> None:

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -181,7 +181,14 @@ def _fetch_once(gu: GithubUrl, token: Optional[str]) -> Tuple[int, Optional[str]
         req.add_header("Authorization", f"Bearer {token}")
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
-            return (resp.status, resp.read().decode("utf-8", errors="replace"))
+            # `utf-8-sig`, like every LOCAL read in this package (frontmatter_edit, frontmatter_index):
+            # a Windows-authored destination arrives with a BOM, plain utf-8 leaves it in front of the
+            # `---`, and the frontmatter reader then sees no frontmatter at all. Before feature 016
+            # that was merely an unhelpful `web_unverifiable`; with it, a destination that HAS a uuid
+            # gets reported as lacking one — exit 4, over an instruction nobody can follow, because
+            # adding a second `uuid:` fixes nothing. This repo already has a regression suite for the
+            # same defect on the local path (tests/test_bom.py); the web path was simply left out.
+            return (resp.status, resp.read().decode("utf-8-sig", errors="replace"))
     except urllib.error.HTTPError as e:
         return (e.code, None)
     except (http.client.InvalidURL, ValueError):
@@ -419,7 +426,11 @@ def check_web_links_online(
             if link.href not in cache:
                 cache[link.href] = fetcher(gu, token)
             status, text = cache[link.href]
-            dest_fm_status, dest_uuid = (read_frontmatter_uuid(text)
+            # `lstrip("\ufeff")` as well as the `utf-8-sig` decode in `_fetch_once`, and not instead of
+            # it: the decode fixes the wire, this fixes the TEXT, whatever produced it. A BOM in front
+            # of the `---` hides the frontmatter, and 016 turns that from an unhelpful
+            # `web_unverifiable` into an exit 4 telling you to add a uuid the file already has.
+            dest_fm_status, dest_uuid = (read_frontmatter_uuid(text.lstrip("\ufeff"))
                                          if (status == 200 and text is not None) else (None, None))
             fnd = _classify(link, gu, status, dest_uuid, have_token, f, owners, dest_fm_status, filtered)
             findings.append(fnd)

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -42,6 +42,26 @@ _TRAILING_WEB_UUID_RE = re.compile(
 )
 
 
+#: Feature 016 (FR-011). Placement is NORMATIVE: immediately after the `)`, or immediately after a
+#: `web-uuid` anchor — nowhere else. `[ \t]*`, NOT `\s*`: the latter crosses newlines, so a marker on
+#: its own line — the natural way to write it for the link BELOW — silently exempted the link ABOVE,
+#: suppressing a real `web_mismatch` and turning an exit 4 into a green run.
+_TRAILING_OWN_EXEMPT_RE = re.compile(r"[ \t]*<!--\s*darnlink-own-exempt\s*-->")
+
+#: FR-006. A commit SHA, long or short, in either case — GitHub accepts an uppercase SHA in `?ref=`,
+#: so a rule that did not fold case would make such a link an unfixable failure. Matched WHOLE:
+#: `release-deadbeef` is a branch and perfectly fixable. Purely textual, and it stops here — a TAG is
+#: textually indistinguishable from a branch of the same name, and telling them apart needs the
+#: network.
+_IMMUTABLE_REF_RE = re.compile(r"[0-9a-fA-F]{7,40}\Z")
+
+
+def owner_is_owned(owner: str, owners: frozenset) -> bool:
+    """FR-001. GitHub logins are ASCII case-insensitive and the parser preserves the case it found,
+    so the comparison — not the parse — folds it."""
+    return owner.casefold() in owners
+
+
 def emit_web_anchor(text: str, href: str, uuid: str) -> str:
     """`[text](href) <!-- web-uuid: uuid -->` — the cross-repo counterpart of the core's robust link.
     `web-uuid` (not `uuid`) keeps it invisible to the core's marker (see FR-002)."""
@@ -110,6 +130,7 @@ class WebLink:
     uuid: Optional[str]  # None => plain web link (not yet anchored); else the anchored uuid
     start: int
     end: int
+    exempt: bool = False  # FR-011: carries <!-- darnlink-own-exempt -->
 
 
 def find_web_links(content: str, ignore: Sequence[Span] = ()) -> List[WebLink]:
@@ -123,10 +144,12 @@ def find_web_links(content: str, ignore: Sequence[Span] = ()) -> List[WebLink]:
         if _in_spans(m.start(), ignore):
             continue
         tail = _TRAILING_WEB_UUID_RE.match(content, m.end())
-        if tail:
-            out.append(WebLink(m["text"], href, tail["uuid"].lower(), m.start(), tail.end()))
-        else:
-            out.append(WebLink(m["text"], href, None, m.start(), m.end()))
+        end = tail.end() if tail else m.end()
+        uuid = tail["uuid"].lower() if tail else None
+        # FR-011: recognised right after the `)` or right after the anchor, and nowhere else. `end`
+        # deliberately does NOT cover it, so an exempt link that is ever rewritten keeps its marker.
+        exempt = _TRAILING_OWN_EXEMPT_RE.match(content, end) is not None
+        out.append(WebLink(m["text"], href, uuid, m.start(), end, exempt))
     return out
 
 
@@ -240,6 +263,7 @@ def default_fetcher(gu: GithubUrl, token: Optional[str], *,
 @dataclass(frozen=True)
 class WebFinding:
     kind: str          # web_ok · web_anchor · web_mismatch · web_not_found · web_unverifiable
+                       # · web_own_no_uuid · web_own_exempt (feature 016)
     file: Path         # the linking file in the scanned tree
     href: str
     detail: str
@@ -254,7 +278,14 @@ class WebFinding:
 
 
 def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Optional[str],
-              have_token: bool, f: Path) -> WebFinding:
+              have_token: bool, f: Path, owners: frozenset = frozenset(),
+              dest_fm_status: Optional[str] = None, filtered: bool = False) -> WebFinding:
+    """Feature 016 adds two kinds on top of 013's five. Two axes (§Precedence): visibility first —
+    `--ignore-block` and code fences never reach here, and a file carrying `darnlink-ignore-file` /
+    `darnlink-ignore-links` arrives with `filtered=True`, which suppresses ONLY the new finding
+    (FR-014), never `web_mismatch` or `web_not_found` (FR-007). Then classification, where **status
+    decides first**: anything other than 200 keeps exactly today's kind, exempt or not — a dead link
+    is dead either way. The exemption and the new finding live strictly inside the 200 branch."""
     if gu is None:
         return WebFinding("web_unverifiable", f, link.href, "not a recognised GitHub blob/raw URL")
     if status in (401, 403):
@@ -297,13 +328,36 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
                           "was not retried because a client-side rejection cannot clear on a retry")
     if status != 200:
         return WebFinding("web_unverifiable", f, link.href, f"fetch failed (status {status})")
-    # status 200: we have the destination content and its uuid (may be None)
+    # --- status 200 from here on ---
+    if link.exempt:
+        # FR-011. Exempt from FR-004, from 013's FR-005 (anchoring) and from `web_mismatch`: a
+        # destination that regenerates is precisely one whose uuid drifts, so without the third the
+        # hatch would not escape. Honoured with or without an owner set — it states a property of the
+        # LINK, not of the run's configuration, and a marker that stopped working when someone dropped
+        # `--own` would let `--write` rewrite the very files it was placed to protect.
+        return WebFinding("web_own_exempt", f, link.href,
+                          "carries <!-- darnlink-own-exempt -->; never anchored, never called stale")
     if link.uuid is None:
         # plain web link -> anchor it if the destination has a uuid
         if dest_uuid:
             return WebFinding("web_anchor", f, link.href,
                               f"plain web link; destination uuid {dest_uuid} -> would anchor",
                               anchored_uuid=dest_uuid)
+        owned = gu is not None and owner_is_owned(gu.owner, owners)
+        if owned and dest_fm_status == "invalid":
+            # FR-004: a different defect. Telling someone to ADD a uuid to a file whose frontmatter
+            # does not parse points them at the wrong thing. Gated on `owned` so FR-001 holds for the
+            # message too: with the feature off this link keeps the wording it has today.
+            return WebFinding("web_unverifiable", f, link.href,
+                              "destination frontmatter is present but not readable (invalid YAML, or a "
+                              "uuid that is not a string) — a different defect from a missing uuid")
+        if (owned
+                and gu.path.lower().endswith(".md")           # FR-005
+                and not _IMMUTABLE_REF_RE.fullmatch(gu.ref)   # FR-006
+                and not filtered):                            # FR-014
+            return WebFinding("web_own_no_uuid", f, link.href,
+                              f"destination is yours ({gu.owner}/{gu.repo}) and {gu.path} has no uuid "
+                              f"in its frontmatter — add one there, then this link can be anchored")
         return WebFinding("web_unverifiable", f, link.href, "destination has no uuid to anchor to")
     # already anchored -> verify
     if dest_uuid is None:
@@ -321,6 +375,7 @@ def check_web_links_online(
     fetcher: Fetcher = default_fetcher,
     block_markers: tuple = (),
     excludes: Optional[set] = None,
+    owners: frozenset = frozenset(),
 ) -> Tuple[List[WebFinding], Dict[Path, str]]:
     """Fetch each web link's destination (once, cached per URL) and classify it. Returns the findings
     and the per-file rewritten content for any `web_anchor` (the caller writes it only under --write).
@@ -331,6 +386,7 @@ def check_web_links_online(
     fetched/anchored. Defaults to the shared `DEFAULT_EXCLUDES`."""
     from .frontmatter_index import iter_markdown_files, DEFAULT_EXCLUDES
     from .frontmatter_edit import read_text_keep_newlines
+    from .links import file_ignores_links, file_is_ignored
 
     if excludes is None:
         excludes = DEFAULT_EXCLUDES
@@ -344,6 +400,10 @@ def check_web_links_online(
             content = read_text_keep_newlines(f)
         except Exception:
             continue
+        # FR-014: the file-level opt-outs suppress the NEW finding only (by kind) — a third, narrower
+        # semantics than the core's "removed from the graph entirely", declared rather than left to the
+        # reader. `--ignore-block` is out of this and unchanged (FR-015).
+        filtered = file_is_ignored(content) or file_ignores_links(content)
         ignore = ignored_spans(content, block_markers) + code_spans(content)
         links = find_web_links(content, ignore)
         if not links:
@@ -354,13 +414,14 @@ def check_web_links_online(
         for link in links:
             gu = parse_github_url(link.href)
             if gu is None:
-                findings.append(_classify(link, None, 0, None, have_token, f))
+                findings.append(_classify(link, None, 0, None, have_token, f, owners))
                 continue
             if link.href not in cache:
                 cache[link.href] = fetcher(gu, token)
             status, text = cache[link.href]
-            dest_uuid = read_frontmatter_uuid(text)[1] if (status == 200 and text is not None) else None
-            fnd = _classify(link, gu, status, dest_uuid, have_token, f)
+            dest_fm_status, dest_uuid = (read_frontmatter_uuid(text)
+                                         if (status == 200 and text is not None) else (None, None))
+            fnd = _classify(link, gu, status, dest_uuid, have_token, f, owners, dest_fm_status, filtered)
             findings.append(fnd)
             if fnd.kind == "web_anchor" and fnd.anchored_uuid:
                 pieces.append(content[cursor:link.start])

--- a/tests/test_own_repo_web_strictness.py
+++ b/tests/test_own_repo_web_strictness.py
@@ -1,0 +1,650 @@
+"""Feature 016: fail on cross-repo web links to YOUR OWN repos whose destination has no `uuid`.
+
+One test per acceptance scenario of `specs/016-own-repo-web-strictness/spec.md`, in order, so a
+failure names the requirement it breaks. The fetch layer is mocked everywhere — no test touches the
+network. Scenarios 8 and 9 additionally build a real git fixture, because FR-002 resolves the owner
+through `git config` and a hand-rolled `.git/config` would not exercise it.
+
+Every assertion here was validated by mutation while it was written: break what it covers and it
+fails. That is not ceremony — three tests in this feature's own history passed while proving nothing
+(one claimed to reach a sentinel the guard intercepted first; another used filler from the very
+bucket it claimed to distinguish).
+"""
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from darnlink.cli import _run_web_check_cli
+from darnlink.weblinks import GithubUrl, check_web_links_online
+
+UUID = "3f9c1a2b-4d5e-6f70-8192-a3b4c5d6e7f8"
+OTHER = "11111111-2222-3333-4444-555555555555"
+SHA40 = "30066b0042d0c5928d959e288144300cb28196c9"
+SHA7 = "30066b0"
+
+OWNED = "https://github.com/owned/repo/blob/main/a.md"
+FOREIGN = "https://github.com/someone-else/repo/blob/main/a.md"
+
+
+def _w(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _fetcher(responses, calls=None):
+    """Maps a full blob URL -> (status, text). Anything unlisted 404s. `calls` records every fetch."""
+    def f(gu: GithubUrl, token):
+        key = f"https://github.com/{gu.owner}/{gu.repo}/blob/{gu.ref}/{gu.path}"
+        if calls is not None:
+            calls.append(key)
+        return responses.get(key, (404, None))
+    return f
+
+
+def _no_uuid(text="# a destination with no frontmatter\n"):
+    return (200, text)
+
+
+def _with_uuid(u=UUID):
+    return (200, f"---\nuuid: {u}\n---\n# dest\n")
+
+
+def _kinds(tmp_path, fetch, owners=frozenset({"owned"})):
+    findings, edits = check_web_links_online(tmp_path, None, fetch, owners=owners)
+    return [f.kind for f in findings], findings, edits
+
+
+#: A git hook exports GIT_DIR and friends, and they override `-C`. Without stripping them these
+#: fixtures build (and then read) the WRONG repository — which is exactly how this was found: the
+#: suite passed standalone and failed under this project's own pre-commit hook.
+_GIT_ENV = {k: v for k, v in os.environ.items()
+            if k not in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR")}
+
+
+def _git_repo(tmp_path, origin: str | None):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True, env=_GIT_ENV)
+    if origin:
+        subprocess.run(["git", "-C", str(tmp_path), "remote", "add", "origin", origin],
+                       check=True, env=_GIT_ENV)
+    return tmp_path
+
+
+# 1
+def test_owned_destination_without_uuid_fails_and_says_where(tmp_path):
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    kinds, findings, _ = _kinds(tmp_path, _fetcher({OWNED: _no_uuid()}))
+    assert kinds == ["web_own_no_uuid"]
+    assert "owned/repo" in findings[0].detail and "a.md" in findings[0].detail
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned"],
+                              fetcher=_fetcher({OWNED: _no_uuid()})) == 4
+
+
+# 2
+def test_a_destination_you_do_not_own_is_unchanged(tmp_path):
+    _w(tmp_path / "src.md", f"see [x]({FOREIGN})\n")
+    kinds, _, _ = _kinds(tmp_path, _fetcher({FOREIGN: _no_uuid()}))
+    assert kinds == ["web_unverifiable"]
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned"],
+                              fetcher=_fetcher({FOREIGN: _no_uuid()})) == 0
+
+
+# 3
+def test_with_no_owner_set_nothing_changes(tmp_path):
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    kinds, _, _ = _kinds(tmp_path, _fetcher({OWNED: _no_uuid()}), owners=frozenset())
+    assert kinds == ["web_unverifiable"]
+    assert _run_web_check_cli([str(tmp_path), "--online"], fetcher=_fetcher({OWNED: _no_uuid()})) == 0
+
+
+# 4
+def test_an_owned_destination_that_has_a_uuid_still_anchors(tmp_path):
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    kinds, _, edits = _kinds(tmp_path, _fetcher({OWNED: _with_uuid()}))
+    assert kinds == ["web_anchor"] and edits
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--write"],
+                              fetcher=_fetcher({OWNED: _with_uuid()})) == 0
+    assert f"<!-- web-uuid: {UUID} -->" in (tmp_path / "src.md").read_text(encoding="utf-8")
+
+
+# 5
+@pytest.mark.parametrize("path,expected", [
+    ("tool.py", "web_unverifiable"),   # cannot carry frontmatter at all (FR-005)
+    ("A.MD", "web_own_no_uuid"),       # Markdown, case-folded like iter_markdown_files
+])
+def test_only_markdown_destinations_can_be_asked_for_a_uuid(tmp_path, path, expected):
+    url = f"https://github.com/owned/repo/blob/main/{path}"
+    _w(tmp_path / "src.md", f"see [x]({url})\n")
+    kinds, _, _ = _kinds(tmp_path, _fetcher({url: _no_uuid()}))
+    assert kinds == [expected]
+
+
+# 6
+@pytest.mark.parametrize("ref,expected", [
+    (SHA40, "web_unverifiable"),
+    (SHA7, "web_unverifiable"),
+    (SHA40.upper(), "web_unverifiable"),   # GitHub accepts it in ?ref=, so the rule must fold case
+    ("v1.2.3", "web_own_no_uuid"),         # a tag is indistinguishable from a branch WITHOUT the network
+])
+def test_a_commit_pinned_destination_can_never_be_fixed_so_it_never_fails(tmp_path, ref, expected):
+    url = f"https://github.com/owned/repo/blob/{ref}/a.md"
+    _w(tmp_path / "src.md", f"see [x]({url})\n")
+    kinds, _, _ = _kinds(tmp_path, _fetcher({url: _no_uuid()}))
+    assert kinds == [expected]
+
+
+@pytest.mark.parametrize("ref", ["release-deadbeef", "v1.2-abc1234", "deadbeef-wip"])
+def test_a_ref_that_merely_ends_in_hex_is_not_a_commit(tmp_path, ref):
+    """FR-006 matches the WHOLE ref. Anchoring it loosely would excuse `release-deadbeef` — a branch,
+    perfectly fixable — and the direction of that error is a false green."""
+    url = f"https://github.com/owned/repo/blob/{ref}/a.md"
+    _w(tmp_path / "src.md", f"see [x]({url})\n")
+    kinds, _, _ = _kinds(tmp_path, _fetcher({url: _no_uuid()}))
+    assert kinds == ["web_own_no_uuid"]
+
+
+def test_the_carve_out_is_not_a_verdict(tmp_path):
+    """FR-005/FR-006 say when FR-004 must NOT fire; they do not turn a link into anything. Read as a
+    terminal step they would silently change behaviour FR-007 freezes: this link is `web_anchor`."""
+    url = f"https://github.com/owned/repo/blob/{SHA40}/a.md"
+    _w(tmp_path / "src.md", f"see [x]({url})\n")
+    kinds, _, edits = _kinds(tmp_path, _fetcher({url: _with_uuid()}))
+    assert kinds == ["web_anchor"] and edits
+
+
+# 7
+def test_a_404_keeps_its_kind_whether_or_not_you_own_it(tmp_path):
+    _w(tmp_path / "src.md", f"see [x]({OWNED}) <!-- web-uuid: {UUID} -->\n")
+    findings, _ = check_web_links_online(tmp_path, None, _fetcher({}), owners=frozenset({"owned"}))
+    assert findings[0].kind == "web_unverifiable"          # no token: ambiguous, as today
+    findings, _ = check_web_links_online(tmp_path, "tok", _fetcher({}), owners=frozenset({"owned"}))
+    assert findings[0].kind == "web_not_found"             # with token: a real break, as today
+
+
+# 8
+@pytest.mark.parametrize("origin", ["git@github.com:owned/src.git",
+                                    "https://github.com/owned/src.git"])
+def test_own_from_origin_reads_the_remote(tmp_path, origin):
+    _git_repo(tmp_path, origin)
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own-from-origin"],
+                              fetcher=_fetcher({OWNED: _no_uuid()})) == 4
+
+
+def test_own_from_origin_unions_with_explicit_owners(tmp_path, capsys):
+    _git_repo(tmp_path, "git@github.com:owned/src.git")
+    _w(tmp_path / "src.md", f"a [x]({OWNED})\nb [y]({FOREIGN})\n")
+    code = _run_web_check_cli([str(tmp_path), "--online", "--own", "someone-else",
+                               "--own-from-origin", "--json"],
+                              fetcher=_fetcher({OWNED: _no_uuid(), FOREIGN: _no_uuid()}))
+    # `code == 4` alone proves nothing: the origin owner produces it on its own. BOTH owners must be
+    # in the set, so both destinations must fail.
+    assert json.loads(capsys.readouterr().out)["web_own_no_uuid"] == 2
+    assert code == 4
+
+
+# 9
+def test_own_from_origin_that_cannot_resolve_is_a_usage_error(tmp_path, capsys):
+    _git_repo(tmp_path, None)  # a repo with no origin
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    calls = []
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own-from-origin"],
+                              fetcher=_fetcher({}, calls)) == 1
+    assert calls == []  # no findings emitted, nothing fetched
+    assert "could not resolve" in capsys.readouterr().err
+
+
+def test_it_is_still_a_usage_error_when_explicit_owners_were_given(tmp_path):
+    """The owner set would NOT be empty. The rule is about the request, not the resulting set:
+    answering a narrower question than the one asked is the same false pass by a smaller door."""
+    _git_repo(tmp_path, None)
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-from-origin"],
+                              fetcher=_fetcher({})) == 1
+
+
+# 10
+def test_ownership_costs_no_extra_fetch(tmp_path):
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    without, with_ = [], []
+    check_web_links_online(tmp_path, None, _fetcher({OWNED: _no_uuid()}, without), owners=frozenset())
+    check_web_links_online(tmp_path, None, _fetcher({OWNED: _no_uuid()}, with_),
+                           owners=frozenset({"owned"}))
+    assert with_ == without == [OWNED]
+
+
+# 11
+def test_the_exemption_marker_takes_a_link_out_of_three_verdicts(tmp_path):
+    _w(tmp_path / "src.md", f"see [x]({OWNED}) <!-- darnlink-own-exempt -->\n")
+    kinds, findings, _ = _kinds(tmp_path, _fetcher({OWNED: _no_uuid()}))
+    assert kinds == ["web_own_exempt"]
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned"],
+                              fetcher=_fetcher({OWNED: _no_uuid()})) == 0
+    # …and without the marker the very same link fails
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned"],
+                              fetcher=_fetcher({OWNED: _no_uuid()})) == 4
+
+
+def test_an_exempt_link_is_never_anchored(tmp_path):
+    before = f"see [x]({OWNED}) <!-- darnlink-own-exempt -->\n"
+    _w(tmp_path / "src.md", before)
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--write"],
+                              fetcher=_fetcher({OWNED: _with_uuid()})) == 0
+    assert (tmp_path / "src.md").read_text(encoding="utf-8") == before
+
+
+def test_an_exempt_anchored_link_whose_destination_drifted_is_not_a_mismatch(tmp_path):
+    """The third exemption, and the one that makes the hatch escape: a destination that regenerates is
+    precisely one whose uuid drifts, so without it the normal migration path leaves a permanent exit 4."""
+    _w(tmp_path / "src.md",
+       f"see [x]({OWNED}) <!-- web-uuid: {UUID} --> <!-- darnlink-own-exempt -->\n")
+    kinds, _, _ = _kinds(tmp_path, _fetcher({OWNED: _with_uuid(OTHER)}))
+    assert kinds == ["web_own_exempt"]
+
+
+def test_both_markers_in_the_normative_order_round_trip(tmp_path):
+    before = f"see [x]({OWNED}) <!-- web-uuid: {UUID} --> <!-- darnlink-own-exempt -->\n"
+    _w(tmp_path / "src.md", before)
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--write"],
+                       fetcher=_fetcher({OWNED: _with_uuid()}))
+    assert (tmp_path / "src.md").read_text(encoding="utf-8") == before
+
+
+def test_the_corruption_case_does_not_append_a_second_anchor(tmp_path):
+    """With the anchor written AFTER the exemption the tail regex cannot see it, so the link reads as
+    plain. The exemption must still be honoured, or `--write` leaves two anchors on one line."""
+    before = f"see [x]({OWNED}) <!-- darnlink-own-exempt --> <!-- web-uuid: {UUID} -->\n"
+    _w(tmp_path / "src.md", before)
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--write"],
+                       fetcher=_fetcher({OWNED: _with_uuid()}))
+    after = (tmp_path / "src.md").read_text(encoding="utf-8")
+    assert after.count("web-uuid:") == 1 and after == before
+
+
+def test_the_marker_does_not_reach_across_a_blank_line(tmp_path):
+    """FR-011 says the marker is recognised immediately after the `)` or the anchor, and NOWHERE else.
+    Written on its own line — the natural way to write it for the link BELOW — a lax `\\s*` made it
+    exempt the link ABOVE, suppressing a real web_mismatch and turning exit 4 into a green run."""
+    _w(tmp_path / "src.md",
+       f"see [x]({OWNED}) <!-- web-uuid: {UUID} -->\n\n<!-- darnlink-own-exempt -->\n")
+    kinds, _, _ = _kinds(tmp_path, _fetcher({OWNED: _with_uuid(OTHER)}))
+    assert kinds == ["web_mismatch"]
+
+
+# 12
+@pytest.mark.parametrize("url", [
+    "https://github.com/owned/repo/blob/main/tool.py",
+    f"https://github.com/owned/repo/blob/{SHA40}/a.md",
+])
+def test_the_exemption_wins_over_the_other_exclusions(tmp_path, url):
+    _w(tmp_path / "src.md", f"see [x]({url}) <!-- darnlink-own-exempt -->\n")
+    kinds, _, _ = _kinds(tmp_path, _fetcher({url: _no_uuid()}))
+    assert kinds == ["web_own_exempt"]
+
+
+def test_an_exempt_link_that_verifies_cleanly_is_still_reported_as_exempt(tmp_path):
+    _w(tmp_path / "src.md",
+       f"see [x]({OWNED}) <!-- web-uuid: {UUID} --> <!-- darnlink-own-exempt -->\n")
+    kinds, _, _ = _kinds(tmp_path, _fetcher({OWNED: _with_uuid()}))
+    assert kinds == ["web_own_exempt"]   # NOT web_ok: the marker describes the link, not the run
+
+
+def test_status_decides_before_the_exemption(tmp_path):
+    """A dead link is dead whether or not its destination regenerates."""
+    _w(tmp_path / "src.md", f"see [x]({OWNED}) <!-- darnlink-own-exempt -->\n")
+    findings, _ = check_web_links_online(tmp_path, "tok", _fetcher({}), owners=frozenset({"owned"}))
+    assert findings[0].kind == "web_not_found"
+
+
+def test_origin_is_read_from_the_scanned_repo_even_under_a_git_hook(tmp_path, monkeypatch):
+    """A git hook exports GIT_DIR/GIT_WORK_TREE, and inherited they OVERRIDE `-C`. The gate runs
+    darnlink FROM a hook, so this is the normal case: without stripping them the answer is about the
+    hook's repository, silently and with a plausible owner."""
+    scanned = _git_repo(tmp_path / "scanned", "git@github.com:owned/src.git")
+    other = _git_repo(tmp_path / "other", "git@github.com:hijacked/x.git")
+    _w(scanned / "src.md", f"see [x]({OWNED})\n")
+    monkeypatch.setenv("GIT_DIR", str(other / ".git"))
+    monkeypatch.setenv("GIT_WORK_TREE", str(other))
+    # owner comes from `scanned` (owned/...), not from `other` (hijacked/...), so the link fails
+    assert _run_web_check_cli([str(scanned), "--online", "--own-from-origin"],
+                              fetcher=_fetcher({OWNED: _no_uuid()})) == 4
+
+
+# 13
+@pytest.mark.parametrize("flag,url", [("OWNED", OWNED),
+                                      ("owned", "https://github.com/OWNED/repo/blob/main/a.md")])
+def test_owner_matching_folds_case(tmp_path, flag, url):
+    _w(tmp_path / "src.md", f"see [x]({url})\n")
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", flag],
+                              fetcher=_fetcher({url: _no_uuid()})) == 4
+
+
+@pytest.mark.parametrize("origin,owned", [
+    ("https://notgithub.com/evil/src.git", False),   # only ENDS in github.com — must not resolve
+    ("https://github.com.evil.test/evil/src.git", False),
+    ("ssh://git@github.com/owned/src.git", True),
+    ("https://GitHub.com/owned/src.git", True),      # hostnames are case-insensitive
+    ("https://user@github.com/owned/src.git", True),
+])
+def test_only_a_real_github_origin_resolves(tmp_path, origin, owned):
+    _git_repo(tmp_path, origin)
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    code = _run_web_check_cli([str(tmp_path), "--online", "--own-from-origin"],
+                              fetcher=_fetcher({OWNED: _no_uuid()}))
+    assert code == (4 if owned else 1)
+
+
+def test_an_empty_owner_is_a_usage_error(tmp_path):
+    """`--own ""` owns nothing, yet it would satisfy the --own-max guard — the very thing that guard
+    exists to prevent."""
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", ""], fetcher=_fetcher({})) == 1
+
+
+# 14
+def test_the_budget_silences_the_verdict_never_the_finding(tmp_path, capsys):
+    b = "https://github.com/owned/repo/blob/main/b.md"
+    _w(tmp_path / "src.md", f"a [x]({OWNED})\nb [y]({b})\n")
+    resp = {OWNED: _no_uuid(), b: _no_uuid()}
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "2"],
+                              fetcher=_fetcher(resp)) == 0
+    out = capsys.readouterr().out
+    assert out.count("[web_own_no_uuid]") == 2 and "clean" not in out
+    # AT the budget is where the ratchet matters most — you are at the ceiling. Without an assert here
+    # the requirement passed while the nudge was silent (the code said `< own_max`); the wording it
+    # then grew was a no-op instruction, so what is pinned is the third branch, not the second.
+    assert "exactly at the budget" in out
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "1"],
+                              fetcher=_fetcher(resp)) == 4
+
+
+def test_the_budget_nudges_you_to_lower_it(tmp_path, capsys):
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "3"],
+                       fetcher=_fetcher({OWNED: _no_uuid()}))
+    assert "lower --own-max to 1" in capsys.readouterr().out
+
+
+def test_a_budgeted_finding_does_not_shield_a_real_break(tmp_path, monkeypatch):
+    """The token matters: without one a 404 is ambiguous by design (013's contract), so there would be
+    no real break to shield and the test would pass for the wrong reason."""
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+    dead = "https://github.com/owned/repo/blob/main/dead.md"
+    _w(tmp_path / "src.md", f"a [x]({OWNED})\nb [y]({dead}) <!-- web-uuid: {UUID} -->\n")
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "5"],
+                              fetcher=_fetcher({OWNED: _no_uuid()})) == 4
+
+
+def test_the_ratchet_is_not_hidden_by_another_failure(tmp_path, monkeypatch, capsys):
+    """FR-013 conditions the OUTCOME WORD on the exit code, not the nudges — and the runs most likely
+    to be read are the failing ones."""
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+    dead = "https://github.com/owned/repo/blob/main/dead.md"
+    _w(tmp_path / "src.md",
+       f"a [x]({OWNED})\nb [y]({dead}) <!-- web-uuid: {UUID} -->\n")
+    code = _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "5"],
+                              fetcher=_fetcher({OWNED: _no_uuid()}))
+    out = capsys.readouterr().out
+    assert code == 4 and "integrity failure" in out
+    assert "lower --own-max to 1" in out          # the ratchet still speaks
+    assert "under budget" not in out              # …but it does not relabel the failure
+
+
+def test_a_homograph_host_is_not_github(tmp_path):
+    """IGNORECASE without ASCII folds U+0131 to `i`, so `gıthub.com/evil` resolved to owner `evil`."""
+    _git_repo(tmp_path, "https://g\u0131thub.com/evil/src.git")
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own-from-origin"],
+                              fetcher=_fetcher({})) == 1
+
+
+@pytest.mark.parametrize("origin", ["ssh://git@github.com:22/owned/src.git",
+                                    "ssh://git@ssh.github.com:443/owned/src.git"])
+def test_githubs_own_firewall_forms_resolve(tmp_path, origin):
+    """GitHub documents both for networks that block port 22. Rejecting them printed "a non-GitHub
+    remote", which was simply false."""
+    _git_repo(tmp_path, origin)
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own-from-origin"],
+                              fetcher=_fetcher({OWNED: _no_uuid()})) == 4
+
+
+def test_a_budget_without_an_owner_set_is_a_usage_error(tmp_path):
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own-max", "1"],
+                              fetcher=_fetcher({})) == 1
+
+
+def test_two_links_to_one_destination_cost_two(tmp_path, capsys):
+    """FR-012 counts findings, not destinations: one edit at the destination clears both, and adding a
+    second link to a known-bad destination does move the number."""
+    _w(tmp_path / "one.md", f"see [x]({OWNED})\n")
+    _w(tmp_path / "two.md", f"see [y]({OWNED})\n")
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "9"],
+                       fetcher=_fetcher({OWNED: _no_uuid()}))
+    assert "lower --own-max to 2" in capsys.readouterr().out
+
+
+def test_the_ceiling_message_does_not_ask_for_a_no_op(tmp_path, capsys):
+    """At the ceiling — where every adoption sits — "lower it to N" when the budget IS N instructs
+    nobody. Third branch, as `dangling_max` has."""
+    b = "https://github.com/owned/repo/blob/main/b.md"
+    _w(tmp_path / "src.md", f"a [x]({OWNED})\nb [y]({b})\n")
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "2"],
+                       fetcher=_fetcher({OWNED: _no_uuid(), b: _no_uuid()}))
+    out = capsys.readouterr().out
+    assert "exactly at the budget" in out and "at the budget)" in out
+    # The arithmetic is the point, and nothing pinned it: with `n - 1` mutated to `n` the message
+    # became the very no-op this test is named after, and it still passed.
+    assert "Fix one and lower it to 1." in out
+    assert "lower --own-max to 2" not in out
+
+
+def test_the_ceiling_arithmetic_at_one_points_at_zero(tmp_path, capsys):
+    """N=1 is the edge of the ceiling branch: the next step is 0, i.e. drop the flag."""
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "1"],
+                       fetcher=_fetcher({OWNED: _no_uuid()}))
+    assert "Fix one and lower it to 0." in capsys.readouterr().out
+
+
+def test_over_budget_says_by_how_much(tmp_path, capsys):
+    """The run fails on its own, but a budget that goes silent exactly when it is exceeded is the one
+    moment its number is worth reading (FR-013's fourth branch)."""
+    b = "https://github.com/owned/repo/blob/main/b.md"
+    _w(tmp_path / "src.md", f"a [x]({OWNED})\nb [y]({b})\n")
+    code = _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "1"],
+                              fetcher=_fetcher({OWNED: _no_uuid(), b: _no_uuid()}))
+    out = capsys.readouterr().out
+    assert code == 4 and "OVER the budget of 1" in out and "1 more than allowed" in out
+
+
+def test_over_budget_says_by_how_much_not_just_that_it_is_over(tmp_path, capsys):
+    """With n=2 and a budget of 1, `n - budget`, `budget` and `1` are the same number, so three
+    different formulas passed the case above. This one separates them."""
+    urls = [f"https://github.com/owned/repo/blob/main/f{i}.md" for i in range(5)]
+    _w(tmp_path / "src.md", "".join(f"[x]({u})\n" for u in urls))
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "2"],
+                       fetcher=_fetcher({u: _no_uuid() for u in urls}))
+    assert "3 more than allowed" in capsys.readouterr().out
+
+
+def test_a_clean_repo_is_told_the_budget_is_doing_nothing(tmp_path, capsys):
+    """The zero branch is the only path to those tails, and no test ran it: three mutations of the
+    wording survived. It is also the observable difference FR-012 requires between `--own-max 0` and
+    omitting the flag."""
+    _w(tmp_path / "src.md", f"see [x]({OWNED}) <!-- web-uuid: {UUID} -->\n")
+    fetch = _fetcher({OWNED: _with_uuid()})
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "0"], fetcher=fetch)
+    assert "it is doing nothing" in capsys.readouterr().out
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "5"], fetcher=fetch)
+    assert "so the rule is a rule again" in capsys.readouterr().out
+
+
+def test_the_budget_is_distinguishable_in_json_too(tmp_path, capsys):
+    """FR-012 requires it on BOTH surfaces: without `own_max` in the payload the two runs were
+    byte-identical, so the machine surface — the one a gate reads — could not tell them apart."""
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    fetch = _fetcher({OWNED: _no_uuid()})
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "0", "--json"],
+                       fetcher=fetch)
+    zero = json.loads(capsys.readouterr().out)
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--json"], fetcher=fetch)
+    omitted = json.loads(capsys.readouterr().out)
+    assert zero["own_max"] == 0 and omitted["own_max"] is None
+    assert zero["exit_code"] == omitted["exit_code"] == 4   # same verdict, distinguishable payload
+
+
+def test_a_negative_budget_is_a_usage_error(tmp_path):
+    """`--own-max -1` produced "OVER the budget of -1 … 2 more than allowed" for one finding."""
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "-1"],
+                              fetcher=_fetcher({})) == 1
+
+
+def test_the_two_exit_zero_qualifiers_compose(tmp_path, capsys):
+    """A budgeted finding and an unreadable destination are different facts about the same exit 0.
+    Keeping only one qualifier would silently revert the other's fix — both exist so that `clean` is
+    never printed over something unexamined."""
+    other = "https://example.com/whatever"
+    _w(tmp_path / "src.md", f"a [x]({OWNED})\nb [y]({other})\n")
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "1"],
+                       fetcher=_fetcher({OWNED: _no_uuid()}))
+    out = capsys.readouterr().out
+    assert "1 owned finding(s), at the budget" in out and "NOT verified" in out
+
+
+def test_a_padded_owner_still_owns(tmp_path):
+    """`--own " owned "` used to pass the emptiness check and match nothing: green run, and a message
+    saying the budget was stale. A stray space producing a false green is the failure this feature
+    exists to remove."""
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", " owned ", "--own-max", "0"],
+                              fetcher=_fetcher({OWNED: _no_uuid()})) == 4
+
+
+# 15
+@pytest.mark.parametrize("marker", ["<!-- darnlink-ignore-file -->", "<!-- darnlink-ignore-links -->"])
+def test_a_file_level_opt_out_filters_only_the_new_kind(tmp_path, marker):
+    dead = "https://github.com/owned/repo/blob/main/dead.md"
+    _w(tmp_path / "src.md",
+       f"{marker}\n\na [x]({OWNED})\nb [y]({dead}) <!-- web-uuid: {UUID} -->\n")
+    findings, _ = check_web_links_online(tmp_path, "tok", _fetcher({OWNED: _no_uuid()}),
+                                         owners=frozenset({"owned"}))
+    kinds = sorted(f.kind for f in findings)
+    # the new finding degrades to unverifiable — reported, not silent — and the real break survives
+    assert kinds == ["web_not_found", "web_unverifiable"]
+
+
+def test_an_ignore_block_region_still_emits_nothing_at_all(tmp_path):
+    _w(tmp_path / "src.md",
+       f"<!-- gen-start -->\nsee [x]({OWNED})\n<!-- gen-end -->\n")
+    findings, _ = check_web_links_online(tmp_path, "tok", _fetcher({}), block_markers=("gen",),
+                                         owners=frozenset({"owned"}))
+    assert findings == []
+
+
+# 16
+def test_both_new_kinds_reach_json_and_the_text_report(tmp_path, capsys):
+    _w(tmp_path / "src.md",
+       f"a [x]({OWNED})\nb [y](https://github.com/owned/repo/blob/main/b.md) <!-- darnlink-own-exempt -->\n")
+    resp = {OWNED: _no_uuid(), "https://github.com/owned/repo/blob/main/b.md": _no_uuid()}
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--json"], fetcher=_fetcher(resp))
+    out = json.loads(capsys.readouterr().out)
+    assert out["web_own_no_uuid"] == 1 and out["web_own_exempt"] == 1
+    assert {f["kind"] for f in out["findings"]} == {"web_own_no_uuid", "web_own_exempt"}
+
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned"], fetcher=_fetcher(resp))
+    text = capsys.readouterr().out
+    assert "own-no-uuid 1" in text and "own-exempt 1" in text
+    assert "[web_own_no_uuid]" in text and "[web_own_exempt]" in text
+
+
+def test_without_an_owner_set_the_summary_line_is_unchanged(tmp_path, capsys):
+    """FR-001: byte-identical when the feature is not switched on."""
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    _run_web_check_cli([str(tmp_path), "--online"], fetcher=_fetcher({OWNED: _no_uuid()}))
+    assert "own-no-uuid" not in capsys.readouterr().out
+
+
+# 17
+def test_the_message_says_what_to_do_and_does_not_promise_write(tmp_path):
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    _, findings, _ = _kinds(tmp_path, _fetcher({OWNED: _no_uuid()}))
+    d = findings[0].detail
+    assert "owned" in d and "repo" in d and "a.md" in d and "frontmatter" in d
+    assert "--write" not in d   # darnlink cannot fix this one; saying so would be a lie
+
+
+# 18
+@pytest.mark.parametrize("resp,kind", [
+    ((403, None), "web_unverifiable"),
+    ((-1, None), "web_unverifiable"),
+    ((-2, None), "web_unverifiable"),
+    ((-3, None), "web_unverifiable"),
+])
+def test_every_other_classification_is_untouched(tmp_path, resp, kind):
+    _w(tmp_path / "src.md", f"see [x]({OWNED}) <!-- web-uuid: {UUID} -->\n")
+    findings, _ = check_web_links_online(tmp_path, "tok", _fetcher({OWNED: resp}),
+                                         owners=frozenset({"owned"}))
+    assert findings[0].kind == kind
+
+
+def test_a_non_github_url_is_untouched_too(tmp_path):
+    _w(tmp_path / "src.md", "see [x](https://example.com/whatever)\n")
+    kinds, _, _ = _kinds(tmp_path, _fetcher({}))
+    assert kinds == ["web_unverifiable"]
+
+
+# 19
+@pytest.mark.parametrize("flags", [["--own", "owned"], ["--own-from-origin"], ["--own-max", "1"]])
+def test_the_new_flags_without_online_are_a_usage_error(tmp_path, flags):
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    calls = []
+    assert _run_web_check_cli([str(tmp_path)] + flags, fetcher=_fetcher({}, calls)) == 1
+    assert calls == []
+
+
+# 20
+def test_at_zero_the_run_is_clean_and_says_to_drop_the_flag(tmp_path, capsys):
+    """An obsolete --own-max on an already-clean repo must not make a clean run look qualified."""
+    _w(tmp_path / "src.md", f"see [x]({OWNED}) <!-- web-uuid: {UUID} -->\n")
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "5"],
+                              fetcher=_fetcher({OWNED: _with_uuid()})) == 0
+    out = capsys.readouterr().out
+    assert "(clean)" in out and "drop --own-max" in out
+
+
+# 21
+def test_unreadable_frontmatter_is_a_different_defect(tmp_path):
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    broken = (200, "---\nuuid: [not, a, string]\n---\n# dest\n")
+    kinds, findings, _ = _kinds(tmp_path, _fetcher({OWNED: broken}))
+    assert kinds == ["web_unverifiable"]
+    assert "not readable" in findings[0].detail and "add" not in findings[0].detail.lower()
+
+
+def test_unreadable_frontmatter_keeps_todays_wording_when_the_feature_is_off(tmp_path):
+    """FR-001 is about bytes, not only verdicts: with no owner set even the detail text must be what
+    it is today, or a consumer that greps the report sees a change it never opted into."""
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    broken = (200, "---\nuuid: [not, a, string]\n---\n# dest\n")
+    _, findings, _ = _kinds(tmp_path, _fetcher({OWNED: broken}), owners=frozenset())
+    assert findings[0].detail == "destination has no uuid to anchor to"
+
+
+# 22
+def test_the_marker_is_honoured_with_no_owner_set_at_all(tmp_path):
+    """The single deliberate exception to FR-001, and the default case during any rollout: nothing
+    passes --own yet, and a marker that stopped working without it would let --write rewrite exactly
+    the files it was placed to protect."""
+    before = f"see [x]({OWNED}) <!-- darnlink-own-exempt -->\n"
+    _w(tmp_path / "src.md", before)
+    kinds, _, _ = _kinds(tmp_path, _fetcher({OWNED: _with_uuid()}), owners=frozenset())
+    assert kinds == ["web_own_exempt"]
+    assert _run_web_check_cli([str(tmp_path), "--online", "--write"],
+                              fetcher=_fetcher({OWNED: _with_uuid()})) == 0
+    assert (tmp_path / "src.md").read_text(encoding="utf-8") == before

--- a/tests/test_own_repo_web_strictness.py
+++ b/tests/test_own_repo_web_strictness.py
@@ -179,10 +179,30 @@ def test_a_bom_in_the_destination_does_not_hide_its_uuid(tmp_path):
     invariant for the LOCAL path; the web path was left out of it."""
     _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
     bom = (200, "\ufeff" + f"---\nuuid: {UUID}\n---\n# dest\n")
-    kinds, _, edits = _kinds(tmp_path, _fetcher({OWNED: bom}))
+    kinds, findings, edits = _kinds(tmp_path, _fetcher({OWNED: bom}))
     assert kinds == ["web_anchor"] and edits          # NOT web_own_no_uuid
+    # the uuid too, not just the kind: a "fix" that invented one would pass on kind alone
+    assert findings[0].anchored_uuid == UUID
     assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned"],
                               fetcher=_fetcher({OWNED: bom})) == 3
+
+
+def test_the_wire_half_of_the_bom_fix_is_pinned_too(monkeypatch):
+    """The `utf-8-sig` decode in `_fetch_once` is the belt to the `lstrip`'s braces, and it is
+    unobservable through the CLI — the strip neutralises it downstream, so no end-to-end test can kill
+    it. Pinned at the seam instead: bytes off the wire, text out."""
+    import io
+    from darnlink.weblinks import _fetch_once
+
+    class _Resp(io.BytesIO):
+        status = 200
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    monkeypatch.setattr("urllib.request.urlopen",
+                        lambda *a, **k: _Resp(b"\xef\xbb\xbf---\nuuid: x\n---\n"))
+    status, text = _fetch_once(GithubUrl("o", "r", "main", "a.md"), None)
+    assert status == 200 and text.startswith("---")   # not "\ufeff---"
 
 
 def test_a_bom_does_not_invent_a_uuid_either(tmp_path):

--- a/tests/test_own_repo_web_strictness.py
+++ b/tests/test_own_repo_web_strictness.py
@@ -145,6 +145,24 @@ def test_a_ref_that_merely_ends_in_hex_is_not_a_commit(tmp_path, ref):
     assert kinds == ["web_own_no_uuid"]
 
 
+def test_a_ref_longer_than_a_sha_is_not_one(tmp_path):
+    """`{7,40}` is a range with a ceiling for a reason: 41 hex characters is not a commit id, and
+    treating it as immutable would suppress a finding that is perfectly fixable."""
+    url = "https://github.com/owned/repo/blob/" + "a" * 41 + "/a.md"
+    _w(tmp_path / "src.md", f"see [x]({url})\n")
+    kinds, _, _ = _kinds(tmp_path, _fetcher({url: _no_uuid()}))
+    assert kinds == ["web_own_no_uuid"]
+
+
+def test_a_run_with_only_exempt_links_still_counts_them(tmp_path, capsys):
+    """FR-016 asks for both kinds in the summary line. Keying the extra counters on the FAILING kind
+    alone would drop them from a run that has only exemptions — the audit trail the marker promises."""
+    _w(tmp_path / "src.md", f"see [x]({OWNED}) <!-- darnlink-own-exempt -->\n")
+    _run_web_check_cli([str(tmp_path), "--online", "--own", "owned"],
+                       fetcher=_fetcher({OWNED: _no_uuid()}))
+    assert "own-exempt 1" in capsys.readouterr().out
+
+
 def test_the_carve_out_is_not_a_verdict(tmp_path):
     """FR-005/FR-006 say when FR-004 must NOT fire; they do not turn a link into anything. Read as a
     terminal step they would silently change behaviour FR-007 freezes: this link is `web_anchor`."""
@@ -152,6 +170,28 @@ def test_the_carve_out_is_not_a_verdict(tmp_path):
     _w(tmp_path / "src.md", f"see [x]({url})\n")
     kinds, _, edits = _kinds(tmp_path, _fetcher({url: _with_uuid()}))
     assert kinds == ["web_anchor"] and edits
+
+
+def test_a_bom_in_the_destination_does_not_hide_its_uuid(tmp_path):
+    """A Windows-authored destination arrives with a BOM. Read as plain utf-8 it sits in front of the
+    `---`, the frontmatter reader sees none, and 016 then reports a file that HAS a uuid as lacking
+    one — exit 4 over an instruction nobody can follow. `tests/test_bom.py` already declares this
+    invariant for the LOCAL path; the web path was left out of it."""
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    bom = (200, "\ufeff" + f"---\nuuid: {UUID}\n---\n# dest\n")
+    kinds, _, edits = _kinds(tmp_path, _fetcher({OWNED: bom}))
+    assert kinds == ["web_anchor"] and edits          # NOT web_own_no_uuid
+    assert _run_web_check_cli([str(tmp_path), "--online", "--own", "owned"],
+                              fetcher=_fetcher({OWNED: bom})) == 3
+
+
+def test_a_bom_does_not_invent_a_uuid_either(tmp_path):
+    """The other direction, so the fix cannot be 'strip anything that looks like a BOM': a destination
+    with a BOM and NO uuid is still the finding it always was."""
+    _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
+    bom = (200, "\ufeff# a destination with no frontmatter\n")
+    kinds, _, _ = _kinds(tmp_path, _fetcher({OWNED: bom}))
+    assert kinds == ["web_own_no_uuid"]
 
 
 # 7
@@ -299,15 +339,19 @@ def test_status_decides_before_the_exemption(tmp_path):
     assert findings[0].kind == "web_not_found"
 
 
-def test_origin_is_read_from_the_scanned_repo_even_under_a_git_hook(tmp_path, monkeypatch):
+@pytest.mark.parametrize("leaked", [
+    ("GIT_DIR", "GIT_WORK_TREE"),
+    ("GIT_COMMON_DIR",),            # redirects on its own; dropping it from the strip list is silent
+])
+def test_origin_is_read_from_the_scanned_repo_even_under_a_git_hook(tmp_path, monkeypatch, leaked):
     """A git hook exports GIT_DIR/GIT_WORK_TREE, and inherited they OVERRIDE `-C`. The gate runs
     darnlink FROM a hook, so this is the normal case: without stripping them the answer is about the
     hook's repository, silently and with a plausible owner."""
     scanned = _git_repo(tmp_path / "scanned", "git@github.com:owned/src.git")
     other = _git_repo(tmp_path / "other", "git@github.com:hijacked/x.git")
     _w(scanned / "src.md", f"see [x]({OWNED})\n")
-    monkeypatch.setenv("GIT_DIR", str(other / ".git"))
-    monkeypatch.setenv("GIT_WORK_TREE", str(other))
+    for var in leaked:
+        monkeypatch.setenv(var, str(other / ".git") if var != "GIT_WORK_TREE" else str(other))
     # owner comes from `scanned` (owned/...), not from `other` (hijacked/...), so the link fails
     assert _run_web_check_cli([str(scanned), "--online", "--own-from-origin"],
                               fetcher=_fetcher({OWNED: _no_uuid()})) == 4
@@ -365,7 +409,9 @@ def test_the_budget_nudges_you_to_lower_it(tmp_path, capsys):
     _w(tmp_path / "src.md", f"see [x]({OWNED})\n")
     _run_web_check_cli([str(tmp_path), "--online", "--own", "owned", "--own-max", "3"],
                        fetcher=_fetcher({OWNED: _no_uuid()}))
-    assert "lower --own-max to 1" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "lower --own-max to 1" in out
+    assert "under budget)" in out      # not "at the budget": 1 finding, budget of 3
 
 
 def test_a_budgeted_finding_does_not_shield_a_real_break(tmp_path, monkeypatch):
@@ -515,6 +561,8 @@ def test_the_two_exit_zero_qualifiers_compose(tmp_path, capsys):
                        fetcher=_fetcher({OWNED: _no_uuid()}))
     out = capsys.readouterr().out
     assert "1 owned finding(s), at the budget" in out and "NOT verified" in out
+    # order matters: the budget qualifier first, then what could not be read
+    assert out.index("at the budget") < out.index("NOT verified")
 
 
 def test_a_padded_owner_still_owns(tmp_path):


### PR DESCRIPTION
Implements the spec merged in #51, and **amends two of its requirements** where review showed the spec itself was wrong (see below). **Opt-in throughout**: with no owner set, behaviour is byte-identical in the text report, the exit code and the files on disk — with one named exception.

## What it adds

- **`--own OWNER`** (repeatable, stripped and case-folded) and **`--own-from-origin`**, a separate flag rather than a magic `--own auto` so an owner literally called `auto` stays expressible. If it cannot resolve, the run is a **usage error even when explicit owners were given**: it is a request, not a fallback.
- **`web_own_no_uuid`, exit 4 — not 3.** Exit 3 promises "re-run with `--write`", and darnlink cannot fix this one: the edit belongs to the destination repository. The message names owner, repo and path, and never mentions `--write`.
- **`--own-max N`**, so a repo can adopt the rule before reaching zero. The budget silences the *verdict*, never the *finding*, and never shields another exit-4 cause.
- **`<!-- darnlink-own-exempt -->`** for a machine-regenerated destination. Exempts from the new finding, from anchoring and from `web_mismatch` — a destination that regenerates is precisely one whose uuid drifts, so without the third the hatch would not escape. **Honoured with or without an owner set**: it states a property of the *link*, not of the run, and a marker that stopped working when someone dropped `--own` would let `--write` rewrite the very files it was placed to protect.

Two exclusions, textual and offline: a destination that is not `.md` can never carry frontmatter, and one pinned to a **commit SHA** (case-folded, whole-ref) can never be given one retroactively. **Tags are deliberately not excluded** — a tag is textually indistinguishable from a branch of the same name, so honouring it would need the network *and* would exclude a maintenance branch for *looking* like a tag.

## Two spec amendments, included here on purpose

**FR-013 and scenario 14.** They required the report to "say that lowering the budget to that number keeps the ratchet" whenever the count is at or below the budget. At the **ceiling** that is a no-op instruction — "lower it to 2" when the budget is 2 — and the ceiling is where a repo sits for most of an adoption, so it is the message printed most often. FR-013 now has **four** branches (zero · below · exactly at · over), which is closer to the precedent it cites than the two it started with. The fourth is new behaviour, not wording: the budget used to go silent exactly when it was exceeded, which is the one moment its number is worth reading.

This is called out because an earlier revision of this PR made the same change **without** amending the spec, and rewrote the test to assert the divergence. Review caught it. Amending the requirement is the resolution; diverging quietly is not.

## Tests

**69 collected from 49 functions**, one per acceptance scenario in spec order so a failure names the requirement it breaks. All with a mocked fetcher; the `--own-from-origin` scenarios build real git fixtures. **307 total.**

Mutation-checked throughout, and that is not ceremony here — **three separate rounds found a test named for a property that did not fix it**, including one that passed with the exact no-op it was named after restored. Every fix in this PR has a mutation that kills it.

## Review

Copilot returned an empty review on every push (quota). **Three independent adversarial passes** were run instead, with verdicts in the comments. Between them they found: a false green from a padded `--own` value, an exemption marker that reached across a blank line and suppressed a real `web_mismatch`, a homograph host that resolved to an attacker-chosen owner, the outcome word overwriting `integrity failure`, and the silent spec divergence above.

One finding is deliberately **not** fixed here and is raised against the spec instead: an `insteadOf` remote never resolves, because FR-002 mandates `git config --get remote.origin.url` where `git ls-remote --get-url` would resolve it offline. The implementation is conformant; the requirement is what wants revisiting.

## Not in this PR

The gate-recipe wiring (`own_web*` keys) — cut from the spec deliberately: it is about how a gate consumes any darnlink exit code, spans two shell surfaces, and is how `dangling_max` was done. Axis first, recipe key in its own change. The implementation added a reason: git hooks export `GIT_DIR`, and inherited it overrides `-C`, so a recipe invoking darnlink from a hook needs that accounted for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)