### PR TITLE
release: v0.21.0 — fail on web links to repos you own whose destination has no uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.21.0] — 2026-08-13
+
 ### Added
 - **`web-check --online` can fail on a destination *you own* that has no `uuid`** — feature 016,
   opt-in (`specs/016-own-repo-web-strictness/spec.md`). The web axis is forgiving by design: a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.20.5"
+version = "0.21.0"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Ships feature 016, specified in #51 and implemented in #59.

## What it is

The web axis is forgiving by design: a destination that fetches 200 without a `uuid` is `web_unverifiable` and the run still exits 0, because the file lives in someone else's repository and cannot be fixed from here. **When the destination is yours that is not an external limitation** — it is a missing two-line edit in a repo you control, and nothing ever said so.

- **`--own OWNER`** (repeatable) and **`--own-from-origin`**; **`web_own_no_uuid`** at exit 4; **`--own-max N`** so a repo can adopt the rule before reaching zero; and **`<!-- darnlink-own-exempt -->`** for destinations that are machine-regenerated, where a `uuid` would be wiped by the next refresh.

Opt-in throughout. With no owner set, behaviour is byte-identical in the text report, the exit code and the files on disk, with two departures the spec names rather than leaves to be discovered.

## Why minor and not patch

It adds flags, two finding kinds and a JSON key. Nothing existing changes — the measurement backing that claim is in #59: 13,500 cases with the feature off, no change to kind, exit code, files or report text.

## Also in

The lang gate moves to the `darnlang` package (#63) and stops applying `--strict` to commit subjects (#66).

## Provenance

Copilot's review was empty on every push in this series (quota). Twelve independent adversarial passes stood in for it across the spec and the implementation. 306 tests, mutation-checked: three of those passes each found a test named for a property it did not actually fix, which is why every guard now has a mutation that kills it.