### PR TITLE
release: v0.20.5 — the web axis stops crashing, and stops saying 'clean' over what it could not read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.20.5] — 2026-08-13
+
 ### Fixed
 - **A tokenless `403` is the anonymous rate limit, not a private repo — and the web axis now says so
   instead of printing a quiet `clean`.** `web-check` reported *"cannot read destination: private repo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.20.4"
+version = "0.20.5"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Six commits had piled up unreleased. That matters more than usual here, because **the whole fleet pins tags, not `main`** — so none of them had reached a single consumer:

| consumers | pinned at |
|---|---|
| six repositories | `v0.20.4` |
| one | `v0.20.3` |
| one | `v0.19.0` |

Measured against the tag itself: `git show v0.20.4:src/darnlink/weblinks.py | grep -c InvalidURL` → **0**. Nobody has the crash fix.

## What this ships

- **`web-check --online` no longer dies on an href it cannot send** (#55). Mirrored third-party content carries two truncated URLs with a space between them; and an accented filename was enough on its own. `http.client.InvalidURL` descends from `HTTPException`, `UnicodeEncodeError` from `ValueError` — neither is an `OSError`, so neither was caught. **Any repository that mirrors third-party content could not run the axis at all**, which is exactly where the axis is most useful.
- **The exit-0 word no longer says `clean` when links could not be READ** (#60), and only offers `GITHUB_TOKEN` when the token would actually change something.
- The lang gate now covers the surfaces that get published (#53) and resolves its baseline against the repo rather than the tool (#49, #58).
- The spec for feature 016 (#51) — specification only, no behaviour change.

## Cut deliberately without feature 016

Its implementation (#59) is still in review. The crash fix has been ready for days and **no review round has touched it**; tying it to a PR still in flight would keep the fleet blocked for no reason. 016 goes out in the next one.

251 tests.