### PR TITLE
dangling: a link with empty text was invisible, not unreported (FR-051)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,9 @@ All notable changes to darnlink are documented here. The format is based on
   so an anchored empty-text link cannot be plain to one function and robust to another — a coupling
   that matters to the **repair** axis and has its own tests, since reverting that half alone leaves
   every `dangling` test green. FR-051.
-- **The whitespace around a link destination is no longer treated as part of it**, as CommonMark
-  requires. Two halves:
+- **Within the `dangling` axis**, the whitespace around a link destination is no longer treated as
+  part of it, as CommonMark requires. (Only that axis — `repair`, `robustify` and `--create-readme`
+  still do not strip; see *Known issues* and #67.) Two halves:
 
   *A destination that is only whitespace is not reported at all.* `[x]( )`, `[x](%20)` and
   `[x]( #sec)` resolved to the linking file's own directory under a blank name, giving a finding
@@ -46,7 +47,11 @@ All notable changes to darnlink are documented here. The format is based on
   denotes `B.md`; judged literally it resolved to `dir/ B.md ` and was reported dead while the file
   sat right there — a **false red on a live file**, which is how a gate gets switched off rather
   than fixed. Applied to the decoded path with the fragment removed, and — the part a first version
-  got wrong — at every place that value is *used*, not only where it is tested. FR-052.
+  got wrong — at every place inside this axis that the value is *used*, not only where it is tested.
+  **ASCII whitespace only**, which is what CommonMark counts: a bare `str.strip()` also removes NBSP
+  and the ideographic space, and since a file really can be named `\xa0a.md`, that turned a link to
+  a **missing** file into a resolved one and reported clean — a false green, and NBSP is precisely
+  what a Word or HTML paste produces. FR-052.
 
   Note this **removes** findings from the pre-existing surface rather than adding any: with a
   non-empty text these shapes were reported before this release. Measured across thirteen local
@@ -75,18 +80,23 @@ All notable changes to darnlink are documented here. The format is based on
 
 ### Known issues — read this before moving a pin
 
-Neither is introduced by this release and both are latent (**0 occurrences across thirteen
+None of the three is introduced by this release and all are latent (**0 occurrences across thirteen
 repositories**), but this release routes more links towards the first, so they belong where a
 consumer deciding on an upgrade will see them — not buried under *Fixed*.
 
 - **`--write` detaches a pandoc attribute block** (#65). The anchor lands between the link and its
   `{…}`, so the block stops applying. Pre-existing: a non-empty link text has always done it. The
   tests added here pin that the block is never *deleted*, which is the worse neighbour of the two.
+- **`--write` silently drops a file's UTF-8 BOM** (#68) on all four write paths. CRLF is preserved
+  meticulously; the BOM is not, and three places in this repo imply otherwise — including the CI
+  Windows matrix, whose stated purpose is BOM/CRLF and whose BOM fixture only covers the *read*
+  path, so it cannot see this.
 - **Whitespace around a destination is stripped by `dangling` but not by `repair`, `robustify` or
   `--create-readme`** (#67), so one link can get two verdicts. The `repair` case is the sharp one:
   a trailing space makes `names_md` false, the link is classified as a directory link and becomes a
   `CONFLICT` diagnosed as *"path and uuid disagree"* — which is untrue, and `--write` never heals
   it, so the gate stays red. FR-052 is deliberately scoped to the `dangling` axis for now.
+
 ### Added
 - **The English-only gate now covers the surfaces that are actually published**: commit messages,
   PR titles/descriptions, issues, and `.md` documentation. Until now it judged one thing —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,12 +46,19 @@ All notable changes to darnlink are documented here. The format is based on
   *A destination with whitespace **around a real name** is stripped before resolving.* `[x]( B.md )`
   denotes `B.md`; judged literally it resolved to `dir/ B.md ` and was reported dead while the file
   sat right there — a **false red on a live file**, which is how a gate gets switched off rather
-  than fixed. Applied to the decoded path with the fragment removed, and — the part a first version
-  got wrong — at every place inside this axis that the value is *used*, not only where it is tested.
-  **ASCII whitespace only**, which is what CommonMark counts: a bare `str.strip()` also removes NBSP
-  and the ideographic space, and since a file really can be named `\xa0a.md`, that turned a link to
-  a **missing** file into a resolved one and reported clean — a false green, and NBSP is precisely
-  what a Word or HTML paste produces. FR-052.
+  than fixed. FR-052.
+
+  Two properties of that strip took four attempts to get right, and both are false greens when
+  wrong, so they are worth stating exactly:
+
+  - **It happens BEFORE percent-decoding.** The whitespace dropped is a *delimiter*, and a delimiter
+    exists only in the source. An escape is content: `[x]( a.md )` denotes `a.md`, but `[x](%20a.md)`
+    denotes `" a.md"` — checked against the reference CommonMark implementation, which emits
+    `href="a.md"` for the first and `href="%20a.md"` for the second. Stripping afterwards made them
+    the same link, so a link to a **missing** file was answered by an existing neighbour.
+  - **ASCII whitespace only**, which is what CommonMark counts. A bare `str.strip()` also removes
+    NBSP and the ideographic space; a file can be named `\xa0a.md`, so that hid a broken link too —
+    and NBSP is precisely what a Word or HTML paste produces.
 
   Note this **removes** findings from the pre-existing surface rather than adding any: with a
   non-empty text these shapes were reported before this release. Measured across thirteen local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,16 @@ All notable changes to darnlink are documented here. The format is based on
   so an anchored empty-text link cannot be plain to one function and robust to another — a coupling
   that matters to the **repair** axis and has its own tests, since reverting that half alone leaves
   every `dangling` test green. FR-051.
-- **`[]( )` — an href of pure whitespace — was reported as a dangling target.** It resolved to the
-  linking file's own directory with a blank name, so the finding read `line 5:  : target does not
-  exist`, naming nothing anyone could go and look for. FR-052.
+- **An href that names no destination is no longer reported.** `[x]( )`, `[x](%20)` and `[x]( #sec)`
+  all resolved to the linking file's own directory under a blank name, giving a finding that read
+  `line 5:  : target does not exist` — naming nothing anyone could go and look for. The last one was
+  worse than cosmetic: ` #section` is a legal in-page anchor, and FR-046 says a bare fragment is
+  never reported, so a valid link was being called dead. Judged on the **decoded** path after the
+  fragment is split off, because the three spellings are one link. FR-052.
+
+  Note this **removes** findings from the pre-existing surface rather than adding any: with a
+  non-empty text these shapes were reported before this release. Measured across eleven local
+  repositories: **0 occurrences**, so no consumer's count moves.
 - **A tokenless `403` is the anonymous rate limit, not a private repo — and the web axis now says so
   instead of printing a quiet `clean`.** `web-check` reported *"cannot read destination: private repo
   and no token provided"* for any `403` without a token. That was wrong every time: GitHub answers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,13 @@ All notable changes to darnlink are documented here. The format is based on
     denotes `" a.md"` — checked against the reference CommonMark implementation, which emits
     `href="a.md"` for the first and `href="%20a.md"` for the second. Stripping afterwards made them
     the same link, so a link to a **missing** file was answered by an existing neighbour.
+  - **The two edges are not the same set.** `cmark` strips VT and FF at the start of a destination
+    and keeps them at the end (`[x](a.md\x0b)` → `href="a.md%0B"`), so a symmetric strip is itself a
+    false green. Leading: space, tab, LF, CR, VT, FF. Trailing: space, tab, LF, CR.
+  - **The rule is POSIX-shaped.** Windows trims trailing spaces from a path component, so
+    `[x](a.md%20)` normalises to `a.md` there and is not dangling. That is the filesystem's answer
+    and this axis exists to ask the filesystem — but a consumer should read it here, not discover it
+    from a build that is red on one OS only.
   - **ASCII whitespace only**, which is what CommonMark counts. A bare `str.strip()` also removes
     NBSP and the ideographic space; a file can be named `\xa0a.md`, so that hid a broken link too —
     and NBSP is precisely what a Word or HTML paste produces.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to darnlink are documented here. The format is based on
   `dangling: 0`. Since those files are converted documents, they arrive in blocks and nobody
   re-reads them.
 
-  ⚠️ **Adopting this is not a no-op for a consumer.** `MD_LINK_RE` is shared by four call sites, so
+  ⚠️ **Adopting this is not a no-op for a consumer.** `MD_LINK_RE` has three call sites, so
   the same repository also gains **36 newly visible web links** (none a `/blob/` URL today, so its
   web gate does not flip — the shape of those URLs, not a guarantee), and `--create-readme` gains a
   path where `![](media/)` can create a `README.md`. A repo at `dangling: repo` with `dangling_max`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,9 +94,18 @@ All notable changes to darnlink are documented here. The format is based on
 
 ### Known issues — read this before moving a pin
 
-None of the three is introduced by this release and all are latent (**0 occurrences across thirteen
-repositories**), but this release routes more links towards the first, so they belong where a
-consumer deciding on an upgrade will see them — not buried under *Fixed*.
+None is introduced by this release, but they belong where a consumer deciding on an upgrade will
+see them rather than buried under *Fixed*. **One of them is live**; the rest are latent at 0
+occurrences across thirteen repositories.
+
+- ⚠️ **LIVE — balanced parentheses in a destination are truncated at the first `)`** (#71).
+  CommonMark allows them; `MD_LINK_RE` does not, so the link is cut short and reported dead while
+  the file it names sits on disk. **104 occurrences in one repository**, clustered in mirrored
+  attachment filenames (`(Parte 1)`, `(February - Monthly)`). The report conceals itself: its own
+  `(resolves to …)` supplies the missing parenthesis, so the truncated path reads as complete, and
+  a reader who checks finds the file present and concludes the *gate* is broken. That repo runs
+  `dangling: warn`, so these print rather than gate — **raising it to `repo` would close the wall on
+  104 files that exist.** Pre-existing and orthogonal to this release.
 
 - **`--write` detaches a pandoc attribute block** (#65). The anchor lands between the link and its
   `{…}`, so the block stops applying. Pre-existing: a non-empty link text has always done it. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to darnlink are documented here. The format is based on
 ## [Unreleased]
 
 ### Fixed
+- **A link with empty text — `![](photo.jpg)`, what pandoc emits for every image in a converted
+  `.docx`/`.odt` — was invisible to every axis, not merely unreported.** `MD_LINK_RE` required at
+  least one character of link text (`[^\]]+`), so such a link never matched: it was not a finding
+  that got filtered, it was never a candidate. The axis then printed `dangling: 0` over a tree full
+  of broken image embeds, which reads as *"no broken links"* but only ever meant *"none of the
+  shapes the regex recognises"*.
+
+  Measured on one repository running the wall at maximum: **7 links of this shape, 7 of them broken,
+  0 visible** — and none with a valid target, so the corpus offered no counter-example either. Since
+  those files are converted documents, they arrive in blocks and nobody re-reads them.
+
+  Reported as the pandoc attribute suffix (`{width="1.1in"}`) hiding the link; it was not.
+  The pattern stops at the `)` and never looks past it, so `![alt](x.jpg){width="1.1in"}` was always
+  seen. The two shapes simply co-occur. Both are pinned in tests so the real cause — the empty text —
+  cannot be re-diagnosed from the same coincidence. `ROBUST_LINK_RE` widens alongside `MD_LINK_RE`,
+  so an anchored empty-text link cannot be plain to one function and robust to another. FR-051.
 - **A tokenless `403` is the anonymous rate limit, not a private repo — and the web axis now says so
   instead of printing a quiet `clean`.** `web-check` reported *"cannot read destination: private repo
   and no token provided"* for any `403` without a token. That was wrong every time: GitHub answers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,12 +100,25 @@ occurrences across thirteen repositories.
 
 - ⚠️ **LIVE — balanced parentheses in a destination are truncated at the first `)`** (#71).
   CommonMark allows them; `MD_LINK_RE` does not, so the link is cut short and reported dead while
-  the file it names sits on disk. **104 occurrences in one repository**, clustered in mirrored
-  attachment filenames (`(Parte 1)`, `(February - Monthly)`). The report conceals itself: its own
-  `(resolves to …)` supplies the missing parenthesis, so the truncated path reads as complete, and
-  a reader who checks finds the file present and concludes the *gate* is broken. That repo runs
-  `dangling: warn`, so these print rather than gate — **raising it to `repo` would close the wall on
-  104 files that exist.** Pre-existing and orthogonal to this release.
+  the file it names sits on disk, clustered in mirrored attachment filenames (`(Parte 1)`,
+  `(February - Monthly)`). The report conceals itself: its own `(resolves to …)` supplies the
+  missing parenthesis, so the truncated path reads as complete, and a reader who checks finds the
+  file present and concludes the *gate* is broken.
+
+  **Size it by 20, not by 104.** Two measurements of the same repository, and only the first is what
+  a wall would enforce:
+
+  | measurement | count |
+  |---|---:|
+  | `dangling` findings the gate **emits** that are truncations | **20** |
+  | truncated links **in the tree** whose paren-completed target exists | 104 |
+
+  An earlier version of this entry printed only the 104 and said raising `dangling` to `repo` "would
+  close the wall on 104 files that exist". That is wrong: a wall counts what the axis emits, and
+  most of the 104 never reach it. The gap between the two is filters this note does not fully
+  account for, which is exactly why the actionable number is the one measured at the gate.
+
+  Pre-existing and orthogonal to this release.
 
 - **`--write` detaches a pandoc attribute block** (#65). The anchor lands between the link and its
   `{…}`, so the block stops applying. Pre-existing: a non-empty link text has always done it. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,16 +33,29 @@ All notable changes to darnlink are documented here. The format is based on
   so an anchored empty-text link cannot be plain to one function and robust to another — a coupling
   that matters to the **repair** axis and has its own tests, since reverting that half alone leaves
   every `dangling` test green. FR-051.
-- **An href that names no destination is no longer reported.** `[x]( )`, `[x](%20)` and `[x]( #sec)`
-  all resolved to the linking file's own directory under a blank name, giving a finding that read
-  `line 5:  : target does not exist` — naming nothing anyone could go and look for. The last one was
-  worse than cosmetic: ` #section` is a legal in-page anchor, and FR-046 says a bare fragment is
-  never reported, so a valid link was being called dead. Judged on the **decoded** path after the
-  fragment is split off, because the three spellings are one link. FR-052.
+- **The whitespace around a link destination is no longer treated as part of it**, as CommonMark
+  requires. Two halves:
+
+  *A destination that is only whitespace is not reported at all.* `[x]( )`, `[x](%20)` and
+  `[x]( #sec)` resolved to the linking file's own directory under a blank name, giving a finding
+  that read `line 5:  : target does not exist` — naming nothing anyone could go and look for. The
+  last was worse than cosmetic: ` #section` is a legal in-page anchor, and FR-046 says a bare
+  fragment is never reported, so a valid link was called dead.
+
+  *A destination with whitespace **around a real name** is stripped before resolving.* `[x]( B.md )`
+  denotes `B.md`; judged literally it resolved to `dir/ B.md ` and was reported dead while the file
+  sat right there — a **false red on a live file**, which is how a gate gets switched off rather
+  than fixed. Applied to the decoded path with the fragment removed, and — the part a first version
+  got wrong — at every place that value is *used*, not only where it is tested. FR-052.
 
   Note this **removes** findings from the pre-existing surface rather than adding any: with a
-  non-empty text these shapes were reported before this release. Measured across eleven local
-  repositories: **0 occurrences**, so no consumer's count moves.
+  non-empty text these shapes were reported before this release. Measured across thirteen local
+  repositories: **0** whitespace-only destinations, and **6** with surrounding whitespace, none of
+  which changes a verdict — only the path the finding names. No consumer's count moves.
+- **Known, not fixed here: `--write` detaches a pandoc attribute block** — the anchor lands between
+  the link and its `{…}`, so the block stops applying. Pre-existing (a non-empty text has always
+  done it) and 0 occurrences today, but this release routes many more links towards it. Tracked in
+  #65; the tests here pin that the block is never *deleted*, which is the worse neighbour.
 - **A tokenless `403` is the anonymous rate limit, not a private repo — and the web axis now says so
   instead of printing a quiet `clean`.** `web-check` reported *"cannot read destination: private repo
   and no token provided"* for any `403` without a token. That was wrong every time: GitHub answers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,7 @@ All notable changes to darnlink are documented here. The format is based on
   non-empty text these shapes were reported before this release. Measured across thirteen local
   repositories: **0** whitespace-only destinations, and **6** with surrounding whitespace, none of
   which changes a verdict — only the path the finding names. No consumer's count moves.
-- **Known, not fixed here: `--write` detaches a pandoc attribute block** — the anchor lands between
-  the link and its `{…}`, so the block stops applying. Pre-existing (a non-empty text has always
-  done it) and 0 occurrences today, but this release routes many more links towards it. Tracked in
-  #65; the tests here pin that the block is never *deleted*, which is the worse neighbour.
+
 - **A tokenless `403` is the anonymous rate limit, not a private repo — and the web axis now says so
   instead of printing a quiet `clean`.** `web-check` reported *"cannot read destination: private repo
   and no token provided"* for any `403` without a token. That was wrong every time: GitHub answers
@@ -76,6 +73,20 @@ All notable changes to darnlink are documented here. The format is based on
   tokenless"* and *"never a false green"* are corrected — **give the axis a token even for public
   destinations**: private ones need it for permission, public ones for quota.
 
+### Known issues — read this before moving a pin
+
+Neither is introduced by this release and both are latent (**0 occurrences across thirteen
+repositories**), but this release routes more links towards the first, so they belong where a
+consumer deciding on an upgrade will see them — not buried under *Fixed*.
+
+- **`--write` detaches a pandoc attribute block** (#65). The anchor lands between the link and its
+  `{…}`, so the block stops applying. Pre-existing: a non-empty link text has always done it. The
+  tests added here pin that the block is never *deleted*, which is the worse neighbour of the two.
+- **Whitespace around a destination is stripped by `dangling` but not by `repair`, `robustify` or
+  `--create-readme`** (#67), so one link can get two verdicts. The `repair` case is the sharp one:
+  a trailing space makes `names_md` false, the link is classified as a directory link and becomes a
+  `CONFLICT` diagnosed as *"path and uuid disagree"* — which is untrue, and `--write` never heals
+  it, so the gate stays red. FR-052 is deliberately scoped to the `dangling` axis for now.
 ### Added
 - **The English-only gate now covers the surfaces that are actually published**: commit messages,
   PR titles/descriptions, issues, and `.md` documentation. Until now it judged one thing —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,15 +14,28 @@ All notable changes to darnlink are documented here. The format is based on
   of broken image embeds, which reads as *"no broken links"* but only ever meant *"none of the
   shapes the regex recognises"*.
 
-  Measured on one repository running the wall at maximum: **7 links of this shape, 7 of them broken,
-  0 visible** — and none with a valid target, so the corpus offered no counter-example either. Since
-  those files are converted documents, they arrive in blocks and nobody re-reads them.
+  Measured on one repository running the wall at maximum, in its own gate scope: **127 links with
+  empty text, 7 of them pointing at a target that does not exist**, and the axis printed
+  `dangling: 0`. Since those files are converted documents, they arrive in blocks and nobody
+  re-reads them.
+
+  ⚠️ **Adopting this is not a no-op for a consumer.** `MD_LINK_RE` is shared by four call sites, so
+  the same repository also gains **36 newly visible web links** (none a `/blob/` URL today, so its
+  web gate does not flip — the shape of those URLs, not a guarantee), and `--create-readme` gains a
+  path where `![](media/)` can create a `README.md`. A repo at `dangling: repo` with `dangling_max`
+  unset goes **0 → 7 and its push wall closes**: fix the links or raise the ceiling *before* moving
+  the pin, not after.
 
   Reported as the pandoc attribute suffix (`{width="1.1in"}`) hiding the link; it was not.
   The pattern stops at the `)` and never looks past it, so `![alt](x.jpg){width="1.1in"}` was always
   seen. The two shapes simply co-occur. Both are pinned in tests so the real cause — the empty text —
   cannot be re-diagnosed from the same coincidence. `ROBUST_LINK_RE` widens alongside `MD_LINK_RE`,
-  so an anchored empty-text link cannot be plain to one function and robust to another. FR-051.
+  so an anchored empty-text link cannot be plain to one function and robust to another — a coupling
+  that matters to the **repair** axis and has its own tests, since reverting that half alone leaves
+  every `dangling` test green. FR-051.
+- **`[]( )` — an href of pure whitespace — was reported as a dangling target.** It resolved to the
+  linking file's own directory with a blank name, so the finding read `line 5:  : target does not
+  exist`, naming nothing anyone could go and look for. FR-052.
 - **A tokenless `403` is the anonymous rate limit, not a private repo — and the web axis now says so
   instead of printing a quiet `clean`.** `web-check` reported *"cannot read destination: private repo
   and no token provided"* for any `403` without a token. That was wrong every time: GitHub answers

--- a/specs/015-dangling-links/spec.md
+++ b/specs/015-dangling-links/spec.md
@@ -266,8 +266,8 @@ be fixed, or the ceiling raised, *before* the pin moves — not after.
   is the filesystem's answer and this axis exists to ask the filesystem, but the asymmetry is real
   and is stated here rather than left for a consumer to discover from a red build on one OS only.
 
-  The whitespace stripped MUST
-  be **CommonMark's, which is ASCII** — space, tab, LF, VT, FF, CR — and never Python's
+  The whitespace involved MUST
+  be **ASCII**, that being what CommonMark counts — and never Python's
   `str.strip()` default, which also removes NBSP and the ideographic space. Those are ordinary
   characters: a file can be named `\xa0a.md`, so stripping them makes a link to a **missing** file
   resolve to an existing neighbour and report clean. That is a false green, in the one function

--- a/specs/015-dangling-links/spec.md
+++ b/specs/015-dangling-links/spec.md
@@ -93,6 +93,32 @@ Measured on the fleet: of the findings this feature adds over a hand-written che
 embeds, **six of fourteen were images pointing outside their repository** — screenshots that stopped
 rendering when a home directory was reorganised, and that no gate had ever mentioned.
 
+## Why an empty link text was the worse bug (FR-051)
+
+FR-050 above reasons about embeds on the assumption that `MD_LINK_RE` sees them. For one very common
+shape it did not: the pattern required `[^\]]+` — **at least one character** of link text — so
+`![](photo.jpg)` matched nothing at all. Not reported and dismissed: **absent**, never a candidate.
+
+That empty alt is not an edge case. It is what **pandoc emits for every image** when converting a
+`.docx` or `.odt`, so it arrives in whole blocks of files imported at once, and the file that carries
+it is exactly the kind nobody re-reads — a converted document, filed and trusted.
+
+The failure mode is the one this whole feature exists to prevent, one level deeper. `dangling: 0` is
+read as *"no broken links"*. It only ever meant *"none of the shapes the regex recognises"*, and the
+gap between those two readings is invisible from the output. Measured on one repository running the
+wall at maximum: **7 links of this shape, 7 of them broken, 0 visible** — and 0 links of this shape
+with a target that exists, so the corpus offered no counter-example either.
+
+Note what this is **not**. The bug was reported as the pandoc attribute suffix (`{width="1.1in"}`)
+hiding the link. That suffix is harmless: the pattern stops at the `)` and never looks past it, and
+`![alt](x.jpg){width="1.1in"}` was always seen. The two shapes co-occur because pandoc emits both at
+once, which is what made the suffix the plausible-looking cause. Both are pinned in the tests so the
+true cause cannot be re-diagnosed later from the same coincidence.
+
+`href` keeps its `+`: a link with no destination has nothing to check. And `ROBUST_LINK_RE` widens
+with `MD_LINK_RE` deliberately — leaving it narrow would make an anchored `[](path) <!-- uuid: … -->`
+plain to one function and robust to another, and the tool's uuid bookkeeping assumes those two agree.
+
 ## Requirements *(mandatory)*
 
 ### Functional Requirements
@@ -123,6 +149,10 @@ rendering when a home directory was reorganised, and that no gate had ever menti
   caller's policy, expressed in the gate recipe, not in the core.
 - **FR-050**: An image embed (`![alt](path)`) whose target does not exist MUST be reported, on the
   same terms as any other link. See below — this is a decision, not an accident of the parser.
+- **FR-051**: A link whose **text is empty** (`[](path)`, `![](path)`) MUST be detected on exactly
+  the same terms as one with text. The link text is what a reader sees; it has no bearing on whether
+  the destination is there, and requiring at least one character of it made such links invisible to
+  every axis, not merely unreported. See below.
 
 ### Key Entities
 

--- a/specs/015-dangling-links/spec.md
+++ b/specs/015-dangling-links/spec.md
@@ -256,6 +256,16 @@ be fixed, or the ceiling raised, *before* the pin moves — not after.
   makes those two the same link, which is a **false green** when only `a.md` exists and a **false
   red** naming the wrong path when `" a.md"` does. This is where FR-046/FR-047's reasoning must NOT
   be borrowed: their spellings do denote the same destination, and whitespace's do not.
+  ⚠️ **The two edges are not the same set.** Adjudicated against the reference implementation:
+  `cmark` strips VT and FF at the START of a destination and keeps them at the END
+  (`[x](a.md\x0b)` → `href="a.md%0B"`). A symmetric strip is therefore a false green. Leading:
+  space, tab, LF, CR, VT, FF. Trailing: space, tab, LF, CR.
+
+  ⚠️ **And the rule is POSIX-shaped.** Windows trims trailing spaces and dots from a path component,
+  so `[x](a.md%20)` — which denotes `"a.md "` — normalises to `a.md` there and is not dangling. That
+  is the filesystem's answer and this axis exists to ask the filesystem, but the asymmetry is real
+  and is stated here rather than left for a consumer to discover from a red build on one OS only.
+
   The whitespace stripped MUST
   be **CommonMark's, which is ASCII** — space, tab, LF, VT, FF, CR — and never Python's
   `str.strip()` default, which also removes NBSP and the ideographic space. Those are ordinary

--- a/specs/015-dangling-links/spec.md
+++ b/specs/015-dangling-links/spec.md
@@ -245,7 +245,13 @@ be fixed, or the ceiling raised, *before* the pin moves — not after.
   rule is applied to the **decoded path with the fragment removed**, on the same terms as FR-046 and
   FR-047 — those spellings denote the same destination, and a rule applied to one of them is a rule
   with a way around it. Guarding the raw href alone left `[](%20)` and `[]( #sec)` still emitting
-  the forbidden finding, the second on a legal in-page anchor (FR-046).
+  the forbidden finding, the second on a legal in-page anchor (FR-046). The whitespace stripped MUST
+  be **CommonMark's, which is ASCII** — space, tab, LF, VT, FF, CR — and never Python's
+  `str.strip()` default, which also removes NBSP and the ideographic space. Those are ordinary
+  characters: a file can be named `\xa0a.md`, so stripping them makes a link to a **missing** file
+  resolve to an existing neighbour and report clean. That is a false green, in the one function
+  this feature owns — and NBSP is exactly what a Word or HTML paste emits, which is the corpus this
+  feature exists for.
 
 ### Key Entities
 

--- a/specs/015-dangling-links/spec.md
+++ b/specs/015-dangling-links/spec.md
@@ -136,9 +136,16 @@ behaviour match the claim. Two notes on scope, both learned by being wrong about
   repo's chat-transcript mirror). None of the 6 changes a verdict: they were dangling before and
   after, and what changed is the path the finding names. So no consumer's count moves — but the rule
   is **not inert**, which the bare "0 occurrences" of an earlier draft implied.
-- **The guard belongs after `split_fragment` and `unquote`, not before.** Written against the raw
-  href it missed `[](%20)` and `[]( #sec)` — the same destination, spelled differently — and the
-  second was a false positive on valid CommonMark rather than a cosmetic finding.
+- **The guard belongs after `split_fragment` and BEFORE `unquote`.** Written against the whole raw
+  href it missed `[]( #sec)`, a false positive on a legal in-page anchor. Written after `unquote` it
+  did something worse: `%20a.md` became `a.md`, so a link to a missing file was answered by an
+  existing neighbour. The fragment is a delimiter and comes off first; the escape is content and
+  stays. Four rounds arrived at that ordering, each fixing one dimension and leaving the next: the
+  literal form, then where the value is used, then ASCII versus Unicode, then encoded versus literal.
+  The single clause that licensed the error — *"those spellings denote the same destination"* — was
+  borrowed from FR-047, where it is true, and it propagated into five documents before anyone
+  checked it against a CommonMark implementation. **When a rule is about syntax, adjudicate it
+  against the reference parser, not against the rule next to it.**
 - **And it has to strip, not just test for empty.** A first version rejected only an all-whitespace
   path, which left `[x]( B.md )` resolving to `dir/ B.md ` and reported dead — while this very
   section argued that surrounding whitespace is not part of the destination. A rule whose stated
@@ -242,10 +249,14 @@ be fixed, or the ceiling raised, *before* the pin moves — not after.
   destination that is *only*
   whitespace MUST NOT be reported at all: it names nothing, and resolving it yields the linking
   file's own directory under a blank name, a finding that names nothing a reader can act on. The
-  rule is applied to the **decoded path with the fragment removed**, on the same terms as FR-046 and
-  FR-047 — those spellings denote the same destination, and a rule applied to one of them is a rule
-  with a way around it. Guarding the raw href alone left `[](%20)` and `[]( #sec)` still emitting
-  the forbidden finding, the second on a legal in-page anchor (FR-046). The whitespace stripped MUST
+  rule is applied to the **raw path with the fragment removed, BEFORE percent-decoding** — the
+  whitespace it drops is a *delimiter*, and a delimiter exists only in the source text. A
+  percent-escape is content: verified against the reference implementation, `[x]( a.md )` yields
+  `a.md` while `[x](%20a.md)` yields `%20a.md`, which denotes `" a.md"`. Stripping after decoding
+  makes those two the same link, which is a **false green** when only `a.md` exists and a **false
+  red** naming the wrong path when `" a.md"` does. This is where FR-046/FR-047's reasoning must NOT
+  be borrowed: their spellings do denote the same destination, and whitespace's do not.
+  The whitespace stripped MUST
   be **CommonMark's, which is ASCII** — space, tab, LF, VT, FF, CR — and never Python's
   `str.strip()` default, which also removes NBSP and the ideographic space. Those are ordinary
   characters: a file can be named `\xa0a.md`, so stripping them makes a link to a **missing** file

--- a/specs/015-dangling-links/spec.md
+++ b/specs/015-dangling-links/spec.md
@@ -130,10 +130,12 @@ a blank name, producing a finding that read `line 5:  : target does not exist`. 
 behaviour match the claim. Two notes on scope, both learned by being wrong about them first:
 
 - **It is a subtraction, not an addition.** With a non-empty text those shapes were reported *before*
-  this release, so FR-052 removes findings from the pre-existing surface. Measured across thirteen
-  local repositories, 14.446 Markdown files and 52.932 in-prose links: **0 occurrences**, so no
-  consumer's count moves — but "0 findings lost" is a claim about the widening, and this rule is the
-  one exception to it.
+  this release, so FR-052 removes findings from the pre-existing surface — the one exception to the
+  "0 findings lost" claim, which is about the widening. Measured across thirteen local repositories:
+  **0** whitespace-only destinations, and **6** with whitespace around a real name (all in one
+  repo's chat-transcript mirror). None of the 6 changes a verdict: they were dangling before and
+  after, and what changed is the path the finding names. So no consumer's count moves — but the rule
+  is **not inert**, which the bare "0 occurrences" of an earlier draft implied.
 - **The guard belongs after `split_fragment` and `unquote`, not before.** Written against the raw
   href it missed `[](%20)` and `[]( #sec)` — the same destination, spelled differently — and the
   second was a false positive on valid CommonMark rather than a cosmetic finding.
@@ -199,7 +201,7 @@ be fixed, or the ceiling raised, *before* the pin moves — not after.
   > The line, link and resolved path travel in the finding's `detail`. This requirement used to add
   > *"no finding kind has ever carried a line field, and widening the shared `Finding` record is
   > outside this feature"* — **no longer true**: `Finding` grew an optional `line` (`report.py:37`)
-  > for the gate recipe's added-lines ratchet, and `robustify.py:397` fills it. The `detail` text is
+  > for the gate recipe's added-lines ratchet, and `_dangling_target`'s caller fills it. The `detail` text is
   > kept because callers parse it, not because the field is unavailable.
 - **FR-042**: `dangling` MUST be **report-only**. No mode, including `--write`, may create, move or
   otherwise alter anything in response to it.

--- a/specs/015-dangling-links/spec.md
+++ b/specs/015-dangling-links/spec.md
@@ -144,6 +144,16 @@ behaviour match the claim. Two notes on scope, both learned by being wrong about
   section argued that surrounding whitespace is not part of the destination. A rule whose stated
   reason covers a case its code does not is worse than a narrower rule honestly scoped: the gap
   reads as a decision nobody took.
+- **Scoped to `dangling`, deliberately, and the scope is written into FR-052 rather than left
+  implied.** The same reasoning applies to three more sites — `_anchor_target`, whose omission means
+  `check` reports "nothing to anchor" over `[x]( B.md )`; `_dir_link_missing_readme`; and `names_md`
+  on the `repair` axis, where the consequence is worst: a trailing space makes `names_md` false, the
+  link is classified as a *directory* link, and it becomes a `CONFLICT` diagnosed as *"path and uuid
+  disagree"* — which is untrue, and unlike a `repair`, `--write` never heals it, so the gate stays
+  red. **0 occurrences across thirteen repositories** (0 of 10.116 robust links), and fixing them
+  changes behaviour on three axes this feature does not own. Filed rather than folded in, for the
+  reason #65 was: a regression fix that also changes behaviour stops being reviewable. The sentence
+  above is narrowed so the gap is a decision on the record, not a silence.
 
 `ROBUST_LINK_RE` widens with `MD_LINK_RE` deliberately — leaving it narrow would make an anchored
 `[](path) <!-- uuid: … -->` plain to one function and robust to another, and the tool's uuid
@@ -227,8 +237,9 @@ be fixed, or the ceiling raised, *before* the pin moves — not after.
   the same terms as one with text. The link text is what a reader sees; it has no bearing on whether
   the destination is there, and requiring at least one character of it made such links invisible to
   every axis, not merely unreported. See below.
-- **FR-052**: The whitespace **surrounding** a link destination MUST NOT be treated as part of it —
-  CommonMark does not. So `[x]( B.md )` MUST be judged as `B.md`, and a destination that is *only*
+- **FR-052**: **Within the `dangling` axis**, the whitespace surrounding a link destination MUST NOT
+  be treated as part of it — CommonMark does not. So `[x]( B.md )` MUST be judged as `B.md`, and a
+  destination that is *only*
   whitespace MUST NOT be reported at all: it names nothing, and resolving it yields the linking
   file's own directory under a blank name, a finding that names nothing a reader can act on. The
   rule is applied to the **decoded path with the fragment removed**, on the same terms as FR-046 and

--- a/specs/015-dangling-links/spec.md
+++ b/specs/015-dangling-links/spec.md
@@ -130,12 +130,18 @@ a blank name, producing a finding that read `line 5:  : target does not exist`. 
 behaviour match the claim. Two notes on scope, both learned by being wrong about them first:
 
 - **It is a subtraction, not an addition.** With a non-empty text those shapes were reported *before*
-  this release, so FR-052 removes findings from the pre-existing surface. Measured across eleven
-  local repositories: 0 occurrences, so no consumer's count moves — but "0 findings lost" is a claim
-  about the widening, and this rule is the one exception to it.
+  this release, so FR-052 removes findings from the pre-existing surface. Measured across thirteen
+  local repositories, 14.446 Markdown files and 52.932 in-prose links: **0 occurrences**, so no
+  consumer's count moves — but "0 findings lost" is a claim about the widening, and this rule is the
+  one exception to it.
 - **The guard belongs after `split_fragment` and `unquote`, not before.** Written against the raw
-  href it missed `[](%20)` and `[]( #sec)` — the same link, spelled differently — and the second was
-  a false positive on valid CommonMark rather than a cosmetic finding.
+  href it missed `[](%20)` and `[]( #sec)` — the same destination, spelled differently — and the
+  second was a false positive on valid CommonMark rather than a cosmetic finding.
+- **And it has to strip, not just test for empty.** A first version rejected only an all-whitespace
+  path, which left `[x]( B.md )` resolving to `dir/ B.md ` and reported dead — while this very
+  section argued that surrounding whitespace is not part of the destination. A rule whose stated
+  reason covers a case its code does not is worse than a narrower rule honestly scoped: the gap
+  reads as a decision nobody took.
 
 `ROBUST_LINK_RE` widens with `MD_LINK_RE` deliberately — leaving it narrow would make an anchored
 `[](path) <!-- uuid: … -->` plain to one function and robust to another, and the tool's uuid
@@ -147,24 +153,35 @@ leaves every `dangling` test green (measured: 0 failures before those tests exis
 
 ### What else the widening newly exposes
 
-`MD_LINK_RE` is shared by four consumers, so the blast radius is not confined to `dangling`.
-Measured on the same repository:
+`MD_LINK_RE` has three call sites — `find_plain_links`, `find_detached_anchors` and
+`find_web_links` — so the blast radius is not confined to `dangling`. Measured on the same
+repository:
 
-| Consumer | Effect |
+| Surface | Effect |
 |---|---|
 | `dangling` | +7 findings, all real broken image embeds; **0 findings lost** |
-| web axis (`find_web_links`) | **+36** links newly visible. None is a `/blob/` URL, so no anchor is demanded and the gate does not flip — but that is the shape of *these* URLs, not a property of the change. One `[](https://github.com/o/r/blob/main/x.md)` anywhere would exit **3** if the destination reads and carries no uuid, and **4** — integrity failure, the harder stop — if it 404s with a token |
-| `robustify --write` | an existing target behind an empty-text link now receives a uuid anchor, and the `!` of an embed is preserved (both tested in `test_robustify.py`). **0 occurrences in the measured corpus**: all 83 empty-text links with a live target point at `.jpg`/`.jpeg`, which are unanchorable |
+| web axis (`find_web_links`) | **+36** links newly visible. None is a `/blob/` URL, so none can demand an anchor and the gate does not flip — the shape of *these* URLs, not a property of the change. See the exit codes below |
+| `robustify --write` | an existing target behind an empty-text link now receives a uuid anchor, and the `!` of an embed is preserved (both tested in `test_robustify.py`). **0 occurrences in the measured corpus**: every empty-text link with a live target points at an unanchorable image |
 | `--create-readme` | `[](sub/)` and `![](media/)` can now **create** `sub/README.md`. 0 occurrences in the measured corpus, so this is live but unexercised |
+| `find_detached_anchors` | absorption changes only where an empty-text link now legitimately claims a trailing comment. `DetachedAnchor` is not a reported `Kind`, so no finding disappears |
+
+What a newly-visible `/blob/` URL would actually do, since a gate's exit code is the one thing this
+tool exists to produce and an earlier draft of this paragraph had it **backwards**:
+
+| Destination | Kind | Exit |
+|---|---|---|
+| reads, **carries** a uuid, link unanchored | `web_anchor` | **3** — anchors pending |
+| reads, carries **no** uuid | `web_unverifiable` | 0 |
+| 404 **with** a token that can see the repo | `web_not_found` | **4** — integrity failure, the harder stop |
+| 404 without a token, or a repo the token cannot see | `web_unverifiable` | 0 |
 
 ⚠️ **One pre-existing write defect this widens the exposure to.** When a link carries a pandoc
-attribute suffix, `--write` inserts the anchor *between* the link and its attributes —
-`[](B.md) <!-- uuid: … -->{.cls}` — which detaches them, since pandoc requires the block to follow
-the `)` immediately. This is **not introduced here**: a non-empty text does the same and always has.
-But the corpus that motivated this feature is converted documents, where the suffix is ubiquitous,
-so the widening routes many more links towards it. Filed separately rather than folded in — mixing a
-behaviour change into a regression fix is how a fix stops being reviewable.
-| `find_detached_anchors` | absorption changes only where an empty-text link now legitimately claims a trailing comment. `DetachedAnchor` is not a reported `Kind`, so no finding disappears |
+attribute block, `--write` inserts the anchor *between* the link and its attributes —
+`[](B.md) <!-- uuid: … -->{.cls}` — detaching them, since pandoc requires the block to follow the
+`)` immediately. **Not introduced here**: a non-empty text does the same and always has. But the
+corpus that motivated this feature is converted documents, where the block is ubiquitous, so the
+widening routes many more links towards it. Filed as #65 rather than folded in — mixing a behaviour
+change into a regression fix is how a fix stops being reviewable.
 
 **Adopting a darnlink with this change is not a no-op for a consumer at `dangling: repo` with
 `dangling_max` unset**: the repository above goes `0 → 7` and its push wall closes. The 7 links must
@@ -208,13 +225,14 @@ be fixed, or the ceiling raised, *before* the pin moves — not after.
   the same terms as one with text. The link text is what a reader sees; it has no bearing on whether
   the destination is there, and requiring at least one character of it made such links invisible to
   every axis, not merely unreported. See below.
-- **FR-052**: An href whose path is **only whitespace** MUST NOT be reported. It names no
-  destination, so there is nothing to check, and resolving it yields the linking file's own
-  directory under a blank name — a finding that names nothing a reader can act on. The rule is
-  applied to the **decoded path with the fragment removed**, on the same terms as FR-046 and
-  FR-047: `[]( )`, `[](%20)` and `[]( #sec)` are one link written three ways, and guarding only the
-  raw spelling left the last two still emitting the finding this rule forbids — the third also
-  violating FR-046, since ` #section` is a legal in-page anchor being called a dead link.
+- **FR-052**: The whitespace **surrounding** a link destination MUST NOT be treated as part of it —
+  CommonMark does not. So `[x]( B.md )` MUST be judged as `B.md`, and a destination that is *only*
+  whitespace MUST NOT be reported at all: it names nothing, and resolving it yields the linking
+  file's own directory under a blank name, a finding that names nothing a reader can act on. The
+  rule is applied to the **decoded path with the fragment removed**, on the same terms as FR-046 and
+  FR-047 — those spellings denote the same destination, and a rule applied to one of them is a rule
+  with a way around it. Guarding the raw href alone left `[](%20)` and `[]( #sec)` still emitting
+  the forbidden finding, the second on a legal in-page anchor (FR-046).
 
 ### Key Entities
 

--- a/specs/015-dangling-links/spec.md
+++ b/specs/015-dangling-links/spec.md
@@ -106,8 +106,17 @@ it is exactly the kind nobody re-reads — a converted document, filed and trust
 The failure mode is the one this whole feature exists to prevent, one level deeper. `dangling: 0` is
 read as *"no broken links"*. It only ever meant *"none of the shapes the regex recognises"*, and the
 gap between those two readings is invisible from the output. Measured on one repository running the
-wall at maximum: **7 links of this shape, 7 of them broken, 0 visible** — and 0 links of this shape
-with a target that exists, so the corpus offered no counter-example either.
+wall at maximum, in that repo's own gate scope: **127 links with empty text, of which 7 point at a
+target that does not exist** — and the axis reported `dangling: 0`.
+
+> ⚠️ **An earlier draft of this paragraph said "7 links of this shape, 7 broken, 0 with a target that
+> exists, so the corpus offered no counter-example".** All three numbers were wrong, and the last was
+> the dangerous one: it argued the change was safe *because* nothing else of this shape existed, when
+> 83 links with a valid target and 36 web links did. The measurement behind it had counted a
+> **narrower** shape than the sentence claimed — images carrying a pandoc attribute suffix, not
+> empty-text links — and the gap was invisible because both counts were called "this shape". A
+> widening is justified by what it newly matches, so counting the subset that motivated it and
+> presenting that as the total inverts the argument.
 
 Note what this is **not**. The bug was reported as the pandoc attribute suffix (`{width="1.1in"}`)
 hiding the link. That suffix is harmless: the pattern stops at the `)` and never looks past it, and
@@ -115,9 +124,35 @@ hiding the link. That suffix is harmless: the pattern stops at the `)` and never
 once, which is what made the suffix the plausible-looking cause. Both are pinned in the tests so the
 true cause cannot be re-diagnosed later from the same coincidence.
 
-`href` keeps its `+`: a link with no destination has nothing to check. And `ROBUST_LINK_RE` widens
-with `MD_LINK_RE` deliberately — leaving it narrow would make an anchored `[](path) <!-- uuid: … -->`
-plain to one function and robust to another, and the tool's uuid bookkeeping assumes those two agree.
+`href` keeps its `+`: a link with no destination has nothing to check. That was stated before it was
+true — `[]()` never matched, but `[]( )` did, and resolved to the linking file's own directory with a
+blank name, producing a finding that read `line 5:  : target does not exist`. FR-052 makes the
+behaviour match the claim.
+
+`ROBUST_LINK_RE` widens with `MD_LINK_RE` deliberately — leaving it narrow would make an anchored
+`[](path) <!-- uuid: … -->` plain to one function and robust to another, and the tool's uuid
+bookkeeping assumes those two agree. **That coupling is load-bearing for `repair`, not for
+`dangling`**: an anchored empty-text link was invisible to *both* finders before, so its uuid never
+reached the repair axis and a moved target silently stopped being healed — a false green one axis
+over from the one this feature names. It needs its own tests, because reverting that half alone
+leaves every `dangling` test green (measured: 0 failures before those tests existed, 3 after).
+
+### What else the widening newly exposes
+
+`MD_LINK_RE` is shared by four consumers, so the blast radius is not confined to `dangling`.
+Measured on the same repository:
+
+| Consumer | Effect |
+|---|---|
+| `dangling` | +7 findings, all real broken image embeds; **0 findings lost** |
+| web axis (`find_web_links`) | **+36** links newly visible. None is a `/blob/` URL, so no anchor is demanded and the gate does not flip — but that is the shape of *these* URLs, not a property of the change. One `[](https://github.com/o/r/blob/main/x.md)` anywhere would now exit 3 |
+| `robustify --write` | an existing target behind an empty-text link now receives a uuid anchor; the `!` of an embed sits outside the match span and is preserved |
+| `--create-readme` | `[](sub/)` and `![](media/)` can now **create** `sub/README.md`. 0 occurrences in the measured corpus, so this is live but unexercised |
+| `find_detached_anchors` | absorption changes only where an empty-text link now legitimately claims a trailing comment. `DetachedAnchor` is not a reported `Kind`, so no finding disappears |
+
+**Adopting a darnlink with this change is not a no-op for a consumer at `dangling: repo` with
+`dangling_max` unset**: the repository above goes `0 → 7` and its push wall closes. The 7 links must
+be fixed, or the ceiling raised, *before* the pin moves — not after.
 
 ## Requirements *(mandatory)*
 
@@ -125,10 +160,14 @@ plain to one function and robust to another, and the tool's uuid bookkeeping ass
 
 - **FR-041**: A plain relative link in a scanned Markdown file whose resolved target path **does not
   exist** MUST be reported as a `dangling` finding, naming the file, the line, the link as written,
-  and the resolved path. The line, link and resolved path travel in the finding's `detail`: no
-  finding kind has ever carried a line field, and widening the shared `Finding` record is outside
-  this feature. A dead link is acted on by opening it, so `file` + line is what makes the report
-  usable without a search.
+  and the resolved path. A dead link is acted on by opening it, so `file` + line is what makes the
+  report usable without a search.
+
+  > The line, link and resolved path travel in the finding's `detail`. This requirement used to add
+  > *"no finding kind has ever carried a line field, and widening the shared `Finding` record is
+  > outside this feature"* — **no longer true**: `Finding` grew an optional `line` (`report.py:37`)
+  > for the gate recipe's added-lines ratchet, and `robustify.py:397` fills it. The `detail` text is
+  > kept because callers parse it, not because the field is unavailable.
 - **FR-042**: `dangling` MUST be **report-only**. No mode, including `--write`, may create, move or
   otherwise alter anything in response to it.
 - **FR-043**: The target's extension MUST NOT affect whether the finding fires; only its existence.
@@ -153,6 +192,9 @@ plain to one function and robust to another, and the tool's uuid bookkeeping ass
   the same terms as one with text. The link text is what a reader sees; it has no bearing on whether
   the destination is there, and requiring at least one character of it made such links invisible to
   every axis, not merely unreported. See below.
+- **FR-052**: An href that is **only whitespace** MUST NOT be reported. It names no destination, so
+  there is nothing to check, and resolving it yields the linking file's own directory under a blank
+  name — a finding that names nothing a reader can act on.
 
 ### Key Entities
 

--- a/specs/015-dangling-links/spec.md
+++ b/specs/015-dangling-links/spec.md
@@ -125,9 +125,17 @@ once, which is what made the suffix the plausible-looking cause. Both are pinned
 true cause cannot be re-diagnosed later from the same coincidence.
 
 `href` keeps its `+`: a link with no destination has nothing to check. That was stated before it was
-true — `[]()` never matched, but `[]( )` did, and resolved to the linking file's own directory with a
-blank name, producing a finding that read `line 5:  : target does not exist`. FR-052 makes the
-behaviour match the claim.
+true — `[]()` never matched, but `[x]( )` did, and resolved to the linking file's own directory with
+a blank name, producing a finding that read `line 5:  : target does not exist`. FR-052 makes the
+behaviour match the claim. Two notes on scope, both learned by being wrong about them first:
+
+- **It is a subtraction, not an addition.** With a non-empty text those shapes were reported *before*
+  this release, so FR-052 removes findings from the pre-existing surface. Measured across eleven
+  local repositories: 0 occurrences, so no consumer's count moves — but "0 findings lost" is a claim
+  about the widening, and this rule is the one exception to it.
+- **The guard belongs after `split_fragment` and `unquote`, not before.** Written against the raw
+  href it missed `[](%20)` and `[]( #sec)` — the same link, spelled differently — and the second was
+  a false positive on valid CommonMark rather than a cosmetic finding.
 
 `ROBUST_LINK_RE` widens with `MD_LINK_RE` deliberately — leaving it narrow would make an anchored
 `[](path) <!-- uuid: … -->` plain to one function and robust to another, and the tool's uuid
@@ -145,9 +153,17 @@ Measured on the same repository:
 | Consumer | Effect |
 |---|---|
 | `dangling` | +7 findings, all real broken image embeds; **0 findings lost** |
-| web axis (`find_web_links`) | **+36** links newly visible. None is a `/blob/` URL, so no anchor is demanded and the gate does not flip — but that is the shape of *these* URLs, not a property of the change. One `[](https://github.com/o/r/blob/main/x.md)` anywhere would now exit 3 |
-| `robustify --write` | an existing target behind an empty-text link now receives a uuid anchor; the `!` of an embed sits outside the match span and is preserved |
+| web axis (`find_web_links`) | **+36** links newly visible. None is a `/blob/` URL, so no anchor is demanded and the gate does not flip — but that is the shape of *these* URLs, not a property of the change. One `[](https://github.com/o/r/blob/main/x.md)` anywhere would exit **3** if the destination reads and carries no uuid, and **4** — integrity failure, the harder stop — if it 404s with a token |
+| `robustify --write` | an existing target behind an empty-text link now receives a uuid anchor, and the `!` of an embed is preserved (both tested in `test_robustify.py`). **0 occurrences in the measured corpus**: all 83 empty-text links with a live target point at `.jpg`/`.jpeg`, which are unanchorable |
 | `--create-readme` | `[](sub/)` and `![](media/)` can now **create** `sub/README.md`. 0 occurrences in the measured corpus, so this is live but unexercised |
+
+⚠️ **One pre-existing write defect this widens the exposure to.** When a link carries a pandoc
+attribute suffix, `--write` inserts the anchor *between* the link and its attributes —
+`[](B.md) <!-- uuid: … -->{.cls}` — which detaches them, since pandoc requires the block to follow
+the `)` immediately. This is **not introduced here**: a non-empty text does the same and always has.
+But the corpus that motivated this feature is converted documents, where the suffix is ubiquitous,
+so the widening routes many more links towards it. Filed separately rather than folded in — mixing a
+behaviour change into a regression fix is how a fix stops being reviewable.
 | `find_detached_anchors` | absorption changes only where an empty-text link now legitimately claims a trailing comment. `DetachedAnchor` is not a reported `Kind`, so no finding disappears |
 
 **Adopting a darnlink with this change is not a no-op for a consumer at `dangling: repo` with
@@ -192,9 +208,13 @@ be fixed, or the ceiling raised, *before* the pin moves — not after.
   the same terms as one with text. The link text is what a reader sees; it has no bearing on whether
   the destination is there, and requiring at least one character of it made such links invisible to
   every axis, not merely unreported. See below.
-- **FR-052**: An href that is **only whitespace** MUST NOT be reported. It names no destination, so
-  there is nothing to check, and resolving it yields the linking file's own directory under a blank
-  name — a finding that names nothing a reader can act on.
+- **FR-052**: An href whose path is **only whitespace** MUST NOT be reported. It names no
+  destination, so there is nothing to check, and resolving it yields the linking file's own
+  directory under a blank name — a finding that names nothing a reader can act on. The rule is
+  applied to the **decoded path with the fragment removed**, on the same terms as FR-046 and
+  FR-047: `[]( )`, `[](%20)` and `[]( #sec)` are one link written three ways, and guarding only the
+  raw spelling left the last two still emitting the finding this rule forbids — the third also
+  violating FR-046, since ` #section` is a legal in-page anchor being called a dead link.
 
 ### Key Entities
 

--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -12,10 +12,14 @@ from typing import List, Sequence, Tuple
 
 # A robust link: a Markdown link immediately followed (any whitespace) by a uuid HTML comment.
 ROBUST_LINK_RE = re.compile(
-    r"\[(?P<text>[^\]]+)\]\((?P<href>[^)]+)\)\s*<!--\s*uuid:\s*(?P<uuid>[0-9a-fA-F-]{36})\s*-->"
+    r"\[(?P<text>[^\]]*)\]\((?P<href>[^)]+)\)\s*<!--\s*uuid:\s*(?P<uuid>[0-9a-fA-F-]{36})\s*-->"
 )
-# Any inline Markdown link.
-MD_LINK_RE = re.compile(r"\[(?P<text>[^\]]+)\]\((?P<href>[^)]+)\)")
+# Any inline Markdown link. `text` is `*`, not `+`: `[](dest)` is a link with empty text, and the
+# empty alt of `![](dest)` is what pandoc emits for every image in a converted .docx/.odt. Requiring
+# one character there made the whole link invisible -- not reported as bad, *absent* -- so a tree
+# full of broken image embeds passed the dangling axis as clean (FR-051). `href` stays `+`: a link
+# with no destination at all has nothing to check.
+MD_LINK_RE = re.compile(r"\[(?P<text>[^\]]*)\]\((?P<href>[^)]+)\)")
 # A uuid comment that immediately follows a link (used to tell plain from robust).
 # No `^`: it is applied with .match(content, pos), which already anchors at pos.
 _TRAILING_UUID_RE = re.compile(r"\s*<!--\s*uuid:\s*[0-9a-fA-F-]{36}\s*-->")

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -68,14 +68,25 @@ def _anchor_target(href: str, linking_file: Path, extra_targets: AbstractSet[Pat
     return None
 
 
-#: CommonMark whitespace, which is ASCII-only: space, tab, LF, VT, FF, CR. Deliberately NOT
-#: `str.strip()`'s default — that removes every character Python calls whitespace, including NBSP
-#: (`\xa0`) and the ideographic space (`　`), which CommonMark treats as ordinary characters.
-#: A file really can be named `\xa0a.md`, and stripping the NBSP made a link to a MISSING file
-#: resolve to an existing neighbour and report clean: a false green, in the one function this
-#: feature owns. NBSP is also exactly what arrives from a Word or HTML paste — the same corpus
-#: that motivated the feature. FR-052.
-_CM_WHITESPACE = " \t\n\r\x0b\x0c"
+#: What delimits a link destination — and **the two edges are not the same set**. Adjudicated
+#: against the reference implementation, not read off the spec. `cmark` gives:
+#:
+#:     [x](\x0ba.md)  ->  href "a.md"       VT leading  : delimiter, dropped
+#:     [x](a.md\x0b)  ->  href "a.md%0B"    VT trailing : CONTENT, kept
+#:
+#: Same for FF. A symmetric strip of all six therefore turns `[x](a.md\x0b)`, which denotes
+#: `a.md\x0b`, into `a.md` — so a link to a MISSING file is answered by an existing neighbour.
+#: A false green, in the one function this feature owns.
+#:
+#: Both sets are ASCII, deliberately NOT `str.strip()`'s default: that removes everything Python
+#: calls whitespace, including NBSP (`\xa0`) and the ideographic space, which CommonMark keeps as
+#: ordinary characters — and NBSP is exactly what a Word or HTML paste produces.
+#:
+#: Four rounds of review each closed one dimension of this rule and re-derived the next from the
+#: prose beside it. The asymmetry is the fourth, and it was caught the same way as the third: by
+#: asking the parser instead of the neighbouring rule. FR-052.
+_CM_WS_LEADING = " \t\n\r\x0b\x0c"
+_CM_WS_TRAILING = " \t\n\r"
 
 
 def _dangling_target(href: str, linking_file: Path) -> Path | None:
@@ -116,7 +127,7 @@ def _dangling_target(href: str, linking_file: Path) -> Path | None:
     # It came from borrowing FR-046/FR-047's reasoning — *"those spellings denote the same
     # destination"* — which is true of a revealed scheme or absolute path and FALSE of whitespace:
     # `%20a.md` and ` a.md` are different destinations. One clause, five documents, four rounds.
-    raw_stripped = path_part.strip(_CM_WHITESPACE)
+    raw_stripped = path_part.lstrip(_CM_WS_LEADING).rstrip(_CM_WS_TRAILING)
     if not raw_stripped:
         return None
     decoded = unquote(raw_stripped)

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -101,21 +101,29 @@ def _dangling_target(href: str, linking_file: Path) -> Path | None:
     # spellings denote the same destination, and a rule applied to only one of them is a rule with a
     # way around it. Guarding the raw href alone left `[](%20)` and `[]( #x)` still emitting the
     # finding this rule forbids, the second on a legal in-page anchor.
+    # `path_part` already has the fragment off, so stripping it here is the whole rule -- and every
+    # resolution below has to use these stripped forms, not the raw href. A first version computed
+    # `stripped` for the emptiness test only and then resolved `href.strip()`, which is a DIFFERENT
+    # string: `.strip()` on the raw href cannot reach a space sitting before a `#`, and the encoded
+    # branch was never stripped at all. Result: `[x]( B.md #s )` and `[x](%20B.md )` resolved to
+    # `dir/B.md ` and `dir/ B.md` and were reported dead while `B.md` sat right there. A rule is only
+    # applied where its value is used.
     stripped = decoded.strip()
     if not stripped:
         return None
+    raw_stripped = path_part.strip()
     # Decoding can change *what kind of thing* the href is, not just how it is spelled:
     # `%2Fetc%2Fpasswd` becomes an absolute path and `http%3A//x` regains its scheme. Both pass
     # `is_local_relative` while encoded, so judging only the raw form would let the encoding walk
     # around FR-046 — suppressing a finding because `/etc/passwd` happens to exist, or inventing one
     # for a URL. The decoded spelling is held to the same rule as the raw one.
-    if encoded and not is_local_relative(decoded):
+    if encoded and not is_local_relative(stripped):
         return None
-    t = resolve_href(href.strip(), linking_file)  # drops the fragment
+    t = resolve_href(raw_stripped, linking_file)
     if t.exists():
         return None
     if encoded:
-        d = resolve_href(decoded, linking_file)
+        d = resolve_href(stripped, linking_file)
         # Report the DECODED path: it is the one the link denotes, and the one to look for on disk.
         return None if d.exists() else d
     return t

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -68,6 +68,16 @@ def _anchor_target(href: str, linking_file: Path, extra_targets: AbstractSet[Pat
     return None
 
 
+#: CommonMark whitespace, which is ASCII-only: space, tab, LF, VT, FF, CR. Deliberately NOT
+#: `str.strip()`'s default — that removes every character Python calls whitespace, including NBSP
+#: (`\xa0`) and the ideographic space (`　`), which CommonMark treats as ordinary characters.
+#: A file really can be named `\xa0a.md`, and stripping the NBSP made a link to a MISSING file
+#: resolve to an existing neighbour and report clean: a false green, in the one function this
+#: feature owns. NBSP is also exactly what arrives from a Word or HTML paste — the same corpus
+#: that motivated the feature. FR-052.
+_CM_WHITESPACE = " \t\n\r\x0b\x0c"
+
+
 def _dangling_target(href: str, linking_file: Path) -> Path | None:
     """The resolved path of a local link that points at **nothing**, or None (feature 015).
 
@@ -108,10 +118,10 @@ def _dangling_target(href: str, linking_file: Path) -> Path | None:
     # branch was never stripped at all. Result: `[x]( B.md #s )` and `[x](%20B.md )` resolved to
     # `dir/B.md ` and `dir/ B.md` and were reported dead while `B.md` sat right there. A rule is only
     # applied where its value is used.
-    stripped = decoded.strip()
+    stripped = decoded.strip(_CM_WHITESPACE)
     if not stripped:
         return None
-    raw_stripped = path_part.strip()
+    raw_stripped = path_part.strip(_CM_WHITESPACE)
     # Decoding can change *what kind of thing* the href is, not just how it is spelled:
     # `%2Fetc%2Fpasswd` becomes an absolute path and `http%3A//x` regains its scheme. Both pass
     # `is_local_relative` while encoded, so judging only the raw form would let the encoding walk

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -68,25 +68,40 @@ def _anchor_target(href: str, linking_file: Path, extra_targets: AbstractSet[Pat
     return None
 
 
-#: What delimits a link destination — and **the two edges are not the same set**. Adjudicated
-#: against the reference implementation, not read off the spec. `cmark` gives:
+#: What delimits a link destination. The two edges are not the same set **and not even the same
+#: kind of operation** — adjudicated against the reference implementation, exhaustively, not read
+#: off the spec.
 #:
-#:     [x](\x0ba.md)  ->  href "a.md"       VT leading  : delimiter, dropped
-#:     [x](a.md\x0b)  ->  href "a.md%0B"    VT trailing : CONTENT, kept
+#: * **Leading**: a genuine strip. All six ASCII whitespace characters are dropped.
+#: * **Trailing**: a *scan terminator*. `cmark` ends the destination at the first
+#:   `{SP, TAB, LF, CR}` and then skips a WIDER separator set — including VT and FF — before the
+#:   title or the `)`. So VT/FF are content only when directly adjacent to the destination.
 #:
-#: Same for FF. A symmetric strip of all six therefore turns `[x](a.md\x0b)`, which denotes
-#: `a.md\x0b`, into `a.md` — so a link to a MISSING file is answered by an existing neighbour.
-#: A false green, in the one function this feature owns.
+#: `rstrip` cannot express that, because it stops at the first character outside its set:
 #:
-#: Both sets are ASCII, deliberately NOT `str.strip()`'s default: that removes everything Python
-#: calls whitespace, including NBSP (`\xa0`) and the ideographic space, which CommonMark keeps as
-#: ordinary characters — and NBSP is exactly what a Word or HTML paste produces.
+#:     [x](B.md\x0b)      cmark "B.md%0B"   rstrip "B.md\x0b"   agree
+#:     [x](B.md \x0b)     cmark "B.md"      rstrip "B.md \x0b"  DISAGREE -> false red
 #:
-#: Four rounds of review each closed one dimension of this rule and re-derived the next from the
-#: prose beside it. The asymmetry is the fourth, and it was caught the same way as the third: by
-#: asking the parser instead of the neighbouring rule. FR-052.
+#: Measured over every ordered pair of whitespace at each edge (121 inputs cmark parses as links):
+#: a symmetric strip agrees 93 times, `lstrip`/`rstrip` 109, terminate-at-first **121**.
+#:
+#: Five rounds of review each re-derived a character SET here and got the next one wrong. This is
+#: the first that changes the SHAPE of the rule, and it is the only formulation that reaches the
+#: parser exactly. FR-052.
 _CM_WS_LEADING = " \t\n\r\x0b\x0c"
-_CM_WS_TRAILING = " \t\n\r"
+#: Where the destination scan stops. Not a strip set: the first occurrence ends the path.
+_CM_WS_SCAN_STOP = " \t\n\r"
+
+
+def _destination(path_part: str) -> str:
+    """The destination a Markdown link denotes, per CommonMark: strip the left, cut at the right."""
+    q = path_part.lstrip(_CM_WS_LEADING)
+    cut = len(q)
+    for i, c in enumerate(q):
+        if c in _CM_WS_SCAN_STOP:
+            cut = i
+            break
+    return q[:cut]
 
 
 def _dangling_target(href: str, linking_file: Path) -> Path | None:
@@ -127,7 +142,7 @@ def _dangling_target(href: str, linking_file: Path) -> Path | None:
     # It came from borrowing FR-046/FR-047's reasoning — *"those spellings denote the same
     # destination"* — which is true of a revealed scheme or absolute path and FALSE of whitespace:
     # `%20a.md` and ` a.md` are different destinations. One clause, five documents, four rounds.
-    raw_stripped = path_part.lstrip(_CM_WS_LEADING).rstrip(_CM_WS_TRAILING)
+    raw_stripped = _destination(path_part)
     if not raw_stripped:
         return None
     decoded = unquote(raw_stripped)

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -81,18 +81,24 @@ def _dangling_target(href: str, linking_file: Path) -> Path | None:
     """
     if not is_local_relative(href):
         return None                       # FR-046: scheme, protocol-relative, absolute, bare #frag
-    # FR-052: an href that is only whitespace names no destination, so there is nothing to check.
-    # `[]()` never matched (`href` is `[^)]+`), but `[]( )` does, and resolving it yields the linking
-    # file's own directory with a blank name -- a finding whose text reads `line 5:  : target does
-    # not exist`, naming nothing the reader can go and look for.
-    if not href.strip():
-        return None
     # FR-047: `resolve_href` does not percent-decode, so `my%20file.md` resolves to a path that never
     # exists. Judging the raw spelling alone would report every percent-encoded link in a tree — the
     # kind of false positive that gets a gate switched off rather than fixed.
     path_part, _ = split_fragment(href)
     decoded = unquote(path_part)
     encoded = decoded != path_part
+    # FR-052: a path that is only whitespace names no destination, so there is nothing to check.
+    # Resolving it yields the linking file's own directory under a blank name — a finding reading
+    # `line 5:  : target does not exist`, which names nothing a reader can go and look for.
+    #
+    # This is judged on the DECODED path, after the fragment is split off, for the same reason
+    # FR-046/FR-047 are: the three spellings are the same link. Testing the raw href instead left
+    # `[](%20)` (a percent-encoded space) and `[]( #x)` (whitespace plus a fragment) still emitting
+    # the exact finding this rule forbids — and the second is worse than cosmetic, since a bare
+    # fragment must never be reported at all (FR-046), so ` #section` was a legal in-page anchor
+    # being called a dead link.
+    if not decoded.strip():
+        return None
     # Decoding can change *what kind of thing* the href is, not just how it is spelled:
     # `%2Fetc%2Fpasswd` becomes an absolute path and `http%3A//x` regains its scheme. Both pass
     # `is_local_relative` while encoded, so judging only the raw form would let the encoding walk

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -81,6 +81,12 @@ def _dangling_target(href: str, linking_file: Path) -> Path | None:
     """
     if not is_local_relative(href):
         return None                       # FR-046: scheme, protocol-relative, absolute, bare #frag
+    # FR-052: an href that is only whitespace names no destination, so there is nothing to check.
+    # `[]()` never matched (`href` is `[^)]+`), but `[]( )` does, and resolving it yields the linking
+    # file's own directory with a blank name -- a finding whose text reads `line 5:  : target does
+    # not exist`, naming nothing the reader can go and look for.
+    if not href.strip():
+        return None
     # FR-047: `resolve_href` does not percent-decode, so `my%20file.md` resolves to a path that never
     # exists. Judging the raw spelling alone would report every percent-encoded link in a tree — the
     # kind of false positive that gets a gate switched off rather than fixed.

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -87,17 +87,22 @@ def _dangling_target(href: str, linking_file: Path) -> Path | None:
     path_part, _ = split_fragment(href)
     decoded = unquote(path_part)
     encoded = decoded != path_part
-    # FR-052: a path that is only whitespace names no destination, so there is nothing to check.
-    # Resolving it yields the linking file's own directory under a blank name — a finding reading
-    # `line 5:  : target does not exist`, which names nothing a reader can go and look for.
+    # FR-052: CommonMark does not count the whitespace surrounding a link destination as part of it,
+    # so `[x]( B.md )` denotes `B.md` and `[x]( )` denotes nothing. darnlink judges both by the same
+    # rule: strip first, then decide.
     #
-    # This is judged on the DECODED path, after the fragment is split off, for the same reason
-    # FR-046/FR-047 are: the three spellings are the same link. Testing the raw href instead left
-    # `[](%20)` (a percent-encoded space) and `[]( #x)` (whitespace plus a fragment) still emitting
-    # the exact finding this rule forbids — and the second is worse than cosmetic, since a bare
-    # fragment must never be reported at all (FR-046), so ` #section` was a legal in-page anchor
-    # being called a dead link.
-    if not decoded.strip():
+    # Stripping matters twice over. A path that is *only* whitespace resolves to the linking file's
+    # own directory under a blank name, giving a finding that reads `line 5:  : target does not
+    # exist` and names nothing a reader can act on. And a path with whitespace *around* a real name
+    # resolves to `dir/ B.md ` — a file that does not exist under that spelling, so a link that
+    # renders and works was reported dead.
+    #
+    # Judged on the DECODED path with the fragment removed, for the reason FR-046/FR-047 are: those
+    # spellings denote the same destination, and a rule applied to only one of them is a rule with a
+    # way around it. Guarding the raw href alone left `[](%20)` and `[]( #x)` still emitting the
+    # finding this rule forbids, the second on a legal in-page anchor.
+    stripped = decoded.strip()
+    if not stripped:
         return None
     # Decoding can change *what kind of thing* the href is, not just how it is spelled:
     # `%2Fetc%2Fpasswd` becomes an absolute path and `http%3A//x` regains its scheme. Both pass
@@ -106,7 +111,7 @@ def _dangling_target(href: str, linking_file: Path) -> Path | None:
     # for a URL. The decoded spelling is held to the same rule as the raw one.
     if encoded and not is_local_relative(decoded):
         return None
-    t = resolve_href(href, linking_file)  # drops the fragment
+    t = resolve_href(href.strip(), linking_file)  # drops the fragment
     if t.exists():
         return None
     if encoded:

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -95,45 +95,44 @@ def _dangling_target(href: str, linking_file: Path) -> Path | None:
     # exists. Judging the raw spelling alone would report every percent-encoded link in a tree — the
     # kind of false positive that gets a gate switched off rather than fixed.
     path_part, _ = split_fragment(href)
-    decoded = unquote(path_part)
-    encoded = decoded != path_part
-    # FR-052: CommonMark does not count the whitespace surrounding a link destination as part of it,
-    # so `[x]( B.md )` denotes `B.md` and `[x]( )` denotes nothing. darnlink judges both by the same
-    # rule: strip first, then decide.
+    # FR-052: CommonMark does not count the whitespace *surrounding* a link destination as part of
+    # it, so `[x]( B.md )` denotes `B.md` and `[x]( )` denotes nothing. That whitespace is a
+    # DELIMITER, and a delimiter exists only in the source text — which is why the strip happens
+    # here, on the raw spelling, BEFORE any decoding.
     #
-    # Stripping matters twice over. A path that is *only* whitespace resolves to the linking file's
-    # own directory under a blank name, giving a finding that reads `line 5:  : target does not
-    # exist` and names nothing a reader can act on. And a path with whitespace *around* a real name
-    # resolves to `dir/ B.md ` — a file that does not exist under that spelling, so a link that
-    # renders and works was reported dead.
+    # Getting that order wrong is not a nicety; it silently changes which file the link names.
+    # Verified against the reference implementation (`cmark`):
     #
-    # Judged on the DECODED path with the fragment removed, for the reason FR-046/FR-047 are: those
-    # spellings denote the same destination, and a rule applied to only one of them is a rule with a
-    # way around it. Guarding the raw href alone left `[](%20)` and `[]( #x)` still emitting the
-    # finding this rule forbids, the second on a legal in-page anchor.
-    # `path_part` already has the fragment off, so stripping it here is the whole rule -- and every
-    # resolution below has to use these stripped forms, not the raw href. A first version computed
-    # `stripped` for the emptiness test only and then resolved `href.strip()`, which is a DIFFERENT
-    # string: `.strip()` on the raw href cannot reach a space sitting before a `#`, and the encoded
-    # branch was never stripped at all. Result: `[x]( B.md #s )` and `[x](%20B.md )` resolved to
-    # `dir/B.md ` and `dir/ B.md` and were reported dead while `B.md` sat right there. A rule is only
-    # applied where its value is used.
-    stripped = decoded.strip(_CM_WHITESPACE)
-    if not stripped:
-        return None
+    #     [x]( a.md )    ->  a.md        the spaces are delimiters, dropped
+    #     [x](%20a.md)   ->  %20a.md     the escape is CONTENT: this denotes " a.md"
+    #     [x](a.md%20)   ->  a.md%20     likewise, "a.md "
+    #
+    # A version that stripped after `unquote` turned `%20a.md` into `a.md`, so a link to a MISSING
+    # file resolved to an existing neighbour and reported clean (a false green), and where the
+    # spaced file did exist the link was reported dead pointing at the wrong path (a false red on a
+    # live file). `%20` is what every tool emits for a space, and a filename with an edge space
+    # exists in the corpus this feature was measured against.
+    #
+    # It came from borrowing FR-046/FR-047's reasoning — *"those spellings denote the same
+    # destination"* — which is true of a revealed scheme or absolute path and FALSE of whitespace:
+    # `%20a.md` and ` a.md` are different destinations. One clause, five documents, four rounds.
     raw_stripped = path_part.strip(_CM_WHITESPACE)
+    if not raw_stripped:
+        return None
+    decoded = unquote(raw_stripped)
+    encoded = decoded != raw_stripped
     # Decoding can change *what kind of thing* the href is, not just how it is spelled:
     # `%2Fetc%2Fpasswd` becomes an absolute path and `http%3A//x` regains its scheme. Both pass
     # `is_local_relative` while encoded, so judging only the raw form would let the encoding walk
     # around FR-046 — suppressing a finding because `/etc/passwd` happens to exist, or inventing one
     # for a URL. The decoded spelling is held to the same rule as the raw one.
-    if encoded and not is_local_relative(stripped):
+    if encoded and not is_local_relative(decoded):
         return None
     t = resolve_href(raw_stripped, linking_file)
     if t.exists():
         return None
     if encoded:
-        d = resolve_href(stripped, linking_file)
+        d = resolve_href(decoded, linking_file)
         # Report the DECODED path: it is the one the link denotes, and the one to look for on disk.
         return None if d.exists() else d
     return t

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -354,3 +354,21 @@ def test_whitespace_around_a_missing_destination_still_dangles(tmp_path):
 
     found = _dangling(plan_robustify(tmp_path))
     assert len(found) == 1 and "gone.md" in found[0].detail
+
+
+def test_encoded_and_fragment_spellings_of_a_real_target_are_stripped(tmp_path):
+    """FR-052 has to be applied where its value is USED, not only where it is tested.
+
+    A version of this rule computed the stripped path for the emptiness check and then resolved
+    `href.strip()` — a different string. `.strip()` on the raw href cannot reach a space sitting
+    before a `#`, and the percent-encoded branch was never stripped at all, so all three of these
+    resolved to `dir/ B.md ` or `dir/B.md ` and were reported dead while `B.md` sat right there.
+
+    A false RED on a live file is not the mirror of a false green, it is how a gate gets switched
+    off — so it is pinned per spelling, not as one case.
+    """
+    _w(tmp_path / "B.md", "# B\n")
+    for i, href in enumerate(["%20B.md ", " B.md #s", "B.md #s", " B.md "]):
+        _w(tmp_path / f"doc{i}.md", f"---\nuuid: {U_A}\n---\n\n[x]({href})\n")
+
+    assert _dangling(plan_robustify(tmp_path)) == []

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -476,3 +476,37 @@ def test_the_delimiter_set_is_asymmetric_between_the_two_edges(tmp_path):
     assert names == ["keep0.md", "keep1.md"], (
         f"the two edges were treated alike; expected only the trailing VT/FF to dangle: {names}"
     )
+
+
+def test_the_trailing_edge_is_a_terminator_not_a_strip(tmp_path):
+    """The sixth dimension of FR-052, and the first that changes the SHAPE of the rule.
+
+    Rounds 3-8 each re-derived a character *set*. This is not a set question. Per `cmark`, the
+    destination scan **ends** at the first `{SP, TAB, LF, CR}`, and a wider separator set — VT and
+    FF included — is skipped afterwards. So VT/FF are content only when *directly adjacent* to the
+    path:
+
+        [x](B.md\\x0b)   -> "B.md%0B"   the VT touches the path: content
+        [x](B.md \\x0b)  -> "B.md"      a space intervenes: the scan already stopped
+
+    `rstrip(" \\t\\n\\r")` cannot express that — it halts at the first character outside its set, so
+    it returns `B.md \\x0b` and the link is reported dead while `B.md` is on disk. Five false reds,
+    all of which the *symmetric* strip it replaced got right: that round traded one false green for
+    five false reds.
+
+    ⚠️ The previous test varies **one** whitespace character per fixture, so the correct algorithm
+    and the wrong one are indistinguishable to it. Both are needed: that one pins which characters
+    belong to each edge, this one pins that the right edge is a cut and not a trim.
+    """
+    _w(tmp_path / "B.md", "# B\n")
+    # a scan-stop followed by a VT/FF: the scan already ended, so the path is B.md and it EXISTS
+    vivos = ["B.md \x0b", "B.md \x0c", "B.md\t\x0b", "B.md\t\x0c", "B.md\r\x0b"]
+    for i, dest in enumerate(vivos):
+        _w(tmp_path / f"alive{i}.md", f"---\nuuid: {U_A}\n---\n\n[x]({dest})\n")
+    # VT touching the path: content, so the destination really is "B.md\x0b" and it does NOT exist
+    _w(tmp_path / "dead.md", f"---\nuuid: {U_A}\n---\n\n[x](B.md\x0b)\n")
+
+    found = _dangling(plan_robustify(tmp_path))
+    assert sorted(f.file.name for f in found) == ["dead.md"], (
+        f"a trailing edge was trimmed instead of cut: {[f.file.name for f in found]}"
+    )

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -244,7 +244,8 @@ def test_image_embed_with_an_empty_alt_is_reported(tmp_path):
     `MD_LINK_RE` required at least one character of link text, so a link whose text is empty did not
     match *at all*. That is the worst failure mode a gate has: the link was not reported as bad, it
     was absent, and the axis printed `dangling: 0` over a tree full of broken embeds. Regression
-    #52 — measured on one real corpus: 7 links of this shape, 7 of them broken, 0 visible.
+    #52 — measured on one real corpus in its own gate scope: 127 links with empty text, 7 of them
+    pointing at a target that does not exist, and the axis reported `dangling: 0`.
     """
     _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n![](gone.png)\n")
 
@@ -264,9 +265,9 @@ def test_pandoc_attribute_suffix_does_not_hide_the_target(tmp_path):
     """#52 reported the `{width="…"}` suffix as the cause. It is not — but it must keep working.
 
     `![alt](x){width="1.1in"}` was already visible: the regex stops at the `)` and never looks at
-    what follows. This pins the empty-alt half; the non-empty-alt half is the test below, and both
-    are needed — a wrong fix that widened the grammar to *consume* the suffix would pass this one
-    alone, since every other test in this file uses an empty alt.
+    what follows. This pins that the suffix does not hide the target; that the suffix stays OUT of
+    the match span is a separate property, and it needs a separate test — see the write case below,
+    because detection alone cannot tell the two apart.
     """
     _w(tmp_path / "doc.md", f'---\nuuid: {U_A}\n---\n\n![](gone.png){{width="1.1in"}}\n')
 
@@ -285,9 +286,8 @@ def test_a_plain_link_with_empty_text_is_reported_too(tmp_path):
 def test_a_non_empty_alt_with_the_pandoc_suffix_is_still_seen(tmp_path):
     """The other half of the suffix pin: a link WITH text and a `{…}` suffix must keep working.
 
-    Without this case, a wrong fix that widened the grammar to *consume* `{width="…"}` would pass
-    every other test in this file — they all use an empty alt, so none of them exercises the suffix
-    against a link the old regex already matched.
+    The old regex already matched this one, so it guards the direction the empty-alt cases cannot:
+    that widening the *text* did not disturb a link that was never affected.
     """
     _w(tmp_path / "doc.md", f'---\nuuid: {U_A}\n---\n\n![shot](gone.png){{width="1.1in"}}\n')
 
@@ -304,5 +304,30 @@ def test_a_whitespace_only_href_is_not_a_dangling_target(tmp_path):
     finding about the *href*.
     """
     _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[]( )\n")
+
+    assert _dangling(plan_robustify(tmp_path)) == []
+
+
+def test_a_percent_encoded_space_is_not_a_dangling_target(tmp_path):
+    """FR-052 is judged on the DECODED path: `[](%20)` is the same link as `[]( )`.
+
+    Guarding the raw href alone left this one still emitting `line 5: %20: target does not exist`,
+    the exact finding the rule forbids, because `%20` is not whitespace until it is decoded. The
+    three spellings of "no destination" have to be one rule, for the same reason FR-046 and FR-047
+    judge the decoded form.
+    """
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[](%20)\n")
+
+    assert _dangling(plan_robustify(tmp_path)) == []
+
+
+def test_whitespace_before_a_bare_fragment_is_not_a_dangling_target(tmp_path):
+    """`[x]( #section)` is a legal in-page anchor, and FR-046 says a bare fragment is never reported.
+
+    Splitting the fragment leaves a path of pure whitespace, so this is FR-052's case — but reaching
+    it requires the guard to sit *after* `split_fragment`. Before that, this was reported as a dead
+    link: not merely a cosmetic finding, a false positive on valid CommonMark.
+    """
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[x]( #section)\n")
 
     assert _dangling(plan_robustify(tmp_path)) == []

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -266,8 +266,9 @@ def test_pandoc_attribute_suffix_does_not_hide_the_target(tmp_path):
 
     `![alt](x){width="1.1in"}` was already visible: the regex stops at the `)` and never looks at
     what follows. This pins that the suffix does not hide the target; that the suffix stays OUT of
-    the match span is a separate property, and it needs a separate test — see the write case below,
-    because detection alone cannot tell the two apart.
+    the match span is a separate property, and it needs a separate test — see
+    `test_robustify.test_write_leaves_any_pandoc_attribute_suffix_untouched`, because detection
+    alone cannot tell the two apart.
     """
     _w(tmp_path / "doc.md", f'---\nuuid: {U_A}\n---\n\n![](gone.png){{width="1.1in"}}\n')
 
@@ -331,3 +332,25 @@ def test_whitespace_before_a_bare_fragment_is_not_a_dangling_target(tmp_path):
     _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[x]( #section)\n")
 
     assert _dangling(plan_robustify(tmp_path)) == []
+
+
+def test_whitespace_around_a_real_destination_is_stripped(tmp_path):
+    """FR-052: CommonMark does not count the whitespace around a destination as part of it.
+
+    `[x]( B.md )` denotes `B.md`. Judging it literally resolves to `dir/ B.md `, which exists under
+    no spelling, so a link that renders and works was reported dead. This is the same rule as the
+    empty case — `[x]( )` denotes nothing, `[x]( B.md )` denotes `B.md` — and an earlier version
+    closed only the first half while the spec argued for both.
+    """
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[x]( B.md )\n")
+    _w(tmp_path / "B.md", "# B\n")
+
+    assert _dangling(plan_robustify(tmp_path)) == []
+
+
+def test_whitespace_around_a_missing_destination_still_dangles(tmp_path):
+    """The other half: stripping must not swallow the finding, only the spelling."""
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[x]( gone.md )\n")
+
+    found = _dangling(plan_robustify(tmp_path))
+    assert len(found) == 1 and "gone.md" in found[0].detail

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -317,15 +317,27 @@ def test_a_percent_encoded_space_is_content_not_a_delimiter(tmp_path):
     (`cmark`), which emits `href="%20"` here and `href="a.md"` for `[x]( a.md )` — it strips the one
     and keeps the other.
 
-    So `[](%20)` denotes a file literally named `" "`, and when that file is absent the link is dead
-    like any other. The version of this test that asserted "clean" was pinning a **false green**:
-    with the strip applied after decoding, `[x](%20a.md)` resolved to `a.md`, so a link to a missing
-    file was silently answered by an existing neighbour.
+    The version of this test that asserted "clean" was pinning a **false green**: with the strip
+    applied after decoding, `[x](%20x.md)` resolved to `x.md`, so a link to a missing file was
+    silently answered by an existing neighbour.
+
+    Both spellings are in one fixture so the *contrast* is what is pinned, not two separate facts.
+
+    ⚠️ The obvious fixture — a bare `[](%20)`, destination `" "` — is **not** used, and the reason is
+    worth writing down: Windows trims trailing spaces from a path component, so `dir/ ` normalises to
+    `dir`, which exists, and the link is not dangling **there**. That is the filesystem's answer, not
+    darnlink's, and this axis exists to ask the filesystem. A platform-dependent fixture would have
+    pinned Linux's answer as if it were the rule. It was caught by the Windows matrix in CI, not
+    here.
     """
-    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[](%20)\n")
+    _w(tmp_path / "x.md", "# x\n")                                   # the neighbour, present
+    _w(tmp_path / "kept.md", f"---\nuuid: {U_A}\n---\n\n[a](%20x.md)\n")   # escape: content
+    _w(tmp_path / "gone.md", f"---\nuuid: {U_A}\n---\n\n[b]( x.md )\n")    # literal: delimiter
 
     found = _dangling(plan_robustify(tmp_path))
-    assert len(found) == 1 and "%20" in found[0].detail
+    assert len(found) == 1, f"the two spellings were conflated: {found}"
+    assert "%20x.md" in found[0].detail          # the encoded one is dead: it denotes " x.md"
+    assert found[0].file == tmp_path / "kept.md"  # …and the literal one is not
 
 
 def test_an_encoded_space_names_a_different_file_from_a_literal_one(tmp_path):
@@ -344,8 +356,11 @@ def test_an_encoded_space_names_a_different_file_from_a_literal_one(tmp_path):
 
     found = _dangling(plan_robustify(tmp_path / "one"))
     assert len(found) == 1, f"an encoded space was treated as a delimiter: {found}"
-    assert "%20a.md" in found[0].detail                      # the link as written
-    assert found[0].detail.rstrip(") ").endswith("/ a.md")   # the path it really denotes
+    assert "%20a.md" in found[0].detail                       # the link as written
+    # The path it really denotes. Built from `Path`, not spelled with a `/`: the detail carries a
+    # native path, so a hard-coded separator passes on Linux and fails on Windows — which is what
+    # the CI matrix caught here.
+    assert str(tmp_path / "one" / " a.md") in found[0].detail
 
 
 def test_whitespace_before_a_bare_fragment_is_not_a_dangling_target(tmp_path):

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -439,19 +439,40 @@ def test_only_ascii_whitespace_is_stripped_from_a_destination(tmp_path):
     assert len(found) == 3, f"a non-ASCII space was treated as whitespace: {found}"
 
 
-def test_every_character_of_the_commonmark_whitespace_set_is_stripped(tmp_path):
-    """All six, one file each — because a set is a claim about six characters, not about one.
+def test_the_delimiter_set_is_asymmetric_between_the_two_edges(tmp_path):
+    """VT and FF delimit a destination on the LEFT and are content on the RIGHT. Per `cmark`:
 
-    Only the space was exercised, so dropping `\\t`, `\\r`, `\\x0b` or `\\x0c` from the constant left
-    the suite green. VT and FF are the surprising members and the easiest to "tidy away"; they are
-    in CommonMark's definition, verified against the reference implementation, so they are pinned
-    here rather than defended in a comment.
+        [x](\\x0bB.md)  ->  href "B.md"       leading  : delimiter
+        [x](B.md\\x0b)  ->  href "B.md%0B"    trailing : content
 
-    Uses a NON-newline set only where a newline could not appear inside a link destination anyway.
+    So a symmetric strip of all six is a **false green**: `[x](B.md\\x0b)` denotes `B.md\\x0b`, and
+    stripping the VT resolves it to `B.md`, which exists — a link to a missing file answered by an
+    existing neighbour.
+
+    ⚠️ The first version of this test asserted the symmetric behaviour and its docstring claimed it
+    was *"verified against the reference implementation"*. It was not: the `%20` half of this rule
+    was adjudicated against `cmark`, and this half was re-derived from the spec prose next to it —
+    the exact substitution the commit that wrote it had just forbidden. Naming that here because a
+    test that asserts a falsehood *while citing a verification* is worse than one with no rationale
+    at all: it stops the next reader from checking.
+
+    LF is absent from the fixture on purpose: a raw newline cannot occur inside a `(...)`
+    destination, so a test using one would pin behaviour on input the grammar never produces.
     """
     _w(tmp_path / "B.md", "# B\n")
-    for i, ws in enumerate([" ", "\t", "\r", "\x0b", "\x0c"]):
-        _w(tmp_path / f"doc{i}.md", f"---\nuuid: {U_A}\n---\n\n[x]({ws}B.md{ws})\n")
+    leading = [" ", "\t", "\r", "\x0b", "\x0c"]
+    trailing_delims = [" ", "\t", "\r"]
+    trailing_content = ["\x0b", "\x0c"]
+
+    for i, ws in enumerate(leading):
+        _w(tmp_path / f"lead{i}.md", f"---\nuuid: {U_A}\n---\n\n[x]({ws}B.md)\n")
+    for i, ws in enumerate(trailing_delims):
+        _w(tmp_path / f"tail{i}.md", f"---\nuuid: {U_A}\n---\n\n[x](B.md{ws})\n")
+    for i, ws in enumerate(trailing_content):
+        _w(tmp_path / f"keep{i}.md", f"---\nuuid: {U_A}\n---\n\n[x](B.md{ws})\n")
 
     found = _dangling(plan_robustify(tmp_path))
-    assert found == [], f"a CommonMark whitespace character was kept as part of the path: {found}"
+    names = sorted(f.file.name for f in found)
+    assert names == ["keep0.md", "keep1.md"], (
+        f"the two edges were treated alike; expected only the trailing VT/FF to dangle: {names}"
+    )

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -264,8 +264,9 @@ def test_pandoc_attribute_suffix_does_not_hide_the_target(tmp_path):
     """#52 reported the `{width="…"}` suffix as the cause. It is not — but it must keep working.
 
     `![alt](x){width="1.1in"}` was already visible: the regex stops at the `)` and never looks at
-    what follows. Both halves are pinned here so the true cause (the empty alt) cannot be re-fixed
-    later by someone reaching for the suffix instead.
+    what follows. This pins the empty-alt half; the non-empty-alt half is the test below, and both
+    are needed — a wrong fix that widened the grammar to *consume* the suffix would pass this one
+    alone, since every other test in this file uses an empty alt.
     """
     _w(tmp_path / "doc.md", f'---\nuuid: {U_A}\n---\n\n![](gone.png){{width="1.1in"}}\n')
 
@@ -279,3 +280,29 @@ def test_a_plain_link_with_empty_text_is_reported_too(tmp_path):
 
     found = _dangling(plan_robustify(tmp_path))
     assert len(found) == 1 and "gone.md" in found[0].detail
+
+
+def test_a_non_empty_alt_with_the_pandoc_suffix_is_still_seen(tmp_path):
+    """The other half of the suffix pin: a link WITH text and a `{…}` suffix must keep working.
+
+    Without this case, a wrong fix that widened the grammar to *consume* `{width="…"}` would pass
+    every other test in this file — they all use an empty alt, so none of them exercises the suffix
+    against a link the old regex already matched.
+    """
+    _w(tmp_path / "doc.md", f'---\nuuid: {U_A}\n---\n\n![shot](gone.png){{width="1.1in"}}\n')
+
+    found = _dangling(plan_robustify(tmp_path))
+    assert len(found) == 1 and "gone.png" in found[0].detail
+
+
+def test_a_whitespace_only_href_is_not_a_dangling_target(tmp_path):
+    """FR-052: `[]( )` names no destination, so there is nothing to check.
+
+    `[]()` never matched (`href` is `[^)]+`) but `[]( )` does, and resolving it gives the linking
+    file's own directory with a blank name — a finding reading `line 5:  : target does not exist`,
+    which names nothing anyone can go and look for. Widening the *text* must not smuggle in a
+    finding about the *href*.
+    """
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[]( )\n")
+
+    assert _dangling(plan_robustify(tmp_path)) == []

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -309,17 +309,43 @@ def test_a_whitespace_only_href_is_not_a_dangling_target(tmp_path):
     assert _dangling(plan_robustify(tmp_path)) == []
 
 
-def test_a_percent_encoded_space_is_not_a_dangling_target(tmp_path):
-    """FR-052 is judged on the DECODED path: `[](%20)` is the same link as `[]( )`.
+def test_a_percent_encoded_space_is_content_not_a_delimiter(tmp_path):
+    """`[](%20)` is NOT the same link as `[]( )` — and an earlier version of this test said it was.
 
-    Guarding the raw href alone left this one still emitting `line 5: %20: target does not exist`,
-    the exact finding the rule forbids, because `%20` is not whitespace until it is decoded. The
-    three spellings of "no destination" have to be one rule, for the same reason FR-046 and FR-047
-    judge the decoded form.
+    FR-052 drops the whitespace that *delimits* a destination, and a delimiter exists only in the
+    source. `%20` is an escape: it is content. Verified against the reference implementation
+    (`cmark`), which emits `href="%20"` here and `href="a.md"` for `[x]( a.md )` — it strips the one
+    and keeps the other.
+
+    So `[](%20)` denotes a file literally named `" "`, and when that file is absent the link is dead
+    like any other. The version of this test that asserted "clean" was pinning a **false green**:
+    with the strip applied after decoding, `[x](%20a.md)` resolved to `a.md`, so a link to a missing
+    file was silently answered by an existing neighbour.
     """
     _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[](%20)\n")
 
-    assert _dangling(plan_robustify(tmp_path)) == []
+    found = _dangling(plan_robustify(tmp_path))
+    assert len(found) == 1 and "%20" in found[0].detail
+
+
+def test_an_encoded_space_names_a_different_file_from_a_literal_one(tmp_path):
+    """The false green and the false red of the same defect, pinned as one pair.
+
+    `a.md` exists; `[x](%20a.md)` denotes `" a.md"`, which does not. Stripping after decoding made
+    the first answer the second — clean over a broken link. And with `" a.md"` present instead, the
+    same bug reported the link dead while naming `a.md`, a path the link never had: a false red on a
+    live file, pointing the reader at the wrong neighbour.
+
+    Reaches the encoded branch specifically. The literal-`\\xa0` test above cannot: with no escape in
+    the href the decoded and raw forms are identical, so half of this function is never exercised.
+    """
+    _w(tmp_path / "one" / "a.md", "# a\n")
+    _w(tmp_path / "one" / "doc.md", f"---\nuuid: {U_A}\n---\n\n[x](%20a.md)\n")
+
+    found = _dangling(plan_robustify(tmp_path / "one"))
+    assert len(found) == 1, f"an encoded space was treated as a delimiter: {found}"
+    assert "%20a.md" in found[0].detail                      # the link as written
+    assert found[0].detail.rstrip(") ").endswith("/ a.md")   # the path it really denotes
 
 
 def test_whitespace_before_a_bare_fragment_is_not_a_dangling_target(tmp_path):
@@ -361,14 +387,19 @@ def test_encoded_and_fragment_spellings_of_a_real_target_are_stripped(tmp_path):
 
     A version of this rule computed the stripped path for the emptiness check and then resolved
     `href.strip()` — a different string. `.strip()` on the raw href cannot reach a space sitting
-    before a `#`, and the percent-encoded branch was never stripped at all, so all three of these
-    resolved to `dir/ B.md ` or `dir/B.md ` and were reported dead while `B.md` sat right there.
+    before a `#`, so these resolved to `dir/B.md ` and were reported dead while `B.md` sat there.
 
     A false RED on a live file is not the mirror of a false green, it is how a gate gets switched
     off — so it is pinned per spelling, not as one case.
+
+    ⚠️ `%20B.md ` was in this list and has been **removed**, because listing it here was itself the
+    defect. Its trailing space is a delimiter and goes; its `%20` is content and stays, so the link
+    denotes `" B.md"` and is dead when only `B.md` exists. Asserting it clean pinned a false green —
+    a test enforcing the bug it was written to prevent. It now lives in
+    `test_an_encoded_space_names_a_different_file_from_a_literal_one`, asserting the opposite.
     """
     _w(tmp_path / "B.md", "# B\n")
-    for i, href in enumerate(["%20B.md ", " B.md #s", "B.md #s", " B.md "]):
+    for i, href in enumerate([" B.md #s", "B.md #s", " B.md "]):
         _w(tmp_path / f"doc{i}.md", f"---\nuuid: {U_A}\n---\n\n[x]({href})\n")
 
     assert _dangling(plan_robustify(tmp_path)) == []
@@ -391,3 +422,21 @@ def test_only_ascii_whitespace_is_stripped_from_a_destination(tmp_path):
 
     found = _dangling(plan_robustify(tmp_path))
     assert len(found) == 3, f"a non-ASCII space was treated as whitespace: {found}"
+
+
+def test_every_character_of_the_commonmark_whitespace_set_is_stripped(tmp_path):
+    """All six, one file each — because a set is a claim about six characters, not about one.
+
+    Only the space was exercised, so dropping `\\t`, `\\r`, `\\x0b` or `\\x0c` from the constant left
+    the suite green. VT and FF are the surprising members and the easiest to "tidy away"; they are
+    in CommonMark's definition, verified against the reference implementation, so they are pinned
+    here rather than defended in a comment.
+
+    Uses a NON-newline set only where a newline could not appear inside a link destination anyway.
+    """
+    _w(tmp_path / "B.md", "# B\n")
+    for i, ws in enumerate([" ", "\t", "\r", "\x0b", "\x0c"]):
+        _w(tmp_path / f"doc{i}.md", f"---\nuuid: {U_A}\n---\n\n[x]({ws}B.md{ws})\n")
+
+    found = _dangling(plan_robustify(tmp_path))
+    assert found == [], f"a CommonMark whitespace character was kept as part of the path: {found}"

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -236,3 +236,46 @@ def test_missing_encoded_path_reports_the_decoded_target(tmp_path):
     assert len(found) == 1
     assert "my missing file.md" in found[0].detail   # decoded, not %20
     assert "my%20missing%20file.md" in found[0].detail  # and the link as written
+
+
+def test_image_embed_with_an_empty_alt_is_reported(tmp_path):
+    """FR-051: `![](gone.png)` — the shape pandoc emits for every image in a converted .docx/.odt.
+
+    `MD_LINK_RE` required at least one character of link text, so a link whose text is empty did not
+    match *at all*. That is the worst failure mode a gate has: the link was not reported as bad, it
+    was absent, and the axis printed `dangling: 0` over a tree full of broken embeds. Regression
+    #52 — measured on one real corpus: 7 links of this shape, 7 of them broken, 0 visible.
+    """
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n![](gone.png)\n")
+
+    found = _dangling(plan_robustify(tmp_path))
+    assert len(found) == 1 and "gone.png" in found[0].detail
+
+
+def test_empty_alt_image_that_exists_is_not_reported(tmp_path):
+    """The other half of the pin: widening the regex must not invent findings."""
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n![](there.png)\n")
+    _w(tmp_path / "there.png", "bytes\n")
+
+    assert _dangling(plan_robustify(tmp_path)) == []
+
+
+def test_pandoc_attribute_suffix_does_not_hide_the_target(tmp_path):
+    """#52 reported the `{width="…"}` suffix as the cause. It is not — but it must keep working.
+
+    `![alt](x){width="1.1in"}` was already visible: the regex stops at the `)` and never looks at
+    what follows. Both halves are pinned here so the true cause (the empty alt) cannot be re-fixed
+    later by someone reaching for the suffix instead.
+    """
+    _w(tmp_path / "doc.md", f'---\nuuid: {U_A}\n---\n\n![](gone.png){{width="1.1in"}}\n')
+
+    found = _dangling(plan_robustify(tmp_path))
+    assert len(found) == 1 and "gone.png" in found[0].detail
+
+
+def test_a_plain_link_with_empty_text_is_reported_too(tmp_path):
+    """Not an image-only bug: `[](gone.md)` was equally invisible, and is a link like any other."""
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[](gone.md)\n")
+
+    found = _dangling(plan_robustify(tmp_path))
+    assert len(found) == 1 and "gone.md" in found[0].detail

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -372,3 +372,22 @@ def test_encoded_and_fragment_spellings_of_a_real_target_are_stripped(tmp_path):
         _w(tmp_path / f"doc{i}.md", f"---\nuuid: {U_A}\n---\n\n[x]({href})\n")
 
     assert _dangling(plan_robustify(tmp_path)) == []
+
+
+def test_only_ascii_whitespace_is_stripped_from_a_destination(tmp_path):
+    """FR-052 strips CommonMark whitespace, which is ASCII. `\\xa0` is an ordinary character.
+
+    `str.strip()` removes everything Python calls whitespace — NBSP, the ideographic space, and
+    ~20 more — but CommonMark counts only space, tab, LF, VT, FF and CR. A file really can be named
+    `\\xa0a.md`, so stripping the NBSP made a link to a MISSING file resolve to an existing
+    neighbour and report **clean**: a false green, in the function this feature owns.
+
+    Not academic: NBSP is what a Word or HTML paste produces, which is the same corpus of converted
+    documents that motivated the whole feature.
+    """
+    _w(tmp_path / "a.md", "# a\n")          # exists — the neighbour a bare .strip() would find
+    for i, href in enumerate(["\xa0a.md", "\u3000a.md", "a.md\xa0"]):
+        _w(tmp_path / f"doc{i}.md", f"---\nuuid: {U_A}\n---\n\n[x]({href})\n")
+
+    found = _dangling(plan_robustify(tmp_path))
+    assert len(found) == 3, f"a non-ASCII space was treated as whitespace: {found}"

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -151,9 +151,12 @@ def test_an_empty_text_image_anchor_is_robust_not_plain():
 def test_emit_round_trips_an_empty_text_link():
     """`emit_robust_link("")` must produce a link the grammar reads back identically.
 
-    The `!` of an image embed sits outside the match span, so a rewrite must leave it in place: an
-    emitter that dropped it would silently turn every repaired image into a text link.
+    Scope, stated because an earlier version of this test overreached: this is emit → parse for an
+    empty text, nothing more. Whether a *rewrite* keeps the `!` of an embed is span arithmetic in
+    `robustify`, which this never calls — it lives in
+    `test_robustify.test_write_preserves_the_bang_of_an_image_embed`.
     """
     out = emit_robust_link("", "new/B.md", U)
-    back = find_robust_links(f"![{out[1:]}" if out.startswith("[") else out)
+    assert out.startswith("[](")
+    back = find_robust_links(out)
     assert len(back) == 1 and back[0].href == "new/B.md" and back[0].text == ""

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -124,3 +124,36 @@ def test_file_is_ignored_marker_inside_code_does_not_count():
     inline = "Use `<!-- darnlink-ignore-file -->` to opt out.\n"
     assert not file_is_ignored(fenced)
     assert not file_is_ignored(inline)
+
+
+def test_detects_a_robust_link_whose_text_is_empty():
+    """FR-051: `ROBUST_LINK_RE` widens with `MD_LINK_RE`, and that coupling needs its own test.
+
+    Reverting only the robust half leaves every dangling test green — measured — because those go
+    through `find_plain_links`. If the two disagree, an anchored `[](x) <!-- uuid: … -->` is plain to
+    one function and robust to the other: `find_plain_links` skips it (it sees the trailing anchor)
+    while `find_robust_links` never sees it, so its uuid drops out of the repair axis entirely and
+    a moved target stops being healed. That is a false green in `repair`, not in `dangling`.
+    """
+    c = f"x [](old/B.md) <!-- uuid: {U} --> y"
+    links = find_robust_links(c)
+    assert len(links) == 1
+    assert links[0].text == "" and links[0].href == "old/B.md" and links[0].uuid == U
+
+
+def test_an_empty_text_image_anchor_is_robust_not_plain():
+    """The two finders must agree on the same input — the invariant the coupling exists to hold."""
+    c = f"![](media/photo.jpg) <!-- uuid: {U} -->"
+    assert len(find_robust_links(c)) == 1
+    assert find_plain_links(c) == []
+
+
+def test_emit_round_trips_an_empty_text_link():
+    """`emit_robust_link("")` must produce a link the grammar reads back identically.
+
+    The `!` of an image embed sits outside the match span, so a rewrite must leave it in place: an
+    emitter that dropped it would silently turn every repaired image into a text link.
+    """
+    out = emit_robust_link("", "new/B.md", U)
+    back = find_robust_links(f"![{out[1:]}" if out.startswith("[") else out)
+    assert len(back) == 1 and back[0].href == "new/B.md" and back[0].text == ""

--- a/tests/test_robustify.py
+++ b/tests/test_robustify.py
@@ -219,3 +219,39 @@ def test_robustify_ignored_target_gets_no_uuid(tmp_path):
     assert (tmp_path / "A.md").read_text() == "see [G](G.md)\n"  # link left plain
     # a link to an ignored target must NOT be reported as no_frontmatter (misleading)
     assert not any(fi.kind is Kind.NO_FRONTMATTER for fi in result.findings)
+
+
+def test_write_preserves_the_bang_of_an_image_embed(tmp_path):
+    """FR-051: the widening routes empty-alt embeds into the WRITE path for the first time.
+
+    The `!` sits outside the match span, so a rewrite must leave it in place. Detection cannot pin
+    this — the finding looks identical either way — and a rewrite that swallowed it would silently
+    turn every repaired image into a text link, which renders as a filename instead of a picture.
+    Seeded before writing this: an emitter that consumes the `!` leaves the whole suite green.
+    """
+    _w(tmp_path / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
+    _w(tmp_path / "A.md", "![](B.md)\n")
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    a = (tmp_path / "A.md").read_text()
+    assert a.startswith("!"), f"the image embed lost its bang: {a!r}"
+    links = find_robust_links(a)
+    assert len(links) == 1 and links[0].href == "B.md" and links[0].text == ""
+
+
+def test_write_leaves_a_pandoc_attribute_suffix_untouched(tmp_path):
+    """The suffix must stay OUT of the match span, and only a write can prove it.
+
+    #52 blamed `{width="…"}` for hiding the link. The fix must not "help" by consuming the suffix:
+    a regex ending `\\)(?:\\{[^}]*\\})?` passes every detection test in the suite — measured, all
+    260 of them — while `--write` silently **deletes the attributes** from the document. Detection
+    reports the same finding either way, so this is the only place the difference is observable.
+    """
+    _w(tmp_path / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
+    _w(tmp_path / "A.md", '![](B.md){width="1.1in" height="2in"}\n')
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    a = (tmp_path / "A.md").read_text()
+    assert 'width="1.1in"' in a and 'height="2in"' in a, f"attributes were eaten: {a!r}"

--- a/tests/test_robustify.py
+++ b/tests/test_robustify.py
@@ -235,13 +235,14 @@ def test_write_preserves_the_bang_of_an_image_embed(tmp_path):
     apply_robustify(plan_robustify(tmp_path))
 
     a = (tmp_path / "A.md").read_text()
-    # Assert the `!` is still attached to THIS link, not merely present somewhere on the line:
-    # the emitted anchor `<!-- uuid: … -->` contains a `!`, so `"!" in a` is true even when the
-    # embed's own bang has been eaten, and `a.startswith("!")` only holds while the fixture happens
-    # to begin with the link. Both are green under a seed that swallows it.
-    assert "![](B.md)" in a, f"the image embed lost its bang: {a!r}"
+    # Assert the WHOLE line, because every weaker form is satisfiable while the behaviour is wrong:
+    # `"!" in a` is true from the anchor's own `<!--`; `a.startswith("!")` only holds while the
+    # fixture begins with the link; and `"![](B.md)" in a` is satisfied by `!![](B.md)`, which is
+    # what an emitter that adds a bang unconditionally would produce. The fixture is deterministic
+    # apart from the uuid, so there is no reason to assert anything less than the output.
     links = find_robust_links(a)
     assert len(links) == 1 and links[0].href == "B.md" and links[0].text == ""
+    assert a == f"see ![](B.md) <!-- uuid: {EXISTING} --> here\n", f"unexpected rewrite: {a!r}"
 
 
 def test_write_leaves_any_pandoc_attribute_suffix_untouched(tmp_path):
@@ -259,12 +260,70 @@ def test_write_leaves_any_pandoc_attribute_suffix_untouched(tmp_path):
     fixture is a claim about a population, and a single sample is the weakest possible one.
     """
     shapes = ['{width="1.1in" height="2in"}', "{.cls}", "{#anchor}", '{.a .b key="v"}']
+    # Vary the LINK TEXT as well as the attribute shape. A version of this test that used an empty
+    # alt throughout was defeated by a seed that ate the block only when the text is non-empty —
+    # 266/266 green while `![alt text](B.md){width=…}` lost its attributes. The text is the axis
+    # this whole feature is about, so it is the last one that should have been held constant.
+    texts = ["", "alt text", "x"]
     _w(tmp_path / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
-    for i, suffix in enumerate(shapes):
-        _w(tmp_path / f"A{i}.md", f"![](B.md){suffix}\n")
+    cases = [(t, s) for t in texts for s in shapes]
+    for i, (text, suffix) in enumerate(cases):
+        _w(tmp_path / f"A{i}.md", f"![{text}](B.md){suffix}\n")
 
     apply_robustify(plan_robustify(tmp_path))
 
-    for i, suffix in enumerate(shapes):
+    for i, (text, suffix) in enumerate(cases):
         a = (tmp_path / f"A{i}.md").read_text()
-        assert suffix in a, f"attribute block {suffix!r} was eaten: {a!r}"
+        assert suffix in a, f"attribute block {suffix!r} was eaten after text {text!r}: {a!r}"
+
+
+def test_repair_write_leaves_a_pandoc_attribute_suffix_untouched(tmp_path):
+    """`ROBUST_LINK_RE` widened too, and it has its OWN write path: `repair`.
+
+    Two regexes were widened and two write paths exist, but only `robustify`'s was guarded. Seeding
+    `\\)(?:\\{[^}]*\\})?` into `ROBUST_LINK_RE` passes the whole suite while `repair --write` moves
+    the link and **deletes the attribute block on the way** — the same corruption as the robustify
+    case, reached through the other door. Round 1 found this half untested for *detection*; its
+    write side stayed untested two rounds longer.
+    """
+    from darnlink.frontmatter_index import build_index
+    from darnlink.repair import plan_repairs, apply_repairs
+
+    # The anchor goes BEFORE the attribute block, because that is where darnlink's own `--write`
+    # puts it (see #65). Writing it the way a human would — `![](x){.cls} <!-- uuid: … -->` — does
+    # not even match `ROBUST_LINK_RE`, which requires the comment to follow the `)` with only
+    # whitespace between; such a link is plain with a detached anchor, and is not this test's case.
+    _w(tmp_path / "new" / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
+    _w(tmp_path / "A.md", f'![](old/B.md) <!-- uuid: {EXISTING} -->{{width="1.1in"}}\n')
+
+    apply_repairs(plan_repairs(tmp_path, build_index(tmp_path)))
+
+    a = (tmp_path / "A.md").read_text()
+    assert "new/B.md" in a, f"repair did not move the link: {a!r}"
+    assert 'width="1.1in"' in a, f"repair ate the attribute block: {a!r}"
+
+
+def test_an_attribute_block_before_the_anchor_is_not_a_robust_link(tmp_path):
+    """The span boundary of `ROBUST_LINK_RE`, pinned where a seed can reach it.
+
+    `![](x){.cls} <!-- uuid: … -->` — attributes between the `)` and the comment — is NOT robust:
+    the grammar allows only whitespace there, so this is a plain link with a detached anchor, and
+    `repair` must leave the file alone. Seeding `\\)(?:\\{[^}]*\\})?` into `ROBUST_LINK_RE` makes it
+    robust, and `repair --write` then rewrites the link and **deletes the block**.
+
+    The sibling test above cannot catch that seed: its fixture puts the block *after* the comment,
+    where the seeded alternative never matches. Two shapes, two tests — the first version of this
+    pair guarded only the shape the seed does not touch, which is no guard at all.
+    """
+    from darnlink.frontmatter_index import build_index
+    from darnlink.repair import plan_repairs, apply_repairs
+
+    _w(tmp_path / "new" / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
+    original = f'![](old/B.md){{width="1.1in"}} <!-- uuid: {EXISTING} -->\n'
+    _w(tmp_path / "A.md", original)
+
+    assert find_robust_links(original) == []
+
+    apply_repairs(plan_repairs(tmp_path, build_index(tmp_path)))
+
+    assert (tmp_path / "A.md").read_text() == original

--- a/tests/test_robustify.py
+++ b/tests/test_robustify.py
@@ -340,15 +340,39 @@ def test_absorbing_a_stray_anchor_does_not_eat_an_attribute_block(tmp_path):
     `![](B.md) <!-- uuid: X -->{.cls` : the block silently becomes prose.
 
     Attribute-block tests exist and detached-anchor tests exist; **no fixture combined them**, so
-    the deletion boundary had no guard at all. Seeded (a `_hspace_start` that steps over `}`) it
-    passes the whole suite. This is the last unguarded write path in the module.
+    the deletion boundary had no guard at all.
+
+    Asserts the whole line, and the reason is not style. The first version of this test used
+    `"{.cls}" in a` plus an anchor count, and **three** distinct corruptions of this exact splice
+    walked through it: an end offset one too high (eats the final newline — a document character in
+    any line with prose after the anchor), one too low (leaves a literal `>` in the document), and a
+    boundary that does not walk back at all (leaves a trailing space). The sibling repair test was
+    rewritten in the very commit that added this one, for exactly this reason; writing the weak form
+    here reintroduced the defect one test below its own fix.
     """
     _w(tmp_path / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
-    original = f"![](B.md){{.cls}} <!-- uuid: {EXISTING} -->\n"
-    _w(tmp_path / "A.md", original)
+    _w(tmp_path / "A.md", f"![](B.md){{.cls}} <!-- uuid: {EXISTING} -->\n")
 
     apply_robustify(plan_robustify(tmp_path))
 
     a = (tmp_path / "A.md").read_text()
-    assert "{.cls}" in a, f"the attribute block lost a brace: {a!r}"
-    assert a.count("<!-- uuid:") == 1, f"the stray was duplicated rather than absorbed: {a!r}"
+    assert a == f"![](B.md) <!-- uuid: {EXISTING} -->{{.cls}}\n", f"bad rewrite: {a!r}"
+
+
+def test_absorbing_a_stray_does_not_eat_a_closing_paren_of_prose(tmp_path):
+    """Same deletion boundary, the other character it could walk back over.
+
+    `(see [x](B.md)) <!-- uuid: X -->` — the comment follows the *parenthetical's* `)`, not the
+    link's, so it is a stray and the absorb path runs. A boundary that walks back over `)` as well
+    as whitespace deletes a character of the author's prose and leaves `(see [x](B.md)` unbalanced.
+
+    The sibling fixture cannot reach this: its attribute block sits between the link and the space,
+    so no `)` is ever adjacent to the boundary. One shape per character the walk-back could eat.
+    """
+    _w(tmp_path / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
+    _w(tmp_path / "A.md", f"(see [x](B.md)) <!-- uuid: {EXISTING} -->\n")
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    a = (tmp_path / "A.md").read_text()
+    assert a == f"(see [x](B.md) <!-- uuid: {EXISTING} -->)\n", f"bad rewrite: {a!r}"

--- a/tests/test_robustify.py
+++ b/tests/test_robustify.py
@@ -280,11 +280,11 @@ def test_write_leaves_any_pandoc_attribute_suffix_untouched(tmp_path):
 def test_repair_write_leaves_a_pandoc_attribute_suffix_untouched(tmp_path):
     """`ROBUST_LINK_RE` widened too, and it has its OWN write path: `repair`.
 
-    Two regexes were widened and two write paths exist, but only `robustify`'s was guarded. Seeding
-    `\\)(?:\\{[^}]*\\})?` into `ROBUST_LINK_RE` passes the whole suite while `repair --write` moves
-    the link and **deletes the attribute block on the way** — the same corruption as the robustify
-    case, reached through the other door. Round 1 found this half untested for *detection*; its
-    write side stayed untested two rounds longer.
+    Two regexes were widened and two write paths exist, but only `robustify`'s was guarded. This
+    pins that `repair` rewrites the href and leaves everything after the anchor byte-for-byte —
+    a splice whose end offset is one character off deletes the `{`, and the block stops being a
+    block. The shape where the attributes sit *before* the anchor is the sibling test below; the
+    two seeds are different and neither test catches the other's.
     """
     from darnlink.frontmatter_index import build_index
     from darnlink.repair import plan_repairs, apply_repairs
@@ -298,9 +298,11 @@ def test_repair_write_leaves_a_pandoc_attribute_suffix_untouched(tmp_path):
 
     apply_repairs(plan_repairs(tmp_path, build_index(tmp_path)))
 
+    # Assert the whole line. `'width="1.1in"' in a` is satisfied by `…-->width="1.1in"}` — the
+    # brace eaten and the block silently demoted to prose — which is exactly the splice-off-by-one
+    # this test exists to catch. Its sibling asserts `== original` for the same reason.
     a = (tmp_path / "A.md").read_text()
-    assert "new/B.md" in a, f"repair did not move the link: {a!r}"
-    assert 'width="1.1in"' in a, f"repair ate the attribute block: {a!r}"
+    assert a == f'![](new/B.md) <!-- uuid: {EXISTING} -->{{width="1.1in"}}\n', f"bad rewrite: {a!r}"
 
 
 def test_an_attribute_block_before_the_anchor_is_not_a_robust_link(tmp_path):
@@ -327,3 +329,26 @@ def test_an_attribute_block_before_the_anchor_is_not_a_robust_link(tmp_path):
     apply_repairs(plan_repairs(tmp_path, build_index(tmp_path)))
 
     assert (tmp_path / "A.md").read_text() == original
+
+
+def test_absorbing_a_stray_anchor_does_not_eat_an_attribute_block(tmp_path):
+    """The one place `robustify` DELETES text, guarded where the two features meet.
+
+    When a link is followed by a stray uuid comment, robustify absorbs it: it removes the stray and
+    re-emits the link anchored. Removing means walking back over the whitespace before the comment
+    — and a boundary that also walks over `}` eats the closing brace of an attribute block, leaving
+    `![](B.md) <!-- uuid: X -->{.cls` : the block silently becomes prose.
+
+    Attribute-block tests exist and detached-anchor tests exist; **no fixture combined them**, so
+    the deletion boundary had no guard at all. Seeded (a `_hspace_start` that steps over `}`) it
+    passes the whole suite. This is the last unguarded write path in the module.
+    """
+    _w(tmp_path / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
+    original = f"![](B.md){{.cls}} <!-- uuid: {EXISTING} -->\n"
+    _w(tmp_path / "A.md", original)
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    a = (tmp_path / "A.md").read_text()
+    assert "{.cls}" in a, f"the attribute block lost a brace: {a!r}"
+    assert a.count("<!-- uuid:") == 1, f"the stray was duplicated rather than absorbed: {a!r}"

--- a/tests/test_robustify.py
+++ b/tests/test_robustify.py
@@ -230,28 +230,41 @@ def test_write_preserves_the_bang_of_an_image_embed(tmp_path):
     Seeded before writing this: an emitter that consumes the `!` leaves the whole suite green.
     """
     _w(tmp_path / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
-    _w(tmp_path / "A.md", "![](B.md)\n")
+    _w(tmp_path / "A.md", "see ![](B.md) here\n")
 
     apply_robustify(plan_robustify(tmp_path))
 
     a = (tmp_path / "A.md").read_text()
-    assert a.startswith("!"), f"the image embed lost its bang: {a!r}"
+    # Assert the `!` is still attached to THIS link, not merely present somewhere on the line:
+    # the emitted anchor `<!-- uuid: … -->` contains a `!`, so `"!" in a` is true even when the
+    # embed's own bang has been eaten, and `a.startswith("!")` only holds while the fixture happens
+    # to begin with the link. Both are green under a seed that swallows it.
+    assert "![](B.md)" in a, f"the image embed lost its bang: {a!r}"
     links = find_robust_links(a)
     assert len(links) == 1 and links[0].href == "B.md" and links[0].text == ""
 
 
-def test_write_leaves_a_pandoc_attribute_suffix_untouched(tmp_path):
+def test_write_leaves_any_pandoc_attribute_suffix_untouched(tmp_path):
     """The suffix must stay OUT of the match span, and only a write can prove it.
 
     #52 blamed `{width="…"}` for hiding the link. The fix must not "help" by consuming the suffix:
-    a regex ending `\\)(?:\\{[^}]*\\})?` passes every detection test in the suite — measured, all
-    260 of them — while `--write` silently **deletes the attributes** from the document. Detection
-    reports the same finding either way, so this is the only place the difference is observable.
+    a regex ending `\\)(?:\\{[^}]*\\})?` passes every *detection* test in the suite while `--write`
+    silently **deletes the attributes** from the document. Detection reports an identical finding
+    either way, so this is the only place the difference is observable.
+
+    Every attribute shape pandoc emits is covered, not just the one from the bug report. A version
+    of this test that used `{width="…"}` alone was defeated by a seed one character narrower —
+    `\\)(?:\\{\\.[^}]*\\})?`, which consumes only class blocks — passing 264/264 while destroying
+    `{.cls}`. That shape is the very one used as the example in issue #65 and in the spec. A test
+    fixture is a claim about a population, and a single sample is the weakest possible one.
     """
+    shapes = ['{width="1.1in" height="2in"}', "{.cls}", "{#anchor}", '{.a .b key="v"}']
     _w(tmp_path / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
-    _w(tmp_path / "A.md", '![](B.md){width="1.1in" height="2in"}\n')
+    for i, suffix in enumerate(shapes):
+        _w(tmp_path / f"A{i}.md", f"![](B.md){suffix}\n")
 
     apply_robustify(plan_robustify(tmp_path))
 
-    a = (tmp_path / "A.md").read_text()
-    assert 'width="1.1in"' in a and 'height="2in"' in a, f"attributes were eaten: {a!r}"
+    for i, suffix in enumerate(shapes):
+        a = (tmp_path / f"A{i}.md").read_text()
+        assert suffix in a, f"attribute block {suffix!r} was eaten: {a!r}"


### PR DESCRIPTION
Closes #52.

## What was broken

`MD_LINK_RE` required at least one character of link text (`[^\]]+`), so a link whose text is empty
— `![](photo.jpg)`, `[](doc.md)` — **never matched**. Not a finding that got filtered: never a
candidate, so no axis ever saw it.

The axis then printed `dangling: 0` over a tree containing broken image embeds. That reads as *"no
broken links"*; it only ever meant *"none of the shapes the regex recognises"*, and nothing in the
output distinguishes the two. The empty alt is what document converters emit for images, so it
arrives in whole blocks of files imported at once — the kind nobody re-reads.

**The reported cause was not the cause.** #52 blamed the pandoc attribute suffix (`{width="1.1in"}`);
measured against the regex, the suffix was always harmless and the empty text was the whole of it.
Both are pinned in tests so the true cause cannot be re-diagnosed from the same coincidence.

## Measured

One repository at `mode: max`, **in its own gate scope** (excludes + ignore-blocks):

| | |
|---|---|
| empty-text links in scope | **127** |
| → non-local (http/mailto/fragment) | 37 |
| → local target **exists** | 83 |
| → local target missing | **7** — every one a real broken image embed |
| `dangling` before → after | **0 → 7** · findings lost: **0** |

## The change

- `[^\]]+` → `[^\]]*` in `MD_LINK_RE` **and** `ROBUST_LINK_RE`. They widen together: leaving the
  robust one narrow would make an anchored `[](path) <!-- uuid: … -->` plain to one finder and robust
  to the other, and that coupling is load-bearing for the **repair** axis.
- **FR-052**, within the `dangling` axis: the whitespace *delimiting* a destination is not part of
  it. Four properties of that rule each took a review round to get right, and each is a false green
  when wrong — the full statement is in the CHANGELOG. In short: strip **before** decoding (an escape
  is content, `[x](%20a.md)` denotes `" a.md"`), **ASCII only** (NBSP is an ordinary character), the
  **two edges differ** (`cmark` keeps VT/FF at the end), and the rule is **POSIX-shaped**.

## ⚠️ Adopting this is not a no-op

`MD_LINK_RE` has three call sites. In the same repository:

- **web axis: +36 links newly visible.** None is a `/blob/` URL today, so its web gate does not flip
  — the shape of those URLs, not a property of the change. A `/blob/` URL exits **3** if the
  destination carries a uuid and **4** if it 404s with a token that can see the repo.
- **`--create-readme`**: `[](sub/)` and `![](media/)` can now create a `README.md`. 0 occurrences.
- **the operational one**: a consumer at `dangling: repo` with `dangling_max` unset goes **0 → 7 and
  its push wall closes**. Fix the links or raise the ceiling *before* moving the pin.

## Known issues, filed rather than folded in

Four, all pre-existing, listed in the CHANGELOG where an upgrader will see them: **#71** — *live*,
104 links reported dead while the file exists, because balanced parentheses in a destination are
truncated · **#65** `--write` detaches a pandoc attribute block · **#67** whitespace is stripped by
`dangling` but not by `repair`/`robustify`/`--create-readme` · **#68** `--write` drops the UTF-8 BOM.

## Verification

- **274 tests pass** (was 251 on `main`).
- **Eight adversarial review rounds**, none of which was allowed to report clean without first
  seeding a defect and proving the suite catches it. Ledgers are comments on this PR.
- Across thirteen repositories and several differential fuzzes: **0 findings lost, 0 writes changed**.
  The only deliberate subtraction is FR-052 — 0 whitespace-only destinations and 6 with surrounding
  whitespace, none of which changes a verdict.
- Round 7 and round 8 adjudicated the whitespace rule against the **reference CommonMark
  implementation** rather than the spec prose, and each overturned a claim the previous rounds had
  propagated. The lesson is written into the spec: when a rule is about syntax, ask the parser.
