### PR TITLE
ci: --strict blocks honest English on a subject line — take it off that surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,19 @@ jobs:
           while IFS= read -r sha; do
             [ -z "$sha" ] && continue
             git log -1 --format=%B "$sha" > "$RUNNER_TEMP/one.txt"
-            darnlang prose "$RUNNER_TEMP/one.txt" --strict \
+            # NO --strict. It was added here as the compensating control for the hook's known gap,
+            # and then measured: layer 3 classifies "hooks: apply darnlang to darnlang" as Tagalog
+            # at 0.86 confidence, and "ci: uv venv --clear, setup-uv makes one" as Estonian -- both
+            # perfectly English. A subject is mostly identifiers and two repetitions of an invented
+            # word dominate it; no threshold on confidence, length or word count separates those
+            # from real findings, which score identically. On a PUBLIC repo that means blocking a
+            # contributor's honest English commit, which is how a gate gets routed around.
+            #
+            # So the gap stays OPEN and stated: a short subject with no accent and none of the
+            # stopwords passes every surface here. A compensating control that does not work is
+            # worse than a hole you can see. Layer 3 keeps the surfaces where it was measured to
+            # work -- issue bodies and PR descriptions, which are prose.
+            darnlang prose "$RUNNER_TEMP/one.txt" \
               --label "commit message $sha" || fail=1
           done < <(git log --format=%H \
             "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}")


### PR DESCRIPTION
Follow-up to #63, from measuring the control that PR added rather than trusting it.

`--strict` (langdetect) was wired onto the per-commit-message step as the compensating control for the hook's known gap. It **blocks honest English**:

| Subject | Classified | Reality |
|---|---|---|
| `hooks: apply darnlang to darnlang` | **tl** (0.86) | English |
| `ci: uv venv --clear, setup-uv makes one` | **et** (0.71) | English |
| `migra el gate de idioma al paquete` | ca (0.86) | Spanish — correctly caught |

A subject line is mostly identifiers, and two repetitions of an invented word dominate it. **No threshold separates the two sets** — confidence, length and word count score the false positives exactly as high as the true ones. On a public repo that means failing a contributor's legitimate commit, which is how a gate gets routed around.

So the gap **stays open and is stated in the file**: a short subject with no accent and none of the dictionary's stopwords passes every surface in this repo. A hole you can see beats a control that does not work — the same mistake, in the other direction, that the review of #63 caught here yesterday.

Layer 3 keeps `lang-pr.yml` and `lang-issue.yml`, where the input is prose (a description, an issue body) rather than a line of identifiers, and where it was measured to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)