### PR TITLE
recipe: say it when the web axis cannot verify — and correct what the file claimed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **A tokenless `403` is the anonymous rate limit, not a private repo — and the web axis now says so
+  instead of printing a quiet `clean`.** `web-check` reported *"cannot read destination: private repo
+  and no token provided"* for any `403` without a token. That was wrong every time: GitHub answers
+  **404**, not 403, for a private repo you cannot see — as `_classify` already explained thirteen
+  lines below the message. A tokenless 403 is the **60/h-per-public-IP anonymous quota**, shared by
+  every machine behind the same NAT, so the message sent readers hunting for a permissions problem
+  they did not have, on destinations that were public and returned 200 in a browser.
+
+  **This is not only a mislabel: it can be a false green.** An un-anchored web link is only
+  discoverable if the destination can be **read**. Measured on one tree, minutes apart: *without*
+  token `exit 0`, *with* token `exit 3` — the link needed anchoring and the tokenless run could not
+  tell. So `ok 0 | unverifiable N` means *"could not look"*, not *"nothing to verify"*, and it is
+  indistinguishable from a repo with no cross-repo links at all.
+
+  Three surfaces changed accordingly: the finding text now names the quota and the remedy; the
+  summary line no longer says plain `clean` when anything was unverifiable; and both recipes (bash
+  and PowerShell) warn when the axis runs without a token. The docs that promised *"public repos work
+  tokenless"* and *"never a false green"* are corrected — **give the axis a token even for public
+  destinations**: private ones need it for permission, public ones for quota.
+
 ### Added
 - **The English-only gate now covers the surfaces that are actually published**: commit messages,
   PR titles/descriptions, issues, and `.md` documentation. Until now it judged one thing —

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ that get relocated and refactored over time.
 >
 > Beyond local links, darnlink can also anchor and verify **cross-repo web links** — a Markdown link
 > to a `https://github.com/owner/repo/blob/…` file in *another* repository, anchored to that file's
-> `uuid`. The opt-in **`web-check --online`** command (off by default; tokenless for public
-> destinations) anchors a plain link and verifies an anchored one, failing on drift. It's
+> `uuid`. The opt-in **`web-check --online`** command (off by default; **give it a `GITHUB_TOKEN`
+> even for public destinations** — not for permission but for quota: anonymous API calls are 60/h
+> per public IP) anchors a plain link and verifies an anchored one, failing on drift. It's
 > **experimental**, and the core stays fully offline unless you invoke it. See
 > [Elevating your link gate §8](docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 -->.
 

--- a/docs/elevating-your-link-gate.md
+++ b/docs/elevating-your-link-gate.md
@@ -281,7 +281,8 @@ Why it's safe to add to an existing fail-closed gate:
   for where a moved target went (no web-side index to walk deterministically) — that's left to the
   human/LLM layer, which re-anchors once it knows the new URL.
 
-Add it as one extra step in the wall (pre-push + CI), gated on having a token for any private targets.
+Add it as one extra step in the wall (pre-push + CI), and give it a token — for **quota** on public
+targets, for **permission** on private ones.
 
 ## Checklist
 
@@ -294,4 +295,5 @@ Add it as one extra step in the wall (pre-push + CI), gated on having a token fo
 - [ ] Gap = 0 → flip the gate to `--create-frontmatter`.
 - [ ] Wire the walls: pre-commit (staged) · pre-push (whole repo) · CI/self-hosted (whole repo).
 - [ ] **If you have cross-repo web links:** anchor them with `web-check --online --write`, add
-      `web-check --online` to the pre-push/CI wall, and provide a token for any private destinations.
+      `web-check --online` to the pre-push/CI wall, and provide a token (quota for public destinations,
+      permission for private ones).

--- a/docs/elevating-your-link-gate.md
+++ b/docs/elevating-your-link-gate.md
@@ -263,10 +263,20 @@ Why it's safe to add to an existing fail-closed gate:
 - **It won't fight your core gate.** The anchor it writes is `<!-- web-uuid: X -->`, a *different*
   marker from the core's `<!-- uuid: X -->` — the core ignores it entirely, so a web anchor never
   trips the local `unresolvable` check. (This is the whole reason it uses its own marker.)
-- **Honest about what it can't reach.** A **private** destination needs a `GITHUB_TOKEN`/`GH_TOKEN`
-  (public repos work tokenless); without one it reports `web_unverifiable` and does **not** fail the
-  build — never a false green, never a crash. Run the online layer wherever a token already lives (a
-  self-hosted CI runner with a GitHub App is the natural home).
+- **Honest about what it can't reach — but give it a token anyway, and here is why.** A `GITHUB_TOKEN`
+  is needed for **both** kinds of destination: private ones for *permission*, **public ones for
+  *quota*** (anonymous GitHub API calls are **60/h per public IP**, shared by every machine behind the
+  same NAT). Without one it reports `web_unverifiable` and does **not** fail the build — never a
+  crash.
+
+  ⚠️ **But "does not fail the build" is not the same as "never a false green", which this page used
+  to claim.** An un-anchored web link is only discoverable if the destination can be **read**.
+  Measured on one tree, minutes apart: **without token `rc=0`** (green), **with token `rc=3`** — the
+  link needed anchoring and the tokenless run could not tell. So an `ok 0 | unverifiable N` is *"could
+  not look"*, not *"nothing to verify"*, and it is indistinguishable from a repo with no cross-repo
+  links at all. Quote the token condition next to any web figure, or it is not comparable between two
+  runs. Run the online layer wherever a token already lives (a self-hosted CI runner with a GitHub
+  App is the natural home).
 - **Narrow by design.** It *anchors* a plain link and *verifies* an anchored one; it does **not** hunt
   for where a moved target went (no web-side index to walk deterministically) — that's left to the
   human/LLM layer, which re-anchors once it knows the new URL.

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -68,9 +68,10 @@
 #        them named by any other axis. Expect a number.
 #   mode ∈ { repair | check | max } — see WHAT IT DOES. Raising it is a one-way ratchet: only up.
 #   web (mode=max only): add a `web-check --online` pass — cross-repo links to OTHER GitHub repos must
-#     resolve to the destination's uuid (read online). Public targets need no token; private ones send
-#     $GITHUB_TOKEN if set, else `web_unverifiable` (a warning, never a failure). Fail-closed on a broken
-#     public web link.
+#     resolve to the destination's uuid (read online). ⚠️ PUBLIC targets need a token too — not for
+#     permission but for QUOTA: anonymous API calls are 60/h per public IP. Without one the pass
+#     reports `web_unverifiable` (a warning, never a failure), which reads like "nothing to check".
+#     Fail-closed on a broken public web link.
 #   create_readme (ANY mode, since the mirror update): also run `--create-readme` — a directory link whose
 #     target folder has no README (no uuid to anchor to) FAILS the gate (dry-run detects it; fix with
 #     `--create-readme --write`). It runs as its OWN dry-run pass, filtered to the `create_readme` findings,
@@ -125,8 +126,10 @@ FAIL_CLOSED="${DARNLINK_GATE_FAIL_CLOSED:-$(read_cfg fail_closed "")}"
 case "${FAIL_CLOSED,,}" in ""|0|false|no|off) FAIL_CLOSED="" ;; *) FAIL_CLOSED=1 ;; esac
 # WEB (opt-in): when on, mode=max adds a 3rd whole-repo pass — `web-check --online` — that verifies
 # cross-repo Markdown links to OTHER GitHub repos still resolve to the destination file's uuid (read
-# online, anchored with `<!-- web-uuid: X -->`). Public destinations need NO token; private ones send
-# $GITHUB_TOKEN if set, else are reported `web_unverifiable` (a warning, NOT a failure — never a crash).
+# online, anchored with `<!-- web-uuid: X -->`). ⚠️ BOTH kinds of destination need $GITHUB_TOKEN:
+# private ones for permission, PUBLIC ones for quota (anonymous API = 60/h per public IP, shared by
+# every machine behind the same NAT). Without it they are reported `web_unverifiable` (a warning, NOT
+# a failure — never a crash), and the gate now says so instead of printing a quiet zero.
 # Fail-closed only on a genuinely broken/moved public web link. Same normalise-the-string dance as above.
 WEB="${DARNLINK_GATE_WEB:-$(read_cfg web "")}"
 case "${WEB,,}" in ""|0|false|no|off) WEB="" ;; *) WEB=1 ;; esac
@@ -330,14 +333,29 @@ if [ "$SCOPE" != "staged" ]; then
     # web links INSIDE someone else's checkout. Fail-closed on a broken public web link; web_unverifiable
     # (private w/o token, or offline) is exit 0. Needs a ref with web-check + its --exclude (v0.12.0+).
     if [ "$rc" -eq 0 ] && [ -n "$WEB" ]; then
-      # web-check needs $GITHUB_TOKEN for PRIVATE destinations (public are tokenless). If it's not
-      # already exported, read it from a read-only PAT FILE (default ~/.config/github_token_ro; override
-      # with DARNLINK_GATE_TOKEN_FILE) — a git hook's env usually lacks it. Without a token a private
-      # destination 404s and reads as broken; with it, it verifies. Missing file → stays unverifiable.
+      # web-check needs $GITHUB_TOKEN. If it's not already exported, read it from a read-only PAT FILE
+      # (default ~/.config/github_token_ro; override with DARNLINK_GATE_TOKEN_FILE) — a git hook's env
+      # usually lacks it. Missing file → stays unverifiable.
+      #
+      # ⚠️ It is NOT only about private destinations. PUBLIC ones need it too, for a different reason:
+      # anonymous GitHub API calls are capped at 60/h PER PUBLIC IP, shared by every machine behind the
+      # same NAT. Measured on a public repo linking only to itself, same tree, minutes apart:
+      #     without token -> ok 0 | unverifiable 52
+      #     with token    -> ok 7 | unverifiable 45
+      # So the axis silently stops verifying depending on WHAT TIME the build runs.
       if [ -z "${GITHUB_TOKEN:-}" ]; then
         _tf="${DARNLINK_GATE_TOKEN_FILE:-$HOME/.config/github_token_ro}"
         # -f: a REGULAR file (not a directory — `-r` alone passes on a dir, then `< dir` fails).
         [ -f "$_tf" ] && [ -r "$_tf" ] && { GITHUB_TOKEN="$(tr -d '\r\n' < "$_tf")"; export GITHUB_TOKEN; }
+      fi
+      # SAY IT when the axis cannot actually verify. `ok 0 | unverifiable N` reads as "nothing to
+      # check" and means "could not look" — and it is indistinguishable from a repo that genuinely has
+      # no cross-repo links. Staying quiet is how this axis ran for months without measuring anything
+      # while the build stayed green. Not a failure: committing offline must keep working.
+      if [ -z "${GITHUB_TOKEN:-}" ]; then
+        echo "darnlink-gate: web axis running WITHOUT a token → anonymous 60/h-per-IP quota." >&2
+        echo "  'ok 0' below means COULD NOT LOOK, not 'nothing to verify'. Quote the token" >&2
+        echo "  condition next to any web figure, or it is not comparable between runs." >&2
       fi
       WEB_ARGS=()
       for e in "${EXCLUDES[@]}";      do [ -n "$e" ] && WEB_ARGS+=(--exclude "$e"); done

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -331,7 +331,7 @@ if [ "$SCOPE" != "staged" ]; then
     # core failure surfaces first). web-check takes the SAME `--exclude` and `--ignore-block` as the core
     # (since 0.12.0) — pass both so it skips vendored clones / mirrors instead of fetching and anchoring
     # web links INSIDE someone else's checkout. Fail-closed on a broken public web link; web_unverifiable
-    # (private w/o token, or offline) is exit 0. Needs a ref with web-check + its --exclude (v0.12.0+).
+    # (no token — public OR private — or offline) is exit 0. Needs a ref with web-check + its --exclude (v0.12.0+).
     if [ "$rc" -eq 0 ] && [ -n "$WEB" ]; then
       # web-check needs $GITHUB_TOKEN. If it's not already exported, read it from a read-only PAT FILE
       # (default ~/.config/github_token_ro; override with DARNLINK_GATE_TOKEN_FILE) — a git hook's env

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -354,8 +354,14 @@ if [ "$SCOPE" != "staged" ]; then
       # while the build stayed green. Not a failure: committing offline must keep working.
       if [ -z "${GITHUB_TOKEN:-}" ]; then
         echo "darnlink-gate: web axis running WITHOUT a token → anonymous 60/h-per-IP quota." >&2
-        echo "  'ok 0' below means COULD NOT LOOK, not 'nothing to verify'. Quote the token" >&2
-        echo "  condition next to any web figure, or it is not comparable between runs." >&2
+        echo "  An 'ok 0 | unverifiable N' from web-check in this run means COULD NOT LOOK," >&2
+        echo "  not 'nothing to verify' — and it is indistinguishable from a repo that has no" >&2
+        echo "  cross-repo links at all." >&2
+        echo "  ⚠️ THIS CAN BE A FALSE GREEN, not just a missing measurement: an un-anchored web" >&2
+        echo "  link is only discoverable if the destination can be READ. Measured on one tree:" >&2
+        echo "  without token rc=0 (green), with token rc=3 (the link needed anchoring)." >&2
+        echo "  Export GITHUB_TOKEN, and quote the token condition next to any web figure —" >&2
+        echo "  without it the number is not comparable between two runs, let alone two repos." >&2
       fi
       WEB_ARGS=()
       for e in "${EXCLUDES[@]}";      do [ -n "$e" ] && WEB_ARGS+=(--exclude "$e"); done

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -133,6 +133,8 @@ if ($scope -ne 'staged') {
         Write-Warning "  cross-repo links at all."
         Write-Warning "  THIS CAN BE A FALSE GREEN: an un-anchored web link is only discoverable if"
         Write-Warning "  the destination can be READ. Measured: without token rc=0, with token rc=3."
+        Write-Warning "  Export GITHUB_TOKEN, and quote the token condition next to any web figure -"
+        Write-Warning "  without it the number is not comparable between two runs, let alone two repos."
       }
       $webArgs = @()
       foreach ($e in $excludes)     { if ($e) { $webArgs += @('--exclude', $e) } }

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -55,8 +55,11 @@ function Invoke-Bail([string]$reason) {
 $excludes     = @(CfgOr 'excludes' @())
 $ignoreBlocks = @(CfgOr 'ignore_blocks' @())
 # WEB (opt-in, mode=max): add a `web-check --online` pass — cross-repo links to OTHER GitHub repos must
-# resolve to the destination's uuid (read online). Public needs no token; private sends $GITHUB_TOKEN if
-# set, else web_unverifiable (a warning). Fail-closed on a broken public web link. Same normalise dance.
+# resolve to the destination's uuid (read online). ⚠️ PUBLIC destinations need a token TOO — not for
+# permission but for QUOTA: anonymous API calls are 60/h per public IP. Without one the pass reports
+# web_unverifiable (a warning), which reads like "nothing to check" and can be a FALSE GREEN: an
+# un-anchored web link is only discoverable if the destination can be READ. Fail-closed on a broken
+# public web link. Same normalise dance.
 $rawWeb = if ($null -ne $env:DARNLINK_GATE_WEB) { $env:DARNLINK_GATE_WEB } else { CfgOr 'web' '' }
 $web = -not ([string]::IsNullOrWhiteSpace([string]$rawWeb) -or
              ([string]$rawWeb).Trim().ToLower() -in @('0','false','no','off'))
@@ -109,8 +112,10 @@ if ($scope -ne 'staged') {
     # web-check takes the SAME --exclude + --ignore-block as the core (since 0.12.0) -> pass both so it
     # skips vendored clones / mirrors instead of fetching+anchoring web links inside them.
     if ($rc -eq 0 -and $web) {
-      # web-check needs $GITHUB_TOKEN for PRIVATE destinations; if not already set, read it from a
-      # read-only PAT file (default ~/.config/github_token_ro; override DARNLINK_GATE_TOKEN_FILE).
+      # web-check needs $GITHUB_TOKEN for BOTH kinds of destination: private ones for permission,
+      # PUBLIC ones for quota (anonymous API = 60/h per public IP, shared by every machine behind the
+      # same NAT). If not already set, read it from a read-only PAT file (default
+      # ~/.config/github_token_ro; override DARNLINK_GATE_TOKEN_FILE).
       if ([string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
         $tf = if ($env:DARNLINK_GATE_TOKEN_FILE) { $env:DARNLINK_GATE_TOKEN_FILE } else { Join-Path $env:USERPROFILE ".config/github_token_ro" }
         # PathType Leaf = a file, not a dir. try/catch so a read error can't terminate the gate under
@@ -118,6 +123,16 @@ if ($scope -ne 'staged') {
         if (Test-Path $tf -PathType Leaf) {
           try { $env:GITHUB_TOKEN = (Get-Content $tf -Raw -ErrorAction Stop).Trim() } catch { }
         }
+      }
+      # SAY IT when the axis cannot actually verify — same wording as the bash recipe on purpose, so
+      # the two surfaces cannot drift into telling the operator different stories.
+      if ([string]::IsNullOrWhiteSpace($env:GITHUB_TOKEN)) {
+        Write-Warning "darnlink-gate: web axis running WITHOUT a token -> anonymous 60/h-per-IP quota."
+        Write-Warning "  An 'ok 0 | unverifiable N' from web-check in this run means COULD NOT LOOK,"
+        Write-Warning "  not 'nothing to verify' - and it is indistinguishable from a repo with no"
+        Write-Warning "  cross-repo links at all."
+        Write-Warning "  THIS CAN BE A FALSE GREEN: an un-anchored web link is only discoverable if"
+        Write-Warning "  the destination can be READ. Measured: without token rc=0, with token rc=3."
       }
       $webArgs = @()
       foreach ($e in $excludes)     { if ($e) { $webArgs += @('--exclude', $e) } }

--- a/recipes/examples/github-actions-darnlink-gate.yml
+++ b/recipes/examples/github-actions-darnlink-gate.yml
@@ -30,4 +30,14 @@ jobs:
             -o "$RUNNER_TEMP/darnlink-gate"
           chmod +x "$RUNNER_TEMP/darnlink-gate"
       - name: darnlink gate (whole repo)
+        # Only needed with `"web": true`, and the reason is QUOTA, not permission: anonymous GitHub
+        # API calls are 60/h per public IP, so without a token the web axis reports `ok 0` — which
+        # reads as "nothing to check" and means "could not look". It can even be a FALSE GREEN: an
+        # un-anchored web link is only discoverable if the destination can be read.
+        #
+        # ⚠️ This automatic token covers THIS repo only. If your Markdown links into OTHER private
+        # repos, it will not read them — that half is permission, and needs a PAT or a GitHub App
+        # token scoped to those repos.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: "$RUNNER_TEMP/darnlink-gate"   # scope=repo from darnlink-gate.json

--- a/recipes/examples/github-actions-darnlink-gate.yml
+++ b/recipes/examples/github-actions-darnlink-gate.yml
@@ -18,7 +18,7 @@ jobs:
   gate:
     runs-on: ubuntu-latest
     env:
-      DARNLINK_REF: git+https://github.com/txemi/darnlink@v0.7.0
+      DARNLINK_REF: git+https://github.com/txemi/darnlink@v0.20.4
       DARNLINK_GATE_FAIL_CLOSED: "1"     # ← the wall MUST fail closed (prefer the env var; see recipe)
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
       - name: Fetch the pinned recipe (public repo → no token)
         run: |
           # -f: fail on a 404 (a moved/typo'd tag), instead of silently writing "404: Not Found".
-          curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/v0.7.0/recipes/darnlink-gate" \
+          curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/v0.20.4/recipes/darnlink-gate" \
             -o "$RUNNER_TEMP/darnlink-gate"
           chmod +x "$RUNNER_TEMP/darnlink-gate"
       - name: darnlink gate (whole repo)

--- a/specs/013-web-robustness/spec.md
+++ b/specs/013-web-robustness/spec.md
@@ -174,6 +174,15 @@ for the `--online` mode** — every other principle stands.
 4. **Moved / 404.** Destination 404s → `web_not_found`, exit 4 (darnlink does not hunt for the new path).
 5. **Private, no token.** Destination returns 403 and no `$GITHUB_TOKEN` → `web_unverifiable`, exit 0
    (honest, never a false pass); with a token the same fetch returns 200 and verifies.
+
+   > ⚠️ **Superseded by \<Unreleased\>, on two counts — kept as written because a spec records what
+   > was designed, not what was later learned.**
+   > **(a) The cause is wrong.** A tokenless `403` is the **anonymous 60/h-per-IP quota**, not a
+   > private repo: GitHub answers **404** for a private repo you cannot see, as scene 4 and FR-006
+   > already imply. Public destinations hit this too.
+   > **(b) "never a false pass" does not hold.** An un-anchored web link is only discoverable if the
+   > destination can be READ, so the same tree exits **0 without a token and 3 with one**. Exit 0 here
+   > means the axis could not look — not that there was nothing to find.
 6. **Core untouched.** `darnlink` / `--robustify` / `check` ignore the web link entirely (exit 0).
 7. **Off by default.** Without `--online`, the fetcher is never called; report-only; exit 0.
 8. **Report-only unless --write.** The verify path never mutates disk (checksums unchanged).

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -439,8 +439,14 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
         # without a token and 3 with one. Say what was not looked at, right where the verdict is read.
         outcome = {0: "clean", 3: "anchors pending", 4: "integrity failure"}[code]
         if code == 0 and unverifiable:
-            outcome = (f"clean of what could be READ — {len(unverifiable)} unverifiable, "
-                       f"NOT verified (export GITHUB_TOKEN)")
+            # Only offer the token when the token would actually change something. `web_unverifiable`
+            # has seven causes and credentials fix two; suggesting it over a non-GitHub URL or a
+            # destination with no uuid is advice that cannot be taken, and advice that cannot be taken
+            # is how this line becomes the next thing everyone scrolls past.
+            fixable = sum(1 for x in unverifiable if x.token_would_help)
+            outcome = f"clean of what could be READ — {len(unverifiable)} unverifiable, NOT verified"
+            if fixable:
+                outcome += f"; {fixable} of them would resolve with GITHUB_TOKEN — export it"
         print(f"  -> exit {code} ({outcome})")
 
     return code

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -431,7 +431,16 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
             print(f"  WROTE {wrote} file(s).")
         elif anchors_pending:
             print("  (dry-run — nothing written. Re-run with --write to anchor.)")
+        # "clean" must not be printed over a pass that could not LOOK. An unverifiable destination is
+        # not a verified one: with the anonymous 60/h-per-IP quota exhausted, every cross-repo link
+        # comes back unverifiable and this line used to summarise it as `clean` — which is how the
+        # axis went unnoticed for months. And it is not merely a missing measurement: an un-anchored
+        # web link is only discoverable if the destination can be READ, so the same tree can exit 0
+        # without a token and 3 with one. Say what was not looked at, right where the verdict is read.
         outcome = {0: "clean", 3: "anchors pending", 4: "integrity failure"}[code]
+        if code == 0 and unverifiable:
+            outcome = (f"clean of what could be READ — {len(unverifiable)} unverifiable, "
+                       f"NOT verified (export GITHUB_TOKEN)")
         print(f"  -> exit {code} ({outcome})")
 
     return code

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -250,7 +250,14 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
     if gu is None:
         return WebFinding("web_unverifiable", f, link.href, "not a recognised GitHub blob/raw URL")
     if status in (401, 403):
-        why = "private repo and no token provided" if not have_token else "token rejected (403/401)"
+        # NOT "private repo": this function says so itself thirteen lines down — GitHub answers 404,
+        # not 403, for a private repo we cannot see. So a tokenless 403 is essentially always the
+        # ANONYMOUS RATE LIMIT (60/h per public IP, shared by every machine behind the same NAT),
+        # and naming it "private repo" sent readers to look for a permissions problem they did not
+        # have, on destinations that were public and returned 200 to a browser.
+        why = ("anonymous request rejected (403: the 60/h per-IP quota is exhausted, or the caller "
+               "is blocked) — export GITHUB_TOKEN to verify" if not have_token
+               else "token rejected (403/401)")
         return WebFinding("web_unverifiable", f, link.href, f"cannot read destination: {why}")
     if status == -2:
         # v0.17.0: the file 404s AND the destination repo is not readable with this token (a private

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -199,7 +199,8 @@ def _repo_accessible(owner: str, repo: str, token: Optional[str]) -> bool:
             return resp.status == 200
     except urllib.error.HTTPError as e:
         if e.code in (403, 404):
-            return False  # genuinely not readable with this token (private cross-org repo)
+            return False  # not readable with this token. NB 403 here is usually QUOTA (or a blocked
+            # repo), not permission — a private repo answers 404. Same distinction as _classify.
         return True       # 5xx/429/other: an outage/throttle, NOT inaccessible -> fall back to 404-is-broken
     except (urllib.error.URLError, TimeoutError, OSError, http.client.HTTPException, ValueError):
         return True   # network blip: don't downgrade a persistent 404 to unverifiable on a transient error
@@ -255,8 +256,8 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
         # ANONYMOUS RATE LIMIT (60/h per public IP, shared by every machine behind the same NAT),
         # and naming it "private repo" sent readers to look for a permissions problem they did not
         # have, on destinations that were public and returned 200 to a browser.
-        why = ("anonymous request rejected (403: the 60/h per-IP quota is exhausted, or the caller "
-               "is blocked) — export GITHUB_TOKEN to verify" if not have_token
+        why = (f"anonymous request rejected ({status}: the 60/h per-IP quota is exhausted, or the "
+               "caller is blocked) — export GITHUB_TOKEN to verify" if not have_token
                else "token rejected (403/401)")
         return WebFinding("web_unverifiable", f, link.href, f"cannot read destination: {why}")
     if status == -2:

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -244,6 +244,13 @@ class WebFinding:
     href: str
     detail: str
     anchored_uuid: Optional[str] = None  # web_anchor: the uuid we would (or did) anchor to
+    # web_unverifiable has SEVEN causes and a token fixes only two of them (401/403 and 404, both
+    # WITHOUT a token). The rest — a non-GitHub URL, a destination with no uuid, a malformed URL, a
+    # transport error, and anything that already failed WITH a token — are not helped by credentials.
+    # Without this flag the summary told operators to "export GITHUB_TOKEN" over findings the token
+    # cannot touch, including in this very repo where all 14 are non-GitHub URLs and the figure is
+    # identical with and without one. An alert that fires when it cannot help is learned and ignored.
+    token_would_help: bool = False
 
 
 def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Optional[str],
@@ -259,7 +266,10 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
         why = (f"anonymous request rejected ({status}: the 60/h per-IP quota is exhausted, or the "
                "caller is blocked) — export GITHUB_TOKEN to verify" if not have_token
                else "token rejected (403/401)")
-        return WebFinding("web_unverifiable", f, link.href, f"cannot read destination: {why}")
+        # token_would_help ONLY when there is no token: with one, a 401/403 means it was REJECTED,
+        # and telling the operator to export the token they already exported is noise.
+        return WebFinding("web_unverifiable", f, link.href, f"cannot read destination: {why}",
+                          token_would_help=not have_token)
     if status == -2:
         # v0.17.0: the file 404s AND the destination repo is not readable with this token (a private
         # cross-org repo — a client org our PAT can't see). A 404 there is ambiguous (could be moved, or
@@ -277,7 +287,8 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
             # a real break (below). This is the "fail-closed ONLY when there is a token" contract.
             return WebFinding("web_unverifiable", f, link.href,
                               "destination 404s but no token — ambiguous (could be a private repo we "
-                              "cannot see, not necessarily moved); a token is needed to call it broken")
+                              "cannot see, not necessarily moved); a token is needed to call it broken",
+                              token_would_help=True)
         return WebFinding("web_not_found", f, link.href,
                           "destination URL 404s; darnlink does not search where it moved (LLM layer's job)")
     if status == -3:

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -129,7 +129,7 @@ def test_online_dest_has_no_uuid_is_mismatch(tmp_path):
     assert findings[0].kind == "web_mismatch"
 
 
-# --- failure cases: 404, private-no-token, unparseable, network error ---
+# --- failure cases: 404, 403-without-token, unparseable, network error ---
 
 def test_online_404_WITH_token_is_web_not_found_exits_4(tmp_path, monkeypatch):
     """WITH a token, a 404 is a real break: the token distinguishes 'moved/deleted' from
@@ -159,7 +159,7 @@ def test_online_403_without_a_token_is_reported_as_quota_not_as_a_private_repo(t
     """A tokenless 403 is the ANONYMOUS RATE LIMIT, not a private repo.
 
     This test used to be called `..._private_no_token_...` and its fixture comment said
-    "private repo, no token -> 403". That is backwards, and `_finding_for` says so itself:
+    "private repo, no token -> 403". That is backwards, and `_classify` says so itself:
     GitHub answers **404**, not 403, for a private repo we cannot see. So a 403 without a
     token is essentially always the 60/h-per-IP anonymous quota — which is what a caller
     behind a shared NAT hits. Naming it "private repo" sent readers hunting for a

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -471,3 +471,37 @@ def test_default_fetcher_404_no_token_skips_repo_check(monkeypatch):
     monkeypatch.setattr(wl, "_repo_accessible", lambda o, r, t: called.__setitem__("n", called["n"]+1) or False)
     assert wl.default_fetcher(gu, None, attempts=1, sleep=lambda _s: None) == (404, None)
     assert called["n"] == 0  # no token -> no repo check
+
+
+# --- the verdict line: it must not advise a remedy that cannot be taken ---
+
+def test_verdict_line_is_plain_clean_when_nothing_was_unverifiable(tmp_path, capsys):
+    _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
+    fetch = _fetcher({URL: (200, f"---\nuuid: {UUID}\n---\n")})
+    assert _run_web_check_cli([str(tmp_path), "--online"], fetcher=fetch) == 0
+    assert "-> exit 0 (clean)" in capsys.readouterr().out
+
+
+def test_verdict_line_does_not_offer_a_token_that_would_not_help(tmp_path, capsys):
+    """`web_unverifiable` has seven causes and a token fixes two. Do not advise it over the other five.
+
+    This is the defect the axis warning itself was added to prevent, one floor down: an alert that
+    fires when it cannot help is learned and ignored. Measured on darnlink's own tree, where all 14
+    unverifiable are non-GitHub URLs: the figure is IDENTICAL with and without a token, and the line
+    still told the operator to export one they had already exported.
+    """
+    # A non-GitHub URL: unverifiable forever, with or without credentials.
+    _w(tmp_path / "conta.md", "see [ext](https://example.com/a/b.md)\n")
+    assert _run_web_check_cli([str(tmp_path), "--online"], fetcher=_fetcher({})) == 0
+    out = capsys.readouterr().out
+    assert "unverifiable, NOT verified" in out          # it still says it did not look
+    assert "GITHUB_TOKEN" not in out                    # but offers no remedy that cannot be taken
+
+
+def test_verdict_line_offers_the_token_when_it_WOULD_help(tmp_path, capsys, monkeypatch):
+    """The mirror case: a tokenless 403 is quota, and a token really does resolve it."""
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
+    assert _run_web_check_cli([str(tmp_path), "--online"], fetcher=_fetcher({URL: (403, None)})) == 0
+    out = capsys.readouterr().out
+    assert "1 of them would resolve with GITHUB_TOKEN" in out

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -155,12 +155,23 @@ def test_online_404_WITHOUT_token_is_unverifiable_exits_0(tmp_path, monkeypatch)
     assert _run_web_check_cli([str(tmp_path), "--online"], fetcher=fetch) == 0
 
 
-def test_online_private_no_token_is_unverifiable(tmp_path):
+def test_online_403_without_a_token_is_reported_as_quota_not_as_a_private_repo(tmp_path):
+    """A tokenless 403 is the ANONYMOUS RATE LIMIT, not a private repo.
+
+    This test used to be called `..._private_no_token_...` and its fixture comment said
+    "private repo, no token -> 403". That is backwards, and `_finding_for` says so itself:
+    GitHub answers **404**, not 403, for a private repo we cannot see. So a 403 without a
+    token is essentially always the 60/h-per-IP anonymous quota — which is what a caller
+    behind a shared NAT hits. Naming it "private repo" sent readers hunting for a
+    permissions problem they did not have, on destinations that were public and returned
+    200 to a browser.
+    """
     _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
-    fetch = _fetcher({URL: (403, None)})  # private repo, no token -> 403
+    fetch = _fetcher({URL: (403, None)})  # anonymous call, quota exhausted -> 403
     findings, _ = check_web_links_online(tmp_path, token=None, fetcher=fetch)
     assert findings[0].kind == "web_unverifiable"
-    assert "no token provided" in findings[0].detail
+    assert "quota" in findings[0].detail
+    assert "private repo" not in findings[0].detail
     # unverifiable does not fail the exit (not a broken link, just unconfirmed)
     assert _run_web_check_cli([str(tmp_path), "--online"], fetcher=fetch) == 0
 


### PR DESCRIPTION
## The claim that was wrong

The header said **"public destinations need NO token"**. Public targets do not need one for **permission** — they need one for **quota**:

> Anonymous GitHub API calls are capped at **60/h per public IP**, shared by every machine behind the same NAT.

So the web axis silently stops verifying **depending on what time the build runs**, and reports `ok 0 | unverifiable N` — which reads as *"nothing to check"* and means *"could not look"*.

**Worse: it is indistinguishable from a repo that genuinely has no cross-repo links.** Nothing about the number tells you which one you are looking at.

## Measured on two different repos

| Repo shape | without token | with token |
|---|---|---|
| public, links only to itself | `ok 0` · unverifiable 52 | **`ok 7`** |
| links to a private repo | `ok 0` · unverifiable 18 | **`ok 5`** |

Both had the axis **enabled**, and neither was verifying anything.

## The change

Deliberately **not** a failure — committing offline must keep working. The gate now prints on stderr when it ends up without a token:

```
darnlink-gate: web axis running WITHOUT a token → anonymous 60/h-per-IP quota.
  'ok 0' below means COULD NOT LOOK, not 'nothing to verify'. Quote the token
  condition next to any web figure, or it is not comparable between runs.
```

**That last line is the point.** A web figure without its token condition beside it cannot be compared between two runs, let alone between two repos — and comparing them is the whole reason the axis reports a number.

Also corrected: the two header blocks that told the reader public targets are tokenless. **A comment that is wrong about the mechanism is worse than no comment**, because it is what someone reads instead of measuring.

## Verification

```
bash -n                 -> clean
without token           -> warning printed, rc=0
with token              -> no warning, ok 0 -> 5, rc=0
repo's own gates        -> 248 tests pass, lang-gate OK, dangling 0
```