### PR TITLE
gate: the own_web keys, so feature 016 can actually be switched on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,3 +111,22 @@ jobs:
         run: uvx --from . darnlink .
       - name: The exact README one-liner, end-to-end over git (pinned to this commit)
         run: uvx --from git+https://github.com/txemi/darnlink.git@${{ github.sha }} darnlink .
+
+  # The PowerShell recipe is SHIPPED and nothing has ever parsed it: the recipe tests skip on Windows
+  # (`pytestmark`), no job runs `pwsh`, and this PR adds new multi-line constructs to it. Parsing is
+  # not testing — it never runs the gate — but it is the cheapest wall against the one failure mode a
+  # bash-only fleet cannot see: a consumer on Windows getting a script that does not even start.
+  # Its own job on ubuntu (pwsh is preinstalled there), not a step in the 8-cell matrix: the file is
+  # OS-independent, so parsing it once is enough.
+  ps1-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse recipes/darnlink-gate.ps1
+        shell: pwsh
+        run: |
+          $errs = $null
+          [void][System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path recipes/darnlink-gate.ps1).Path, [ref]$null, [ref]$errs)
+          if ($errs) { $errs | ForEach-Object { Write-Host "::error::$($_.ToString())" }; exit 1 }
+          Write-Host "recipes/darnlink-gate.ps1 parses clean"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+- **`darnlink-gate`: the `own_web` keys, so feature 016 can actually be switched on.** The rule
+  shipped in v0.21.0 lives in the CLI; until now no gate invoked it, so it protected nothing. Both
+  recipes — bash and PowerShell — now read `own_web` (a list of owners), `own_web_from_origin` (bool)
+  and `own_web_max` (int) and pass them through.
+
+  Three details keep it honest, and each is the same rule an existing key already follows:
+
+  - **`own_web_from_origin` is its own key, not a sentinel inside the list** — an owner literally
+    called `origin` has to stay expressible, the same reason the CLI has a flag rather than
+    `--own auto`.
+  - **A non-numeric budget counts as ABSENT, never as infinite.** Silently widening an allowance is
+    the one direction a config typo must not be able to go (`dangling_max` established this).
+  - **Exit 1 is a CONFIG error, not a verdict about the repository.** Feature 016 makes it reachable
+    from configuration — a budget with no owners, an unresolvable origin — and reporting it as a red
+    gate would send someone hunting for broken links that do not exist. It is not routed to `bail()`
+    either: that exits the script, which would skip every axis after this one, the bug this same pass
+    was fixed for once already.
+
+  The wiring is asserted on the **invocation**, not the verdict: without a token an unreadable
+  destination is `web_unverifiable` and the gate exits 0 whether or not the flags were passed, so a
+  verdict-based test cannot tell — and did not. Dropping the `--own` loop entirely left every other
+  recipe test green until the shim started recording argv.
+
 ## [0.21.0] — 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,22 @@ All notable changes to darnlink are documented here. The format is based on
   verdict-based test cannot tell — and did not. Dropping the `--own` loop entirely left every other
   recipe test green until the shim started recording argv.
 
+  Two further silent no-ops closed while wiring it, both found by mutation rather than by reading:
+
+  - **An empty owner entry passed without a word.** `[""]` flattens to exactly what an absent key
+    gives, so the list length is now read separately from its value — and a *partially* empty list is
+    named too, the case where the config lists three owners and the gate enforces one.
+  - **`web-check`'s exit 4 had no test protecting it from the `rc>3` fail-open heuristic.** Its codes
+    are all in 0..4 and none of them means *unreachable*, which is why the web verdict is marked
+    final; remove that immunity and a genuine 4 — exactly how feature 016 reports an owned
+    destination with no uuid — turns into **0** under the default, with the suite green.
+
+### Fixed
+- **Nothing had ever parsed `recipes/darnlink-gate.ps1`.** The recipe tests skip on Windows and no CI
+  job ran `pwsh`, so a syntax error in the shipped PowerShell recipe would have reached consumers as
+  a script that does not start. CI now parses it. Parsing is not testing — it never runs the gate —
+  but it is the one failure mode a bash-only fleet cannot see at all.
+
 ## [0.21.0] — 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ All notable changes to darnlink are documented here. The format is based on
 - **`darnlink-gate`: the `own_web` keys, so feature 016 can actually be switched on.** The rule
   shipped in v0.21.0 lives in the CLI; until now no gate invoked it, so it protected nothing. Both
   recipes — bash and PowerShell — now read `own_web` (a list of owners), `own_web_from_origin` (bool)
-  and `own_web_max` (int) and pass them through.
+  and `own_web_max` (int) and pass them through — including an explicit `own_web_max: 0`, which the
+  PowerShell config reader dropped at first because it tests truthiness and PowerShell reads JSON `0`
+  as false. That is the one value whose distinction from *absent* is the whole point of the budget.
 
   Three details keep it honest, and each is the same rule an existing key already follows:
 
@@ -19,11 +21,16 @@ All notable changes to darnlink are documented here. The format is based on
     `--own auto`.
   - **A non-numeric budget counts as ABSENT, never as infinite.** Silently widening an allowance is
     the one direction a config typo must not be able to go (`dangling_max` established this).
-  - **Exit 1 is a CONFIG error, not a verdict about the repository.** Feature 016 makes it reachable
-    from configuration — a budget with no owners, an unresolvable origin — and reporting it as a red
-    gate would send someone hunting for broken links that do not exist. It is not routed to `bail()`
-    either: that exits the script, which would skip every axis after this one, the bug this same pass
-    was fixed for once already.
+  - **An exit 1 is treated as likely-config, but only when this run passed an `own_*` flag.** Feature
+    016 makes exit 1 reachable from configuration — a budget with no owners, an unresolvable origin —
+    and reporting that as a red gate would send someone hunting for broken links that do not exist.
+    But exit 1 is *not* exclusively a usage error: `uvx` exits 1 on its own failures and an uncaught
+    exception exits 1 too, so an unconditional reading would have turned those green for every
+    consumer with `web: true`, including repositories that never adopted 016 — a worse guarantee than
+    before the key existed. And it respects `fail_closed`: under fail-open the axis is dropped with a
+    warning, in CI it becomes 4, because there the gate *is* the wall and an axis that could not run
+    is not a pass. It is not routed to `bail()` either: that exits the script and would skip every
+    axis after this one, the bug this same pass was fixed for once already.
 
   The wiring is asserted on the **invocation**, not the verdict: without a token an unreadable
   destination is `web_unverifiable` and the gate exits 0 whether or not the flags were passed, so a

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -47,6 +47,38 @@ is that orchestration in one place; a consumer carries only a tiny config + a 3-
   Windows-only surface silently does not gate this axis. Being explicit rather than letting the
   difference be discovered: on a repo that gates on both, POSIX gates it and Windows does not.
 
+- `web` (opt-in, **default off**, `mode=max` only) → adds a whole-repo `web-check --online` pass:
+  cross-repo Markdown links to **other GitHub repos** must resolve to the destination file's `uuid`,
+  read over the network and anchored with `<!-- web-uuid: X -->`.
+  ⚠️ **Both public and private destinations need `GITHUB_TOKEN`** — private ones for permission,
+  **public ones for quota** (anonymous API = 60/h per public IP, shared by everyone behind the same
+  NAT). Without it they come back `web_unverifiable`, which is a warning and reads like *nothing to
+  check*: **that is a false green**, because an un-anchored web link is only discoverable if the
+  destination can be READ. Measured on one repo, same tree, same day: without token `rc=0`, with
+  token `rc=3`. Quote the token condition next to any web figure or it isn't comparable.
+
+- `own_web` / `own_web_from_origin` / `own_web_max` (opt-in, **need `web`**) → feature 016. A web
+  destination owned by **you** whose `.md` has no `uuid` stops being *someone else's problem* and
+  **fails the gate**: it is a two-line edit in a repo you control, so it is fixable, which is the
+  whole difference from an external link.
+
+  | key | Value | Meaning |
+  |---|---|---|
+  | `own_web` | list of GitHub owners | the owners you control |
+  | `own_web_from_origin` | bool | also count this repo's `origin` owner. A **separate key, not a sentinel** in the list, so an owner literally called `origin` stays expressible |
+  | `own_web_max` | int | a budget, so the rung is adoptable before the repo reaches zero. **Non-numeric counts as ABSENT, never as infinite** — widening an allowance is the one direction a config typo must not be able to go |
+
+  A misconfiguration (a budget with no owners, an empty owner name, `own_web_from_origin` in a tree
+  with no GitHub `origin`) exits `1`, and the recipe reports it as **likely-config** rather than as a
+  verdict about the repository — but **only when this run actually passed an `own_*` flag**, because
+  exit `1` is not exclusively a usage error (`uvx` and an uncaught exception use it too). Under
+  `fail_closed` it still fails, with `4`: in CI an axis that could not run is not a pass.
+
+  ⚠️ **`darnlink-gate.ps1` implements these keys, but its web pass still `exit`s the moment it
+  finishes**, so on Windows the create-readme and dangling axes do not run after a web pass — the
+  bug the POSIX recipe was fixed for. Same caveat as `dangling` below: stated rather than left to be
+  discovered.
+
 - `scope=repo` → judge the whole tree (**the wall — use in pre-push & CI**).
   `scope=staged` → judge only the files you're committing (**multi-session pre-commit**, so a
   teammate's in-flight plain link doesn't block your commit). It filters `darnlink check --json` by

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -124,6 +124,21 @@ print("\n".join(v) if isinstance(v, list) else (v if v is not None else default)
 PY
 }
 
+# How many entries a LIST key has — which `read_cfg` cannot tell you: it joins with newlines, so an
+# absent key, `[]` and `[""]` all arrive as the empty string. `[""]` is the likeliest typo of the
+# three (a template line left half-filled) and the only one that must be named out loud, so ask for
+# the length separately instead of trying to infer it from the flattened value.
+read_cfg_len() { python3 - "$cfg" "$1" <<'PY' 2>/dev/null || printf '0'
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    d = {}
+v = d.get(sys.argv[2])
+print(len(v) if isinstance(v, list) else 0)
+PY
+}
+
 REF="${DARNLINK_REF:-$(read_cfg ref 'git+https://github.com/txemi/darnlink@v0.7.0')}"
 MODE="${DARNLINK_GATE_MODE:-$(read_cfg mode check)}"
 SCOPE="${DARNLINK_GATE_SCOPE:-$(read_cfg scope repo)}"
@@ -149,6 +164,7 @@ case "${WEB,,}" in ""|0|false|no|off) WEB="" ;; *) WEB=1 ;; esac
 # LIST of names, never a sentinel: `own_web_from_origin` is its own key precisely so an owner literally
 # called `origin` stays expressible, the same reason the CLI has a flag instead of `--own auto`.
 mapfile -t OWN_WEB < <(read_cfg own_web "")
+OWN_WEB_N="$(read_cfg_len own_web)"; [[ "$OWN_WEB_N" =~ ^[0-9]+$ ]] || OWN_WEB_N=0
 OWN_WEB_FROM_ORIGIN="${DARNLINK_GATE_OWN_WEB_FROM_ORIGIN:-$(read_cfg own_web_from_origin "")}"
 case "${OWN_WEB_FROM_ORIGIN,,}" in ""|0|false|no|off) OWN_WEB_FROM_ORIGIN="" ;; *) OWN_WEB_FROM_ORIGIN=1 ;; esac
 # A budget, so the rung is adoptable before a repo reaches zero. Non-numeric counts as ABSENT, never as
@@ -332,7 +348,8 @@ PY
 
 # F4: `own_web` rides on `web` and on mode=max. Configured where the pass never runs it is a silent
 # no-op that READS like protection — exactly what the CLI refuses to do with `--own-max` and no owners.
-if [ -n "${OWN_WEB[*]}$OWN_WEB_FROM_ORIGIN$OWN_WEB_MAX" ] && { [ -z "$WEB" ] || [ "$MODE" != "max" ]; }; then
+if { [ "$OWN_WEB_N" -gt 0 ] || [ -n "$OWN_WEB_FROM_ORIGIN$OWN_WEB_MAX" ]; } \
+   && { [ -z "$WEB" ] || [ "$MODE" != "max" ]; }; then
   echo "darnlink-gate: own_web* is configured but the web pass does not run here (web=${WEB:-off}," >&2
   echo "  mode=$MODE — it needs web on AND mode=max). The 016 rule is NOT being applied." >&2
 fi
@@ -399,14 +416,21 @@ if [ "$SCOPE" != "staged" ]; then
       WEB_ARGS=()
       for e in "${EXCLUDES[@]}";      do [ -n "$e" ] && WEB_ARGS+=(--exclude "$e"); done
       for b in "${IGNORE_BLOCKS[@]}"; do [ -n "$b" ] && WEB_ARGS+=(--ignore-block "$b"); done
-      OWN_PASSED=""
-      for o in "${OWN_WEB[@]}";       do [ -n "$o" ] && { WEB_ARGS+=(--own "$o"); OWN_PASSED=1; }; done
+      OWN_PASSED=""; OWN_WEB_USED=0
+      for o in "${OWN_WEB[@]}"; do
+        [ -n "$o" ] && { WEB_ARGS+=(--own "$o"); OWN_PASSED=1; OWN_WEB_USED=$((OWN_WEB_USED + 1)); }
+      done
       [ -n "$OWN_WEB_FROM_ORIGIN" ] && { WEB_ARGS+=(--own-from-origin); OWN_PASSED=1; }
       [ -n "$OWN_WEB_MAX" ]         && { WEB_ARGS+=(--own-max "$OWN_WEB_MAX"); OWN_PASSED=1; }
-      # An owner list that is present but entirely empty is a typo, and a silent one: the axis would
-      # run with no ownership at all and go green looking like it had checked.
-      if [ "${#OWN_WEB[@]}" -gt 0 ] && [ -n "${OWN_WEB[0]}${OWN_WEB[*]}" ] && [ -z "$OWN_PASSED" ]; then
+      # An owner entry that is present but empty is a typo, and a silent one: the axis would run with
+      # less ownership than the config claims and go green looking like it had checked all of it. It
+      # is counted, not inferred from the joined value — `[""]` flattens to exactly what an absent key
+      # gives, and `[""]` is the shape a half-filled template line actually takes.
+      if [ "$OWN_WEB_N" -gt 0 ] && [ "$OWN_WEB_USED" -eq 0 ]; then
         echo "darnlink-gate: own_web is set but every entry is empty — no ownership was applied." >&2
+      elif [ "$OWN_WEB_USED" -lt "$OWN_WEB_N" ]; then
+        echo "darnlink-gate: own_web has $((OWN_WEB_N - OWN_WEB_USED)) empty entry/entries out of" >&2
+        echo "  $OWN_WEB_N — they were ignored, so fewer owners are enforced than the config lists." >&2
       fi
       run web-check . --online "${WEB_ARGS[@]}"; rc=$?
       set -e

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -67,6 +67,14 @@
 #        Measured on a nine-repo fleet: 2,356 links pointing at files that do not exist, none of
 #        them named by any other axis. Expect a number.
 #   mode ∈ { repair | check | max } — see WHAT IT DOES. Raising it is a one-way ratchet: only up.
+#   own_web (needs `web`): a LIST of GitHub owners you control. A destination owned by one of them
+#     whose .md has no uuid stops being "someone else's problem" and FAILS the gate — you can fix it,
+#     it is a missing two-line edit in a repo you own. `own_web_from_origin: true` adds this repo's
+#     `origin` owner; it is a separate key, not a sentinel in the list, so an owner literally called
+#     `origin` stays expressible. `own_web_max: <int>` budgets it, so the rung is adoptable before you
+#     reach zero — same ratchet shape as `dangling_max`, and a non-numeric value counts as ABSENT,
+#     never as infinite. A config error here (a budget with no owners, an unresolvable origin) exits 1,
+#     which the recipe reports as a CONFIG error and NOT as a verdict about the repository.
 #   web (mode=max only): add a `web-check --online` pass — cross-repo links to OTHER GitHub repos must
 #     resolve to the destination's uuid (read online). ⚠️ PUBLIC targets need a token too — not for
 #     permission but for QUOTA: anonymous API calls are 60/h per public IP. Without one the pass
@@ -133,6 +141,21 @@ case "${FAIL_CLOSED,,}" in ""|0|false|no|off) FAIL_CLOSED="" ;; *) FAIL_CLOSED=1
 # Fail-closed only on a genuinely broken/moved public web link. Same normalise-the-string dance as above.
 WEB="${DARNLINK_GATE_WEB:-$(read_cfg web "")}"
 case "${WEB,,}" in ""|0|false|no|off) WEB="" ;; *) WEB=1 ;; esac
+# OWN_WEB (opt-in, needs `web`): the owners you control. A destination owned by one of them whose .md
+# has no uuid stops being "someone else's problem" and becomes a gate failure — see feature 016. A
+# LIST of names, never a sentinel: `own_web_from_origin` is its own key precisely so an owner literally
+# called `origin` stays expressible, the same reason the CLI has a flag instead of `--own auto`.
+mapfile -t OWN_WEB < <(read_cfg own_web "")
+OWN_WEB_FROM_ORIGIN="${DARNLINK_GATE_OWN_WEB_FROM_ORIGIN:-$(read_cfg own_web_from_origin "")}"
+case "${OWN_WEB_FROM_ORIGIN,,}" in ""|0|false|no|off) OWN_WEB_FROM_ORIGIN="" ;; *) OWN_WEB_FROM_ORIGIN=1 ;; esac
+# A budget, so the rung is adoptable before a repo reaches zero. Non-numeric counts as ABSENT, never as
+# infinite: silently WIDENING an allowance is the one direction a config typo must not be able to go —
+# the same rule `dangling_max` follows, and for the same reason.
+OWN_WEB_MAX="${DARNLINK_GATE_OWN_WEB_MAX:-$(read_cfg own_web_max "")}"
+if [ -n "$OWN_WEB_MAX" ] && ! [[ "$OWN_WEB_MAX" =~ ^[0-9]+$ ]]; then
+  echo "darnlink-gate: own_web_max='$OWN_WEB_MAX' is not a non-negative integer — ignoring it." >&2
+  OWN_WEB_MAX=""
+fi
 # CREATE_README (opt-in): when on, mode=max also runs `--create-readme` — a directory link whose target
 # folder has no README (so no uuid to anchor to) FAILS the gate (dry-run: it's DETECTED, not written).
 # Robustify it by hand with `--create-readme --write`. Raises the max ceiling from "files" to "folders".
@@ -366,8 +389,23 @@ if [ "$SCOPE" != "staged" ]; then
       WEB_ARGS=()
       for e in "${EXCLUDES[@]}";      do [ -n "$e" ] && WEB_ARGS+=(--exclude "$e"); done
       for b in "${IGNORE_BLOCKS[@]}"; do [ -n "$b" ] && WEB_ARGS+=(--ignore-block "$b"); done
+      for o in "${OWN_WEB[@]}";       do [ -n "$o" ] && WEB_ARGS+=(--own "$o"); done
+      [ -n "$OWN_WEB_FROM_ORIGIN" ] && WEB_ARGS+=(--own-from-origin)
+      [ -n "$OWN_WEB_MAX" ]         && WEB_ARGS+=(--own-max "$OWN_WEB_MAX")
       run web-check . --online "${WEB_ARGS[@]}"; rc=$?
       set -e
+      # EXIT 1 IS A USAGE ERROR, NOT A VERDICT ABOUT THE REPO, and feature 016 makes it reachable from
+      # CONFIGURATION: own_web_max without own_web, an empty owner name, or own_web_from_origin in a
+      # tree with no GitHub `origin`. Reporting it as a red gate would send someone hunting for broken
+      # links that do not exist. It must not go to `bail()` either — that EXITS the script, so a typo
+      # would skip every axis after this one, which is the bug this pass already fixed once. Say what
+      # is wrong, drop the axis for this run, and let the rest of the gate speak.
+      if [ "$rc" -eq 1 ]; then
+        echo "darnlink-gate: web-check rejected its own arguments (exit 1) — this is a CONFIG error," >&2
+        echo "  not a finding about this repository. Check own_web / own_web_from_origin /" >&2
+        echo "  own_web_max in darnlink-gate.json. The web axis did NOT run this time." >&2
+        rc=0
+      fi
       # web-check's contract (all in 0..4, none of them "unreachable"): 0 = clean (a network/token
       # failure is reported web_unverifiable, still exit 0 — it NEVER exits high); 3 = a plain web link
       # not yet anchored (dry-run: it COULD be robustified) — a real gate failure, which is the point

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -73,8 +73,11 @@
 #     `origin` owner; it is a separate key, not a sentinel in the list, so an owner literally called
 #     `origin` stays expressible. `own_web_max: <int>` budgets it, so the rung is adoptable before you
 #     reach zero — same ratchet shape as `dangling_max`, and a non-numeric value counts as ABSENT,
-#     never as infinite. A config error here (a budget with no owners, an unresolvable origin) exits 1,
-#     which the recipe reports as a CONFIG error and NOT as a verdict about the repository.
+#     never as infinite. A misconfiguration here (a budget with no owners, an unresolvable origin)
+#     exits 1, and the recipe reports it as likely-config rather than as a verdict about the
+#     repository — but ONLY when this run actually passed an own_* flag, because exit 1 is not
+#     exclusively a usage error (uvx and an uncaught exception use it too). Under `fail_closed` it
+#     still fails the gate with 4: in CI an axis that could not run is not a pass.
 #   web (mode=max only): add a `web-check --online` pass — cross-repo links to OTHER GitHub repos must
 #     resolve to the destination's uuid (read online). ⚠️ PUBLIC targets need a token too — not for
 #     permission but for QUOTA: anonymous API calls are 60/h per public IP. Without one the pass
@@ -327,6 +330,13 @@ PY
   printf '%s\n' "$out"
 }
 
+# F4: `own_web` rides on `web` and on mode=max. Configured where the pass never runs it is a silent
+# no-op that READS like protection — exactly what the CLI refuses to do with `--own-max` and no owners.
+if [ -n "${OWN_WEB[*]}$OWN_WEB_FROM_ORIGIN$OWN_WEB_MAX" ] && { [ -z "$WEB" ] || [ "$MODE" != "max" ]; }; then
+  echo "darnlink-gate: own_web* is configured but the web pass does not run here (web=${WEB:-off}," >&2
+  echo "  mode=$MODE — it needs web on AND mode=max). The 016 rule is NOT being applied." >&2
+fi
+
 if [ "$SCOPE" != "staged" ]; then
   # ---- whole-repo (the wall). darnlink's own exit code is the gate. ----
   # set +e around the run: darnlink exits 0/1/2/3 (findings ARE non-zero) — set -e must not kill us
@@ -389,22 +399,39 @@ if [ "$SCOPE" != "staged" ]; then
       WEB_ARGS=()
       for e in "${EXCLUDES[@]}";      do [ -n "$e" ] && WEB_ARGS+=(--exclude "$e"); done
       for b in "${IGNORE_BLOCKS[@]}"; do [ -n "$b" ] && WEB_ARGS+=(--ignore-block "$b"); done
-      for o in "${OWN_WEB[@]}";       do [ -n "$o" ] && WEB_ARGS+=(--own "$o"); done
-      [ -n "$OWN_WEB_FROM_ORIGIN" ] && WEB_ARGS+=(--own-from-origin)
-      [ -n "$OWN_WEB_MAX" ]         && WEB_ARGS+=(--own-max "$OWN_WEB_MAX")
+      OWN_PASSED=""
+      for o in "${OWN_WEB[@]}";       do [ -n "$o" ] && { WEB_ARGS+=(--own "$o"); OWN_PASSED=1; }; done
+      [ -n "$OWN_WEB_FROM_ORIGIN" ] && { WEB_ARGS+=(--own-from-origin); OWN_PASSED=1; }
+      [ -n "$OWN_WEB_MAX" ]         && { WEB_ARGS+=(--own-max "$OWN_WEB_MAX"); OWN_PASSED=1; }
+      # An owner list that is present but entirely empty is a typo, and a silent one: the axis would
+      # run with no ownership at all and go green looking like it had checked.
+      if [ "${#OWN_WEB[@]}" -gt 0 ] && [ -n "${OWN_WEB[0]}${OWN_WEB[*]}" ] && [ -z "$OWN_PASSED" ]; then
+        echo "darnlink-gate: own_web is set but every entry is empty — no ownership was applied." >&2
+      fi
       run web-check . --online "${WEB_ARGS[@]}"; rc=$?
       set -e
-      # EXIT 1 IS A USAGE ERROR, NOT A VERDICT ABOUT THE REPO, and feature 016 makes it reachable from
-      # CONFIGURATION: own_web_max without own_web, an empty owner name, or own_web_from_origin in a
-      # tree with no GitHub `origin`. Reporting it as a red gate would send someone hunting for broken
-      # links that do not exist. It must not go to `bail()` either — that EXITS the script, so a typo
-      # would skip every axis after this one, which is the bug this pass already fixed once. Say what
-      # is wrong, drop the axis for this run, and let the rest of the gate speak.
-      if [ "$rc" -eq 1 ]; then
-        echo "darnlink-gate: web-check rejected its own arguments (exit 1) — this is a CONFIG error," >&2
-        echo "  not a finding about this repository. Check own_web / own_web_from_origin /" >&2
-        echo "  own_web_max in darnlink-gate.json. The web axis did NOT run this time." >&2
-        rc=0
+      # Exit 1 CAN be a usage error — feature 016 makes it reachable from CONFIGURATION: own_web_max
+      # without own_web, an empty owner name, own_web_from_origin in a tree with no GitHub `origin`.
+      # But it is NOT only that: `uvx` exits 1 on its own failures and an uncaught Python exception
+      # exits 1 too. So this only fires when THIS RUN passed an own_* flag — otherwise a repo that
+      # never adopted 016 would have its exit 1 turned green, which is a worse guarantee than before
+      # this key existed.
+      #
+      # And even then it respects `fail_closed`: under fail-open it drops the axis with a warning, but
+      # in CI — where the gate IS the wall — a config error that cannot be validated must not be a
+      # pass. It becomes 4 ("could not gate") and is marked final, so the run still fails and the
+      # remaining axes still execute. It must NOT go to `bail()`, which exits the script and would skip
+      # them, the bug this pass was fixed for once already.
+      if [ "$rc" -eq 1 ] && [ -n "$OWN_PASSED" ]; then
+        echo "darnlink-gate: web-check rejected its own arguments (exit 1) — most likely a CONFIG" >&2
+        echo "  error rather than a finding about this repository. Check own_web /" >&2
+        echo "  own_web_from_origin / own_web_max in darnlink-gate.json. The web axis did NOT run." >&2
+        if [ -n "$FAIL_CLOSED" ]; then
+          echo "  fail_closed is on: an axis that could not run is not a pass. -> 4" >&2
+          rc=4
+        else
+          rc=0
+        fi
       fi
       # web-check's contract (all in 0..4, none of them "unreachable"): 0 = clean (a network/token
       # failure is reported web_unverifiable, still exit 0 — it NEVER exits high); 3 = a plain web link

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -73,10 +73,18 @@ $ownWebFromOrigin = -not ([string]::IsNullOrWhiteSpace([string]$rawOWFO) -or
                           ([string]$rawOWFO).Trim().ToLower() -in @('0','false','no','off'))
 # A budget, so the rung is adoptable before a repo reaches zero. Non-numeric counts as ABSENT, never as
 # infinite: silently WIDENING an allowance is the one direction a config typo must not be able to go.
-$rawOWM = if ($null -ne $env:DARNLINK_GATE_OWN_WEB_MAX) { $env:DARNLINK_GATE_OWN_WEB_MAX } else { CfgOr 'own_web_max' '' }
+# NOT CfgOr here: it tests truthiness, and PowerShell reads the JSON `0` as [int]0, which is $false —
+# so `own_web_max: 0` silently became "absent". That is the one value whose distinction from absent is
+# the entire point of the budget, and it would have diverged from bash, which passes it. Read by
+# PRESENCE instead.
+$rawOWM = if ($null -ne $env:DARNLINK_GATE_OWN_WEB_MAX) { $env:DARNLINK_GATE_OWN_WEB_MAX }
+          elseif ($cfg -and $cfg.PSObject.Properties.Name -contains 'own_web_max') { $cfg.own_web_max }
+          else { '' }
 $ownWebMax = ''
 if (-not [string]::IsNullOrWhiteSpace([string]$rawOWM)) {
-  if (([string]$rawOWM).Trim() -match '^\d+$') { $ownWebMax = ([string]$rawOWM).Trim() }
+  # `[0-9]` and no Trim, to match the bash recipe character for character: `\d` in .NET also matches
+  # Unicode digits, and trimming here would accept ' 3 ' where bash rejects it.
+  if (([string]$rawOWM) -match '^[0-9]+$') { $ownWebMax = [string]$rawOWM }
   else { Write-Warning "darnlink-gate: own_web_max='$rawOWM' is not a non-negative integer - ignoring it." }
 }
 # CREATE_README (opt-in, mode=max): also run --create-readme — a directory link whose target folder has
@@ -155,20 +163,28 @@ if ($scope -ne 'staged') {
       $webArgs = @()
       foreach ($e in $excludes)     { if ($e) { $webArgs += @('--exclude', $e) } }
       foreach ($b in $ignoreBlocks) { if ($b) { $webArgs += @('--ignore-block', $b) } }
-      foreach ($o in $ownWeb)       { if ($o) { $webArgs += @('--own', $o) } }
-      if ($ownWebFromOrigin) { $webArgs += '--own-from-origin' }
-      if ($ownWebMax)        { $webArgs += @('--own-max', $ownWebMax) }
+      $ownPassed = $false
+      foreach ($o in $ownWeb)       { if ($o) { $webArgs += @('--own', $o); $ownPassed = $true } }
+      if ($ownWebFromOrigin)               { $webArgs += '--own-from-origin'; $ownPassed = $true }
+      if (-not [string]::IsNullOrEmpty($ownWebMax)) { $webArgs += @('--own-max', $ownWebMax); $ownPassed = $true }
       & uvx --from $ref darnlink web-check . --online @webArgs
       $webRc = $LASTEXITCODE
       # EXIT 1 IS A USAGE ERROR, NOT A VERDICT ABOUT THE REPO, and feature 016 makes it reachable from
       # CONFIGURATION: own_web_max without own_web, an empty owner name, or own_web_from_origin in a
       # tree with no GitHub `origin`. Reporting it as a red gate would send someone hunting for broken
       # links that do not exist. Say what is wrong and drop the axis for this run.
-      if ($webRc -eq 1) {
-        Write-Warning "darnlink-gate: web-check rejected its own arguments (exit 1) - this is a CONFIG"
-        Write-Warning "  error, not a finding about this repository. Check own_web /"
+      # Only when THIS RUN passed an own_* flag: uvx exits 1 on its own failures and an uncaught
+      # Python exception exits 1 too, so an unconditional swallow would turn those green for a repo
+      # that never adopted 016 — a worse guarantee than before this key existed. And it respects
+      # fail_closed: in CI an axis that could not run is not a pass.
+      if ($webRc -eq 1 -and $ownPassed) {
+        Write-Warning "darnlink-gate: web-check rejected its own arguments (exit 1) - most likely a CONFIG"
+        Write-Warning "  error rather than a finding about this repository. Check own_web /"
         Write-Warning "  own_web_from_origin / own_web_max in darnlink-gate.json. The web axis did NOT run."
-        $webRc = 0
+        if ($failClosed) {
+          Write-Warning "  fail_closed is on: an axis that could not run is not a pass. -> 4"
+          $webRc = 4
+        } else { $webRc = 0 }
       }
       exit $webRc
     }

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -67,7 +67,10 @@ $web = -not ([string]::IsNullOrWhiteSpace([string]$rawWeb) -or
 # has no uuid stops being "someone else's problem" and becomes a gate failure - feature 016. A LIST of
 # names, never a sentinel: `own_web_from_origin` is its own key precisely so an owner literally called
 # `origin` stays expressible, the same reason the CLI has a flag instead of `--own auto`.
-$ownWeb = @(CfgOr 'own_web' @())
+# Read by PRESENCE, not by truthiness, for the same reason as `own_web_max` below: PowerShell unwraps
+# a one-element array, so `["" ]` is $false to CfgOr and would come back as "absent" — losing the very
+# entry the empty-entry warning exists to name.
+$ownWeb = @(if ($cfg -and $cfg.PSObject.Properties.Name -contains 'own_web') { $cfg.own_web } else { @() })
 $rawOWFO = if ($null -ne $env:DARNLINK_GATE_OWN_WEB_FROM_ORIGIN) { $env:DARNLINK_GATE_OWN_WEB_FROM_ORIGIN } else { CfgOr 'own_web_from_origin' '' }
 $ownWebFromOrigin = -not ([string]::IsNullOrWhiteSpace([string]$rawOWFO) -or
                           ([string]$rawOWFO).Trim().ToLower() -in @('0','false','no','off'))
@@ -92,6 +95,15 @@ if (-not [string]::IsNullOrWhiteSpace([string]$rawOWM)) {
 $rawCR = if ($null -ne $env:DARNLINK_GATE_CREATE_README) { $env:DARNLINK_GATE_CREATE_README } else { CfgOr 'create_readme' '' }
 $createReadme = -not ([string]::IsNullOrWhiteSpace([string]$rawCR) -or
                       ([string]$rawCR).Trim().ToLower() -in @('0','false','no','off'))
+
+# F4: `own_web` rides on `web` and on mode=max. Configured where the pass never runs it is a silent
+# no-op that READS like protection - exactly what the CLI refuses to do with `--own-max` and no owners.
+if (($ownWeb.Count -gt 0 -or $ownWebFromOrigin -or -not [string]::IsNullOrEmpty($ownWebMax)) -and
+    ((-not $web) -or $mode -ne 'max')) {
+  $webShown = if ($web) { '1' } else { 'off' }
+  Write-Warning "darnlink-gate: own_web* is configured but the web pass does not run here (web=$webShown,"
+  Write-Warning "  mode=$mode - it needs web on AND mode=max). The 016 rule is NOT being applied."
+}
 
 # --- guard: read-only. Never pass --write through. ---
 if ($args -contains '--write') {
@@ -164,9 +176,18 @@ if ($scope -ne 'staged') {
       foreach ($e in $excludes)     { if ($e) { $webArgs += @('--exclude', $e) } }
       foreach ($b in $ignoreBlocks) { if ($b) { $webArgs += @('--ignore-block', $b) } }
       $ownPassed = $false
-      foreach ($o in $ownWeb)       { if ($o) { $webArgs += @('--own', $o); $ownPassed = $true } }
+      $ownWebUsed = 0
+      foreach ($o in $ownWeb) { if ($o) { $webArgs += @('--own', $o); $ownPassed = $true; $ownWebUsed++ } }
       if ($ownWebFromOrigin)               { $webArgs += '--own-from-origin'; $ownPassed = $true }
       if (-not [string]::IsNullOrEmpty($ownWebMax)) { $webArgs += @('--own-max', $ownWebMax); $ownPassed = $true }
+      # Same two warnings as the bash recipe, same wording: an owner entry that is present but empty
+      # is a typo that makes the axis enforce less than the config claims, and it would go green.
+      if ($ownWeb.Count -gt 0 -and $ownWebUsed -eq 0) {
+        Write-Warning "darnlink-gate: own_web is set but every entry is empty - no ownership was applied."
+      } elseif ($ownWebUsed -lt $ownWeb.Count) {
+        Write-Warning "darnlink-gate: own_web has $($ownWeb.Count - $ownWebUsed) empty entry/entries out of"
+        Write-Warning "  $($ownWeb.Count) - they were ignored, so fewer owners are enforced than the config lists."
+      }
       & uvx --from $ref darnlink web-check . --online @webArgs
       $webRc = $LASTEXITCODE
       # EXIT 1 IS A USAGE ERROR, NOT A VERDICT ABOUT THE REPO, and feature 016 makes it reachable from

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -63,6 +63,22 @@ $ignoreBlocks = @(CfgOr 'ignore_blocks' @())
 $rawWeb = if ($null -ne $env:DARNLINK_GATE_WEB) { $env:DARNLINK_GATE_WEB } else { CfgOr 'web' '' }
 $web = -not ([string]::IsNullOrWhiteSpace([string]$rawWeb) -or
              ([string]$rawWeb).Trim().ToLower() -in @('0','false','no','off'))
+# OWN_WEB (opt-in, needs `web`): the owners you control. A destination owned by one of them whose .md
+# has no uuid stops being "someone else's problem" and becomes a gate failure - feature 016. A LIST of
+# names, never a sentinel: `own_web_from_origin` is its own key precisely so an owner literally called
+# `origin` stays expressible, the same reason the CLI has a flag instead of `--own auto`.
+$ownWeb = @(CfgOr 'own_web' @())
+$rawOWFO = if ($null -ne $env:DARNLINK_GATE_OWN_WEB_FROM_ORIGIN) { $env:DARNLINK_GATE_OWN_WEB_FROM_ORIGIN } else { CfgOr 'own_web_from_origin' '' }
+$ownWebFromOrigin = -not ([string]::IsNullOrWhiteSpace([string]$rawOWFO) -or
+                          ([string]$rawOWFO).Trim().ToLower() -in @('0','false','no','off'))
+# A budget, so the rung is adoptable before a repo reaches zero. Non-numeric counts as ABSENT, never as
+# infinite: silently WIDENING an allowance is the one direction a config typo must not be able to go.
+$rawOWM = if ($null -ne $env:DARNLINK_GATE_OWN_WEB_MAX) { $env:DARNLINK_GATE_OWN_WEB_MAX } else { CfgOr 'own_web_max' '' }
+$ownWebMax = ''
+if (-not [string]::IsNullOrWhiteSpace([string]$rawOWM)) {
+  if (([string]$rawOWM).Trim() -match '^\d+$') { $ownWebMax = ([string]$rawOWM).Trim() }
+  else { Write-Warning "darnlink-gate: own_web_max='$rawOWM' is not a non-negative integer - ignoring it." }
+}
 # CREATE_README (opt-in, mode=max): also run --create-readme — a directory link whose target folder has
 # no README (no uuid) FAILS the gate (dry-run detects it; fix with --create-readme --write).
 $rawCR = if ($null -ne $env:DARNLINK_GATE_CREATE_README) { $env:DARNLINK_GATE_CREATE_README } else { CfgOr 'create_readme' '' }
@@ -139,8 +155,22 @@ if ($scope -ne 'staged') {
       $webArgs = @()
       foreach ($e in $excludes)     { if ($e) { $webArgs += @('--exclude', $e) } }
       foreach ($b in $ignoreBlocks) { if ($b) { $webArgs += @('--ignore-block', $b) } }
+      foreach ($o in $ownWeb)       { if ($o) { $webArgs += @('--own', $o) } }
+      if ($ownWebFromOrigin) { $webArgs += '--own-from-origin' }
+      if ($ownWebMax)        { $webArgs += @('--own-max', $ownWebMax) }
       & uvx --from $ref darnlink web-check . --online @webArgs
-      exit $LASTEXITCODE
+      $webRc = $LASTEXITCODE
+      # EXIT 1 IS A USAGE ERROR, NOT A VERDICT ABOUT THE REPO, and feature 016 makes it reachable from
+      # CONFIGURATION: own_web_max without own_web, an empty owner name, or own_web_from_origin in a
+      # tree with no GitHub `origin`. Reporting it as a red gate would send someone hunting for broken
+      # links that do not exist. Say what is wrong and drop the axis for this run.
+      if ($webRc -eq 1) {
+        Write-Warning "darnlink-gate: web-check rejected its own arguments (exit 1) - this is a CONFIG"
+        Write-Warning "  error, not a finding about this repository. Check own_web /"
+        Write-Warning "  own_web_from_origin / own_web_max in darnlink-gate.json. The web axis did NOT run."
+        $webRc = 0
+      }
+      exit $webRc
     }
   } else {
     & uvx --from $ref darnlink check . @dlArgs @args   # `darnlink check` → 0/2/3 (mode=check|repair)

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -704,3 +704,100 @@ def test_own_web_configured_where_the_pass_never_runs_says_so(sandbox):
     r = run({"mode": "check", "web": True, "own_web": ["owned"]})
 
     assert "NOT being applied" in (r.stdout + r.stderr)
+
+
+def _uvx_forcing_web_check_to(tmp_path, code: int) -> Path:
+    """A uvx shim that makes ONLY the web pass exit with `code` and lets every other subcommand
+    through — the only way to exercise the recipe's reading of a code the real tool will not produce
+    on demand."""
+    d = tmp_path / f"uvx{code}"
+    d.mkdir()
+    (d / "uvx").write_text(
+        f'#!/usr/bin/env bash\ncase " $* " in *" web-check "*) exit {code};; esac\n'
+        'args=("$@"); [ "${args[0]:-}" = "--from" ] && args=("${args[@]:2}")\n'
+        '[ "${args[0]:-}" = "darnlink" ] && args=("${args[@]:1}")\n'
+        'exec "${DARNLINK_BIN:-darnlink}" "${args[@]}"\n')
+    (d / "uvx").chmod(0o755)
+    return d
+
+
+@pytest.mark.parametrize("cfg", [
+    {"mode": "max", "web": True, "own_web": ["me"]},
+    {"mode": "max", "web": True, "own_web_from_origin": True},
+    {"mode": "max", "web": True, "own_web_max": 5},
+])
+def test_each_own_flag_on_its_own_arms_the_config_reading_of_exit_1(sandbox, tmp_path, cfg):
+    """Only `own_web_max` was exercised, so a mutation that stopped `--own` or `--own-from-origin`
+    from arming the swallow survived: those two repos got the pre-016 behaviour and nothing said so."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+
+    r = run(cfg, uvx_dir=_uvx_forcing_web_check_to(tmp_path, 1))
+
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "did NOT run" in (r.stdout + r.stderr)
+
+
+def test_a_genuine_web_4_is_not_re_read_as_a_network_hiccup(sandbox, tmp_path):
+    """web-check's codes are all in 0..4 and none of them means "unreachable", so its 4 — which is
+    exactly how feature 016 reports an owned destination with no uuid — must survive the rc>3
+    fail-open heuristic. Drop the RC_IS_FINAL immunity and this repo goes GREEN under the default."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+
+    r = run({"mode": "max", "web": True, "own_web": ["owned"]},
+            uvx_dir=_uvx_forcing_web_check_to(tmp_path, 4))
+
+    assert r.returncode == 4, r.stdout + r.stderr
+
+
+def test_after_a_fail_closed_config_error_the_later_axes_still_run(sandbox):
+    """The 4 must be CARRIED, not bail()'d: bail exits the script and the create-readme / dangling
+    axes never speak. Asserting only the exit code cannot tell the two apart — both give 4."""
+    repo, run = sandbox
+    (repo / "docs").mkdir()
+    (repo / "docs" / "page.md").write_text("# page\n")
+    (repo / "A.md").write_text("# A\nthe [docs](docs/)\ngone [g](nope/missing.md)\n")
+
+    r = run({"mode": "max", "web": True, "own_web_max": 5, "fail_closed": True,
+             "create_readme": True, "create_readme_excludes": ["mirrors/**"],
+             "dangling": "repo"})
+    out = r.stdout + r.stderr
+
+    assert r.returncode == 4, out
+    assert "create-readme axis" in out, out
+    assert "dangling axis" in out, out
+
+
+def test_a_single_empty_owner_is_named_not_swallowed(sandbox):
+    """`["" ]` is the likeliest shape of the typo (a half-filled template line) and the one the
+    joined value cannot distinguish from an absent key — it went through silently, axis running with
+    no ownership at all and going green as if it had checked."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+
+    r = run({"mode": "max", "web": True, "own_web": [""]})
+
+    assert "every entry is empty" in (r.stdout + r.stderr), r.stdout + r.stderr
+
+
+def test_some_empty_owners_among_good_ones_are_named_too(sandbox):
+    """The all-empty case was covered and this one was not, so the config could list three owners,
+    enforce one, and say nothing — fewer owners than the file claims, with a clean exit."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+
+    r = run({"mode": "max", "web": True, "own_web": ["owned", "", ""]})
+
+    assert "2 empty entry/entries out of" in (r.stdout + r.stderr), r.stdout + r.stderr
+
+
+def test_own_web_of_only_empty_entries_still_trips_the_pass_never_runs_warning(sandbox):
+    """F4 read presence off the JOINED value, so an owner list of empty strings looked absent to it
+    too: configured under mode=check it said nothing at all."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+
+    r = run({"mode": "check", "web": True, "own_web": [""]})
+
+    assert "NOT being applied" in (r.stdout + r.stderr), r.stdout + r.stderr

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -89,12 +89,15 @@ def sandbox(tmp_path):
     )
     shim.chmod(0o755)
 
-    def run(config: dict, argv_log: Path | None = None) -> subprocess.CompletedProcess:
+    def run(config: dict, argv_log: Path | None = None, uvx_dir: Path | None = None,
+            extra_env: dict | None = None) -> subprocess.CompletedProcess:
         (repo / "darnlink-gate.json").write_text(json.dumps(config))
         env = _clean_env()
         if argv_log is not None:
             env["DARNLINK_ARGV_LOG"] = str(argv_log)
-        env["PATH"] = f"{bindir}{os.pathsep}" + env.get("PATH", "")
+        if extra_env:
+            env.update(extra_env)
+        env["PATH"] = f"{uvx_dir or bindir}{os.pathsep}" + env.get("PATH", "")
         env["DARNLINK_BIN"] = _darnlink_bin()
         return subprocess.run(
             ["bash", str(RECIPE)], cwd=repo, env=env, capture_output=True, text=True
@@ -560,7 +563,7 @@ def test_own_web_max_without_own_web_is_a_config_error_not_a_verdict(sandbox):
 
     out = r.stdout + r.stderr
     assert r.returncode == 0, out
-    assert "CONFIG error" in out and "did NOT run" in out
+    assert "CONFIG" in out and "did NOT run" in out
 
 
 def test_a_junk_own_web_max_is_ignored_not_treated_as_infinite(sandbox):
@@ -631,3 +634,73 @@ def test_absent_keys_leave_the_command_line_untouched(sandbox, tmp_path):
 
     web = [l for l in log.read_text().splitlines() if "web-check" in l]
     assert web and "--own" not in web[0], web
+
+
+def test_an_exit_1_is_NOT_swallowed_for_a_repo_that_never_opted_in(sandbox, tmp_path):
+    """The blocking defect this pass shipped with: the swallow was unconditional, so ANY exit 1 —
+    `uvx` failing on its own, an uncaught Python exception — turned green for every consumer with
+    `web: true`, including those who never adopted 016. Worse than before the key existed."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+    fake = tmp_path / "exit1bin"
+    fake.mkdir()
+    (fake / "uvx").write_text('#!/usr/bin/env bash\ncase " $* " in *" web-check "*) exit 1;; esac\n'
+                              'args=("$@"); [ "${args[0]:-}" = "--from" ] && args=("${args[@]:2}")\n'
+                              '[ "${args[0]:-}" = "darnlink" ] && args=("${args[@]:1}")\n'
+                              'exec "${DARNLINK_BIN:-darnlink}" "${args[@]}"\n')
+    (fake / "uvx").chmod(0o755)
+
+    r = run({"mode": "max", "web": True}, uvx_dir=fake)   # no own_* keys at all
+
+    assert r.returncode == 1, r.stdout + r.stderr
+
+
+def test_under_fail_closed_a_config_error_is_not_a_pass(sandbox, tmp_path):
+    """In CI the gate IS the wall: an axis that could not run must not read as one that ran clean.
+    Fail-open drops it with a warning; fail-closed makes it 4 — and the later axes still execute,
+    because bail() would exit the script and skip them."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+
+    r = run({"mode": "max", "web": True, "own_web_max": 5, "fail_closed": True})
+
+    assert r.returncode == 4, r.stdout + r.stderr
+    assert "not a pass" in (r.stdout + r.stderr)
+
+
+def test_an_explicit_zero_budget_reaches_the_cli(sandbox, tmp_path):
+    """`own_web_max: 0` is the value whose distinction from "absent" is the whole point of FR-012, and
+    it was the one not covered: a mutation that dropped the explicit 0 survived the suite."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+    log = tmp_path / "argv.log"
+
+    run({"mode": "max", "web": True, "own_web": ["owned"], "own_web_max": 0}, argv_log=log)
+
+    web = [l for l in log.read_text().splitlines() if "web-check" in l]
+    assert web and "--own-max 0" in web[0], web
+
+
+def test_the_env_overrides_win_over_the_json(sandbox, tmp_path, monkeypatch):
+    """Both new env keys were added to the leak-scrub list and then never exercised: renaming either
+    one in the recipe left the whole suite green."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+    log = tmp_path / "argv.log"
+
+    run({"mode": "max", "web": True, "own_web": ["owned"], "own_web_max": 3}, argv_log=log,
+        extra_env={"DARNLINK_GATE_OWN_WEB_MAX": "9", "DARNLINK_GATE_OWN_WEB_FROM_ORIGIN": "1"})
+
+    web = [l for l in log.read_text().splitlines() if "web-check" in l]
+    assert web and "--own-max 9" in web[0] and "--own-from-origin" in web[0], web
+
+
+def test_own_web_configured_where_the_pass_never_runs_says_so(sandbox):
+    """Configured under mode=check the rule simply does not apply, and a no-op that reads like
+    protection is what the CLI itself refuses to be."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+
+    r = run({"mode": "check", "web": True, "own_web": ["owned"]})
+
+    assert "NOT being applied" in (r.stdout + r.stderr)

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -43,6 +43,7 @@ _LEAKY_ENV = (
     "DARNLINK_REF", "DARNLINK_GATE_MODE", "DARNLINK_GATE_SCOPE", "DARNLINK_GATE_FAIL_CLOSED",
     "DARNLINK_GATE_WEB", "DARNLINK_GATE_CREATE_README", "DARNLINK_GATE_TOKEN_FILE",
     "DARNLINK_GATE_DANGLING", "DARNLINK_GATE_DANGLING_MAX",
+    "DARNLINK_GATE_OWN_WEB_FROM_ORIGIN", "DARNLINK_GATE_OWN_WEB_MAX",
     # ⚠️ And git's own. `git` exports these to every hook it runs, so when this suite is executed
     # FROM the repo's pre-commit hook (`tools/check.sh`), an un-scrubbed `git` in a test inherits
     # GIT_DIR from the outer repo while using the sandbox as its work tree. That combination is not
@@ -80,13 +81,19 @@ def sandbox(tmp_path):
         'args=("$@")\n'
         '[ "${args[0]:-}" = "--from" ] && args=("${args[@]:2}")\n'   # drop `--from <ref>`
         '[ "${args[0]:-}" = "darnlink" ] && args=("${args[@]:1}")\n'  # drop the tool name
+        # Record the argv when asked. A WIRING test cannot assert on the verdict: without a token the
+        # destination is unverifiable and the gate exits 0 whether or not the flag was passed — which
+        # is exactly how a dropped `--own` survived mutation until this existed.
+        '[ -n "${DARNLINK_ARGV_LOG:-}" ] && printf \'%s\\n\' "$*" >> "$DARNLINK_ARGV_LOG"\n'
         'exec "${DARNLINK_BIN:-darnlink}" "${args[@]}"\n'
     )
     shim.chmod(0o755)
 
-    def run(config: dict) -> subprocess.CompletedProcess:
+    def run(config: dict, argv_log: Path | None = None) -> subprocess.CompletedProcess:
         (repo / "darnlink-gate.json").write_text(json.dumps(config))
         env = _clean_env()
+        if argv_log is not None:
+            env["DARNLINK_ARGV_LOG"] = str(argv_log)
         env["PATH"] = f"{bindir}{os.pathsep}" + env.get("PATH", "")
         env["DARNLINK_BIN"] = _darnlink_bin()
         return subprocess.run(
@@ -527,3 +534,100 @@ def test_staged_scope_survives_a_payload_bigger_than_one_env_var(sandbox):
 
     assert "Argument list too long" not in out, out[:400]
     assert r.returncode == 0, out[:400]   # the added line carries no link → nothing to gate on
+
+
+# --- own_web: the feature-016 keys (a list of owners, a boolean, and a budget) ---
+
+def _owned_web_link_without_uuid(repo: Path) -> None:
+    """A plain web link to a `.md` in a repo we will claim as ours, whose destination has no uuid.
+    The gate never reaches the network in these tests: `web-check` is the shimmed local darnlink, and
+    without a token a destination it cannot read is `web_unverifiable`, exit 0. What is exercised here
+    is the WIRING — that the keys reach the CLI at all — not the classification, which lives in
+    tests/test_own_repo_web_strictness.py."""
+    (repo / "A.md").write_text(
+        "# A\nsee [x](https://github.com/owned/repo/blob/main/a.md) plain\n")
+
+
+def test_own_web_max_without_own_web_is_a_config_error_not_a_verdict(sandbox):
+    """Feature 016 makes exit 1 reachable from CONFIGURATION. Reported as a red gate it would send
+    someone hunting for broken links that do not exist; routed to `bail()` it would EXIT the script
+    and skip every axis after it — the bug this pass already fixed once. It warns, drops the axis, and
+    lets the rest of the gate speak."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+
+    r = run({"mode": "max", "web": True, "own_web_max": 5})
+
+    out = r.stdout + r.stderr
+    assert r.returncode == 0, out
+    assert "CONFIG error" in out and "did NOT run" in out
+
+
+def test_a_junk_own_web_max_is_ignored_not_treated_as_infinite(sandbox):
+    """Silently WIDENING an allowance is the one direction a config typo must not be able to go —
+    the same rule `dangling_max` follows. Ignored, and said out loud."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+
+    r = run({"mode": "max", "web": True, "own_web": ["owned"], "own_web_max": "muchos"})
+
+    assert "not a non-negative integer" in (r.stdout + r.stderr)
+
+
+def test_own_web_is_a_list_so_an_owner_called_origin_stays_expressible(sandbox):
+    """`own_web_from_origin` is its own key rather than a sentinel inside the list, for the same
+    reason the CLI has a flag instead of `--own auto`: an owner literally called `origin` must remain
+    a legal input. Here it is passed as a plain owner and the gate accepts it."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+
+    r = run({"mode": "max", "web": True, "own_web": ["origin", "owned"]})
+
+    out = r.stdout + r.stderr
+    assert "CONFIG error" not in out, out       # not rejected as a bad argument
+    assert r.returncode == 0, out
+
+
+def test_the_keys_do_nothing_when_the_web_axis_is_off(sandbox, tmp_path):
+    """`own_web` rides on `web`. With the axis off the pass must not run at all — asserted on the
+    INVOCATION, because the exit code cannot tell: a destination nobody can read is unverifiable and
+    the gate exits 0 whether or not web-check ran."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+    log = tmp_path / "argv.log"
+
+    r = run({"mode": "max", "own_web": ["owned"], "own_web_max": 0}, argv_log=log)
+
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert not [l for l in log.read_text().splitlines() if "web-check" in l], log.read_text()
+
+
+def test_the_owner_keys_actually_reach_the_cli(sandbox, tmp_path):
+    """The wiring itself, asserted on the INVOCATION rather than the verdict. Without a token the
+    destination is unverifiable and the gate exits 0 whether or not the flags were passed, so a
+    verdict-based test cannot tell — and did not: dropping the `--own` loop entirely left every other
+    test in this file green."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+    log = tmp_path / "argv.log"
+
+    run({"mode": "max", "web": True, "own_web": ["owned", "other"],
+         "own_web_from_origin": True, "own_web_max": 3}, argv_log=log)
+
+    web = [l for l in log.read_text().splitlines() if "web-check" in l]
+    assert web, log.read_text()
+    assert "--own owned" in web[0] and "--own other" in web[0]
+    assert "--own-from-origin" in web[0]
+    assert "--own-max 3" in web[0]
+
+
+def test_absent_keys_leave_the_command_line_untouched(sandbox, tmp_path):
+    """The rule every key in this recipe follows: not opting in changes nothing for you."""
+    repo, run = sandbox
+    _owned_web_link_without_uuid(repo)
+    log = tmp_path / "argv.log"
+
+    run({"mode": "max", "web": True}, argv_log=log)
+
+    web = [l for l in log.read_text().splitlines() if "web-check" in l]
+    assert web and "--own" not in web[0], web


### PR DESCRIPTION
Feature 016 shipped in **v0.21.0** — in the CLI. **No gate invoked it**, so it protected nothing. This is the wiring.

## What it adds

Both recipes — bash and PowerShell — read three keys and pass them through:

```json
{ "web": true, "own_web": ["your-org"], "own_web_from_origin": true, "own_web_max": 5 }
```

## Three details, each following a rule an existing key already established

- **`own_web_from_origin` is its own key, not a sentinel inside the list.** An owner literally called `origin` has to stay expressible — the same reason the CLI has a flag rather than `--own auto`.
- **A non-numeric budget counts as ABSENT, never as infinite.** Silently *widening* an allowance is the one direction a config typo must not be able to go; `dangling_max` established that.
- **Exit 1 is read as a likely CONFIG error — but only when this run passed an `own_*` flag.** 016 makes exit 1 reachable from configuration (a budget with no owners, an unresolvable origin), and reporting that as a red gate would send someone hunting for broken links that do not exist. It is **not** exclusively a usage error, though: `uvx` exits 1 on its own failures and an uncaught exception exits 1 too. The first draft of this PR swallowed it unconditionally, and that was a regression measured on a repo carrying **no `own_*` keys at all**: `rc=1` on `main`, `rc=0` on the branch, with `fail_closed: true` not rescuing it. So the swallow is guarded by whether a flag was actually passed, and under `fail_closed` it does not become a pass — it becomes **4**, marked final, *not* routed to `bail()` (which exits the script and would skip every axis after this one, the bug this same pass was fixed for in #45).

## The tests assert the invocation, not the verdict

That is not a style choice. Without a token an unreadable destination is `web_unverifiable` and the gate exits 0 **whether or not the flags were passed**, so a verdict-based test cannot tell the difference — and did not: **dropping the `--own` loop entirely left every other recipe test green** until the shim started recording argv. The same held for the web guard itself: *"the keys do nothing when the axis is off"* passed with the guard removed.

## What two adversarial rounds changed

Every item below was found by mutation, not by reading — each is a line whose removal left the suite green:

- The **unconditional exit-1 swallow** above (blocking; measured against `main` across six exit codes × `fail_closed`, now byte-identical in all twelve cells for a repo with no `own_*` keys).
- **`own_web_max: 0` was dropped by the PowerShell recipe**: `CfgOr` tests truthiness and PowerShell reads JSON `0` as `$false`, so the one value whose distinction from *absent* is the entire point of a budget silently became absent. Read by property presence now — and the same fix was needed for `own_web`, where a one-element list unwraps to its element.
- **The `RC_IS_FINAL` immunity had no test.** `web-check`'s codes are all in 0..4 and none of them means *unreachable*, so its `4` — exactly how 016 reports an owned destination with no uuid — must escape the `rc>3` fail-open heuristic. Removing the immunity turned a genuine 4 into **0** under the default, with the whole suite green.
- **Empty owner entries passed silently.** `["" ]` flattens to exactly what an absent key gives, so the list length is now read separately; a partially-empty list is named too (the config listed three owners and enforced one).
- Two warnings existed **only in bash**; both are in the `.ps1` now.
- **Nothing had ever parsed `darnlink-gate.ps1`** — the recipe tests skip on Windows and no job ran `pwsh`. A parse job is added to CI.

**325 tests.** Mutations killed: the three `own_*` flags each arming the swallow on its own, the `web` guard, ignoring `fail_closed`, `4`→`1`, `bail()` instead of a final rc, both empty-entry warnings, the F4 presence read, non-numeric budget acceptance, dropping the explicit `0`, and the `RC_IS_FINAL` immunity.

## Not in this PR

Turning the keys on anywhere. The fleet is at zero owned-without-uuid links today, so the rule would find nothing — its value is keeping that zero, and that is a per-repo decision.
