### PR TITLE
recipes: the pin lives in one place, and the examples finally get a gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,10 @@ All notable changes to darnlink are documented here. The format is based on
   Nothing reads it, which is the shape of a mine rather than a bug: harmless until someone adds
   `--version` or trusts `darnlink.__version__`, at which point the tool lies about itself. Derived
   from the installed package metadata now, and **lazily** (PEP 562): importing it eagerly cost
-  **+33 ms, +34 %** on `import darnlink.cli`, and darnlink runs as a pre-commit hook on every commit.
+  **+34 %** on `import darnlink.cli` — `importlib.metadata` drags in the whole `email` stack — and
+  darnlink runs as a pre-commit hook on every commit. The percentage is what reproduces: two
+  independent runs of the same A/B agreed on ~34 % and disagreed on the absolute (+33 ms vs +45 ms),
+  so the milliseconds belong to the machine and are not quoted as a property of the change.
 
 ### Added
 - **`tests/test_recipe_examples.py` — the examples are code, and nothing had ever run them.** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Fixed
+- **The shipped CI examples carried their own copy of the pin, and both had rotted.** Measured
+  against the tags on the day this changed: the GitHub Actions example was pinned at `v0.20.4` with
+  **2** releases published since, the Jenkins one at `v0.7.0` with **22** — wrong for over a year.
+  They are the copy-paste templates for the very consumption path a release exists to serve, so a new
+  adopter silently installed a gate far behind the one being documented. The canonical
+  `recipes/README.md` was worse: its `curl` block *told you* to pin `v0.7.0`.
+
+  Both examples now **derive** the version from the `ref` in `darnlink-gate.json`, reading the **key**
+  with the JSON parser the recipe already depends on — not grepping the file, where a version string
+  anywhere else (an excluded path, say) would win silently, which is the same "quietly picks a
+  version" failure the step exists to prevent, one layer up. Any ref shape the recipe accepts works:
+  tag, branch or SHA. The one it does not cover is a `ref` with no `@version` at all, and it says so.
+
+  *Nothing fails when two copies of a version number drift* — which is why the second copy is gone
+  rather than synchronised.
+
+- **`__version__` said `0.5.0` against `0.22.0` in `pyproject.toml`** — seventeen minors adrift.
+  Nothing reads it, which is the shape of a mine rather than a bug: harmless until someone adds
+  `--version` or trusts `darnlink.__version__`, at which point the tool lies about itself. Derived
+  from the installed package metadata now, and **lazily** (PEP 562): importing it eagerly cost
+  **+33 ms, +34 %** on `import darnlink.cli`, and darnlink runs as a pre-commit hook on every commit.
+
+### Added
+- **`tests/test_recipe_examples.py` — the examples are code, and nothing had ever run them.** The
+  release that added a `ps1-syntax` job on exactly that argument then put non-trivial shell into two
+  example files with no gate at all. The tests **extract** the commands from the example files and
+  execute them: against tag, branch, SHA and `@`-in-the-host refs, against a decoy version elsewhere
+  in the JSON, and against the four cases that must fail loudly. Extracted rather than copied, so the
+  examples cannot drift while the test passes against its own private copy.
+
+- **A rung for feature 016 in `docs/elevating-your-link-gate.md`.** The ladder that tells a consumer
+  how to climb never mentioned the rule, two releases after it shipped. §9 covers the keys, the
+  exemption marker, and the traps that only show up when measured — including that **the pin and the
+  keys must move in the same commit**, because an older CLI turns the whole axis into a green no-op,
+  and that a **bare URL is invisible to the web axis** (only Markdown-syntax links are seen).
+
 ## [0.22.0] — 2026-08-13
 
 > ### ⚠️ Moving your pin to this release CAN turn a green gate red — without you changing anything

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ All notable changes to darnlink are documented here. The format is based on
 ### Fixed
 - **The shipped CI examples carried their own copy of the pin, and both had rotted.** Measured
   against the tags on the day this changed: the GitHub Actions example was pinned at `v0.20.4` with
-  **2** releases published since, the Jenkins one at `v0.7.0` with **22** — wrong for over a year.
+  **3** releases published since, the Jenkins one at `v0.7.0` with **23** — and `v0.7.0` is 23 days
+  old, in a project that is 34 days old. The drift is measured in releases, not in time: this moves
+  fast enough that a pin can be twenty-three releases stale and less than a month old.
   They are the copy-paste templates for the very consumption path a release exists to serve, so a new
   adopter silently installed a gate far behind the one being documented. The canonical
   `recipes/README.md` was worse: its `curl` block *told you* to pin `v0.7.0`.

--- a/docs/elevating-your-link-gate.md
+++ b/docs/elevating-your-link-gate.md
@@ -323,8 +323,14 @@ Three things worth knowing before turning it on:
 - **The pin and the keys must move in the SAME commit.** A CLI older than v0.21.0 does not know the
   flags, so `web-check` exits 1 as a usage error, the recipe reads that as a config problem and drops
   the axis — with a warning on stderr, but a **green** exit under the default fail-open. Measured.
-- **`<!-- darnlink-own-exempt -->`** next to a link exempts it — for a destination that is
-  machine-generated, where adding frontmatter is not yours to decide. Never anchored, never stale.
+- **`<!-- darnlink-own-exempt -->` exempts a link — placed immediately after it, on the SAME line.**
+  For a destination that is machine-generated, where adding frontmatter is not yours to decide.
+  Never anchored, never stale.
+  ⚠️ On the line *above* — which is the natural way to write it, and how the tests name that case —
+  it does **not** exempt: measured, the link still reports `own_no_uuid` and the run still exits 4.
+  That is deliberate. A marker that reached across a newline would let one placed on its own line
+  silently exempt whatever link happened to sit above it, which is a false green in the direction
+  that matters.
 - **Only Markdown-syntax links are seen.** A bare `https://…` URL pasted into a list is invisible to
   the entire web axis: not anchored, not verified, not even counted as unverifiable. Measured with
   both spellings of the same URL in the same file — one finding, not two. So a clean web number is a

--- a/docs/elevating-your-link-gate.md
+++ b/docs/elevating-your-link-gate.md
@@ -284,6 +284,59 @@ Why it's safe to add to an existing fail-closed gate:
 Add it as one extra step in the wall (pre-push + CI), and give it a token — for **quota** on public
 targets, for **permission** on private ones.
 
+## 9. The last rung: stop letting your OWN repos off the hook (`own_web`)
+
+Everything in §8 is forgiving on purpose. A destination that fetches 200 but has no `uuid` is
+`web_unverifiable` and the run still exits 0, because the file lives in **someone else's**
+repository: you cannot add frontmatter to a repo you do not control, and a gate that fails on
+something you cannot fix is a gate people delete.
+
+That reasoning stops applying the moment the destination is **yours**. Then it is not an external
+limitation — it is a missing two-line edit in a repo you control, and until this rung existed nothing
+ever said so. The link stayed un-anchorable forever, counted in the same bucket as a link into a
+stranger's repository.
+
+Your `darnlink-gate.json` needs `"web": true` and `"mode": "max"` already; then add the keys. It is
+**one JSON object** — the block below shows the three keys together, not three separate files, and it
+has no comments in it, because the recipe parses this file with a strict JSON reader and swallows the
+error: a file it cannot parse gives you *every key at its default*, silently, including a `ref` far
+older than yours.
+
+```json
+{
+  "own_web_from_origin": true,
+  "own_web": ["your-org", "your-user"],
+  "own_web_max": 5
+}
+```
+
+`own_web_from_origin` adds this repo's own GitHub owner; `own_web` names owners explicitly (the two
+combine); `own_web_max` is a budget, so you can adopt before you are at zero.
+
+A finding is `web_own_no_uuid`, and it names owner, repo and path so you know which file to open. It
+never suggests `--write`: darnlink cannot fix this one from here — the edit belongs in the other
+repository. It fails the gate at **exit 4** — *unless* a budget covers it, which is exactly what
+`own_web_max` is for: under the budget the finding is still reported, only the verdict is silenced.
+
+Three things worth knowing before turning it on:
+
+- **The pin and the keys must move in the SAME commit.** A CLI older than v0.21.0 does not know the
+  flags, so `web-check` exits 1 as a usage error, the recipe reads that as a config problem and drops
+  the axis — with a warning on stderr, but a **green** exit under the default fail-open. Measured.
+- **`<!-- darnlink-own-exempt -->`** next to a link exempts it — for a destination that is
+  machine-generated, where adding frontmatter is not yours to decide. Never anchored, never stale.
+- **Only Markdown-syntax links are seen.** A bare `https://…` URL pasted into a list is invisible to
+  the entire web axis: not anchored, not verified, not even counted as unverifiable. Measured with
+  both spellings of the same URL in the same file — one finding, not two. So a clean web number is a
+  statement about your `[text](url)` links, and about nothing else.
+
+**Expect a backlog on the first run, and budget for it.** Measured on a nine-repository fleet the day
+this feature was specified: **17 confirmed** links to files we owned and had never given a `uuid`
+(and up to 24 counting the unresolved). That is why `own_web_max` exists — it is a budget, not a
+cliff. Once that debt is paid the number stays at or near zero and the rung changes job: on the same
+fleet two days later, with the eight web-enabled repos cleaned up, switching the rule on found
+**one**. Both numbers are real; which one you get depends entirely on whether you have paid yet.
+
 ## Checklist
 
 - [ ] Read the gap with `--robustify --create-frontmatter`; split into Bucket A / Bucket B.

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -100,23 +100,23 @@ The gate runs at three layers, each at the scope that fits — **deliberate, not
 [`docs/elevating-your-link-gate.md §7`](../docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 -->): staged & fast locally,
 whole-repo where it's the wall.
 
-**1. Config** — `darnlink-gate.json` at the repo root (all keys optional). Replace `<latest-tag>`
-with a real tag from [releases](https://github.com/txemi/darnlink/releases) — a pin, never a branch.
-
-⚠️ **Do not add `//` comments to it.** JSON has none, and a config that does not parse does not fail
-loudly on every surface: the local hooks revert *every* key to its default and go green having
-validated a policy written in no file. (This very document shipped two commented examples for
-exactly one commit. Copied verbatim, they ran an old pinned version with zero excludes, green.)
+**1. Config** — `darnlink-gate.json` at the repo root (all keys optional):
 
 ```json
 {
-  "ref": "git+https://github.com/txemi/darnlink@<latest-tag>",
+  "ref": "git+https://github.com/txemi/darnlink@vX.Y.Z",
   "excludes": ["secrets", "external_repos"],
   "ignore_blocks": ["txmd-autogrid"],
   "mode": "check",
   "scope": "repo"
 }
 ```
+
+⚠️ **`vX.Y.Z` is a placeholder, and it is the one thing here you must not copy verbatim.** Resolve it
+when you paste — `gh release view -R txemi/darnlink --json tagName -q .tagName` — because this is the
+*only* pin: every CI surface derives from it. A concrete tag printed in a document is how the last
+one rotted; it sat at `v0.7.0` through **22** releases, quietly recommending a gate from well over a
+year earlier. The recipe itself says the same thing about its own header, for the same reason.
 
 **Repos with a big `mirrors/` tree** (a faithful local copy of an external system) usually want a
 fourth shape: enforce robustify + the create-readme axis, but skip README-creation *under the mirror*
@@ -125,7 +125,7 @@ the mirror. Two keys make that expressible:
 
 ```json
 {
-  "ref": "git+https://github.com/txemi/darnlink@<latest-tag>",
+  "ref": "git+https://github.com/txemi/darnlink@vX.Y.Z",
   "mode": "check",
   "create_readme": true,
   "create_readme_excludes": ["mirrors"],
@@ -180,43 +180,19 @@ not snippets to assemble (assembling the CI one wrong yields a wall that fails *
 any CI can fetch it **without a token** (no private checkout, no cred):
 
 ```bash
-VER=$(jq -re 'if has("ref") then .ref else error("darnlink-gate.json has no \"ref\"") end | split("@") | last' darnlink-gate.json)
+# Derive the version from the `ref` you already declared — do NOT write a second copy of it here.
+VER=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json"))["ref"].rsplit("@",1)[1])')
 curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate" -o darnlink-gate
 chmod +x darnlink-gate
 ```
 
-The tag comes from your `darnlink-gate.json`, so the gate is deterministic and there is only ever
-one place to bump. **A moving ref (`main`, or a major alias like `v1`) is not a pin** — both resolve
-and both fetch different code over time. Do not grep the json for a version either: a regex happily
-matches one inside some OTHER key and fetches a real-but-wrong tag with no error at all.
-
-Windows agents fetch `darnlink-gate.ps1` the same
-way. Locally, drop it on your `PATH` (e.g. `~/.local/bin`).
-
-## If your CI reuses its workspace, clean up after every other stage
-
-The gate scans the tree **recursively** from `git rev-parse --show-toplevel`. On hosted runners that
-never matters — the workspace is fresh each run. On a **self-hosted agent it persists between
-builds**, so anything another stage leaves behind (a report directory, a clone of some other repo)
-is inside your tree by the time the gate looks, and the gate fails on files that are not yours.
-
-Two habits fix it, and both belong to the stages that create the mess, not to this one:
-
-- **clone foreign repos OUTSIDE the workspace** — a sibling directory, not a subdirectory;
-- **remove generated directories after archiving them** (in Jenkins, `post { always { … } }`).
-
-⚠️ **Do not reach for `excludes` here** — and note this is the one case where it is wrong, which is
-why the distinction matters:
-
-| What it is | Lives in | Right tool |
-|---|---|---|
-| **Vendored or generated everywhere** — a foreign repo you committed, or a tree every machine regenerates (`.pytest_cache`, `output`) | in git, or in every clone alike | `excludes` ✅ |
-| **CI litter** — what another stage wrote into the workspace this build | nowhere, only on that agent | **clean it up** ❌ not `excludes` |
-
-Excluding litter silences *this* gate and leaves every other tree-scanning check in your pipeline
-broken: you have not removed the foreign files, only stopped one tool from mentioning them. And the
-exclude then sits in the config of every clone, describing a mess that only ever existed on one
-agent.
+**One pin, and it lives in `darnlink-gate.json`.** This block used to hard-code a tag and tell you to
+keep it pinned — and that instruction is what rotted: it sat at `v0.7.0` for **22 releases**, quietly
+telling every new adopter to install a gate far behind the one documented right above it. Nothing
+fails when two copies of a version number drift, so the second copy has to go rather than be kept in
+sync. `-f` so a moved or typo'd version is a 404 instead of a file containing the words
+"404: Not Found". Windows agents fetch `darnlink-gate.ps1` the same way. Locally, drop it on your
+`PATH` (e.g. `~/.local/bin`).
 
 ## Notes
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -115,8 +115,8 @@ whole-repo where it's the wall.
 ⚠️ **`vX.Y.Z` is a placeholder, and it is the one thing here you must not copy verbatim.** Resolve it
 when you paste — `gh release view -R txemi/darnlink --json tagName -q .tagName` — because this is the
 *only* pin: every CI surface derives from it. A concrete tag printed in a document is how the last
-one rotted; it sat at `v0.7.0` through **22** releases, quietly recommending a gate from well over a
-year earlier. The recipe itself says the same thing about its own header, for the same reason.
+one rotted; it sat at `v0.7.0` through **23** releases, quietly recommending a gate far behind the one
+documented beside it. The recipe itself says the same thing about its own header, for the same reason.
 
 **Repos with a big `mirrors/` tree** (a faithful local copy of an external system) usually want a
 fourth shape: enforce robustify + the create-readme axis, but skip README-creation *under the mirror*
@@ -187,7 +187,7 @@ chmod +x darnlink-gate
 ```
 
 **One pin, and it lives in `darnlink-gate.json`.** This block used to hard-code a tag and tell you to
-keep it pinned — and that instruction is what rotted: it sat at `v0.7.0` for **22 releases**, quietly
+keep it pinned — and that instruction is what rotted: it sat at `v0.7.0` for **23 releases**, quietly
 telling every new adopter to install a gate far behind the one documented right above it. Nothing
 fails when two copies of a version number drift, so the second copy has to go rather than be kept in
 sync. `-f` so a moved or typo'd version is a 404 instead of a file containing the words

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -45,8 +45,11 @@
 #   Resolve it when you paste:
 #       gh release view -R txemi/darnlink --json tagName -q .tagName
 #   A concrete tag written into this comment is exactly how the example rotted last time: it sat at
-#   v0.7.0 for thirteen releases and quietly recommended two rungs below what its own author was
-#   running. Any pin printed here ages the moment it is committed, so no pin is RECOMMENDED here.
+#   v0.7.0 and quietly recommended two rungs below what its own author was running. Any pin printed
+#   here ages the moment it is committed, so no pin is RECOMMENDED here.
+#   (This note used to say "for thirteen releases". It was 13 when written and 23 by v0.22.0 — a
+#   count in prose ages exactly like the pin it warns about, so the number is gone rather than
+#   maintained. The current figure lives in recipes/README.md, where it is dated.)
 #
 #   The one tag this file does print -- the `ref` fallback further down -- is not a recommendation:
 #   it is the version this script runs when a repo declares none, and it is frozen at whatever it

--- a/recipes/examples/Jenkinsfile-stage.groovy
+++ b/recipes/examples/Jenkinsfile-stage.groovy
@@ -1,29 +1,16 @@
 // EXAMPLE Jenkins stage — darnlink link gate, the SERVER-SIDE wall (piece 4, self-hosted).
 //
 // The natural home for the wall on a PRIVATE repo where hosted CI minutes are billed or branch
-// protection is unavailable: a self-hosted agent runs the same check with no billing.
+// protection is unavailable: a self-hosted agent runs the same check with no billing. Fetches the
+// PINNED recipe from the PUBLIC darnlink repo — no credentials — and runs it FAIL-CLOSED.
 //
 // INSTALL: drop this stage into your declarative Jenkinsfile's `stages { … }`.
-// ASSUMES: `uvx` and `python3` on the agent (the recipe needs python3 anyway to read the json).
-//          `astral-sh` installs `uv` into ~/.local/bin; if that is not on PATH, prepend it inside
-//          the sh block. The optional token block needs the Credentials Binding plugin.
-//
-// ONE PIN, and it lives in darnlink-gate.json. Do not hardcode a version here and do not set
-// `DARNLINK_REF`: the recipe reads that variable as an ENV OVERRIDE THAT WINS over the json, so a
-// tag left in a committed Jenkinsfile silently overrides what the repo asked for, and bumping the
-// json does nothing. (The override itself is useful — to try an unreleased build from one branch —
-// just never leave it committed.)
+// ASSUMES: `uvx` is available on the agent. `astral-sh` installs `uv` into ~/.local/bin; if it isn't
+//          on PATH, prepend it (e.g. `export PATH="$HOME/.local/bin:$PATH"`) inside the sh block.
+// The pin is DERIVED from darnlink-gate.json, never repeated here. Two copies of a version number is
+// one copy too many: this file carried its own tag and it went stale, because nothing fails when two
+// copies drift. Bump `darnlink-gate.json` and both CI surfaces move with it.
 
-// ⚠️ IF your darnlink-gate.json sets `"web": true`, WRAP the `sh` block below in:
-//
-//     withCredentials([string(credentialsId: 'your-github-readonly-pat', variable: 'GITHUB_TOKEN')]) {
-//       sh ''' … '''
-//     }
-//
-// Without a token the web check does NOT fail — every link comes back `web_unverifiable` and the
-// stage goes GREEN having verified ZERO web links. A gate that cannot do its job should say so, not
-// pass quietly. It is left OUT of the code below so the example runs as copy-pasted: an unresolvable
-// credentialsId aborts the stage, and `"web": false` is the default.
 stage('darnlink gate (links)') {
   environment {
     DARNLINK_GATE_FAIL_CLOSED = '1'   // the wall must fail closed
@@ -31,25 +18,19 @@ stage('darnlink gate (links)') {
   steps {
     sh '''
       set -eu
-      ROOT=$(git rev-parse --show-toplevel)
-
-      # `ref` is optional to the recipe (it falls back to a default frozen at v0.7.0 — old, and NOT
-      # the version you fetched), but this example insists on it: an unpinned gate is not a wall.
-      VER=$(python3 -c 'import json,sys
-cfg = json.load(open(sys.argv[1], encoding="utf-8-sig"))   # -sig: jq tolerates a BOM; python must too
-if "ref" not in cfg:
-    sys.exit("darnlink-gate.json has no \\"ref\\": pin the version there, not in the Jenkinsfile")
-print(cfg["ref"].rsplit("@", 1)[1])' "$ROOT/darnlink-gate.json")
-
-      # OUTSIDE the workspace on purpose: this gate scans the tree recursively, and a stage that
-      # litters the workspace is exactly what the section below warns about.
-      GATE="${WORKSPACE_TMP:-${TMPDIR:-/tmp}}/.darnlink-gate.$$"
-      trap 'rm -f "$GATE"' EXIT        # `set -e` would otherwise skip the cleanup on a red gate
-
+      # Read the `ref` KEY, not the file — byte-identical to the GitHub Actions example on purpose.
+      # A grep for a version-shaped string takes the first match anywhere in the json, so an excluded
+      # path containing one would win silently: the same "silently picks a version" failure this step
+      # exists to prevent. Any ref the recipe accepts works: tag, branch or SHA. python3 is already a
+      # hard dependency of the recipe itself (it parses this same file).
+      VER=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json"))["ref"].rsplit("@",1)[1])') \
+        || { echo "cannot derive the pin: darnlink-gate.json has no ref key, or its ref has no @version" >&2; exit 1; }
       # -f: fail on a 404 (moved/typo'd tag) instead of writing "404: Not Found" and running garbage.
-      curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/${VER}/recipes/darnlink-gate" -o "$GATE"
-      chmod +x "$GATE"
-      "$GATE"                            # scope=repo from darnlink-gate.json
+      curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate" \
+        -o "$WORKSPACE/.darnlink-gate"
+      chmod +x "$WORKSPACE/.darnlink-gate"
+      "$WORKSPACE/.darnlink-gate"          # scope=repo from darnlink-gate.json
+      rm -f "$WORKSPACE/.darnlink-gate"
     '''
   }
 }

--- a/recipes/examples/README.md
+++ b/recipes/examples/README.md
@@ -20,14 +20,24 @@ recipe ([`../darnlink-gate`](../darnlink-gate)) at the scope that fits each laye
 staged locally so parallel contributors don't block each other; whole-repo where the gate is the wall.
 A whole-repo **pre-commit** would deadlock — don't; that's what pre-push is for.
 
-**ONE pin, and it lives in `darnlink-gate.json`.** No example here hardcodes a version: the two CI
-ones derive it from that file's `ref`, and the two hooks never pinned anything. So a `ref` bump takes
-effect everywhere the moment you commit it — there is nothing to "keep in sync".
+**There is only ONE pin, and it is not here.** Both server-side examples *derive* the recipe version
+from your `darnlink-gate.json`'s `ref`, so bumping that one file moves both of them at once. (The
+local hooks are a slightly different story: they `exec darnlink-gate` off your `PATH`, so `ref` moves
+the *CLI* they run but not the recipe script itself — that one is deployed, not fetched per run.)
 
-⚠️ **Do not reach for `DARNLINK_REF` to pin instead.** The recipe reads it as an env override that
-**wins over the json**, so a tag left in a committed workflow silently overrides what the repo asked
-for, and bumping the json does nothing. It is for trying an unreleased build from one branch; never
-commit it.
+This paragraph used to say "keep them in sync, bump both together", and that is precisely how they
+rotted. Measured against the tags on the day this changed: the Actions example was pinned at `v0.20.4`
+with **2** releases published since, and the Jenkins one at `v0.7.0` with **22** — the second had been
+wrong for well over a year. **Nothing fails when two copies of a version number drift.** If you copy
+these into a repo, do not reintroduce a literal tag.
+
+The derivation reads the `ref` **key** rather than grepping the file for something version-shaped —
+a version string anywhere else in the json (an excluded path, say) would otherwise win silently,
+which is the very failure the step exists to prevent. It takes whatever follows the last `@`, so a
+tag, a branch and a SHA all work, and an `@` in the host (`git+ssh://git@github.com/…`) does not
+confuse it. **One shape it does not cover:** a `ref` with *no* `@version` at all. `uvx` accepts that
+(it means the default branch) and the derivation cannot — over ssh it yields a host fragment instead
+of failing, and the `curl -f` turns it into a 404 one step later. Pin a version in `ref`.
 
 **Raising to fail-closed links (`mode=max`)** is a one-line change in `darnlink-gate.json`
 (`"mode": "max"`) once the repo's gap is 0 — the hooks and CI here need no edit. Follow

--- a/recipes/examples/README.md
+++ b/recipes/examples/README.md
@@ -27,8 +27,9 @@ the *CLI* they run but not the recipe script itself — that one is deployed, no
 
 This paragraph used to say "keep them in sync, bump both together", and that is precisely how they
 rotted. Measured against the tags on the day this changed: the Actions example was pinned at `v0.20.4`
-with **2** releases published since, and the Jenkins one at `v0.7.0` with **22** — the second had been
-wrong for well over a year. **Nothing fails when two copies of a version number drift.** If you copy
+with **3** releases published since, and the Jenkins one at `v0.7.0` with **23** — and that `v0.7.0`
+is 23 days old, in a project 34 days old. Staleness here is counted in releases, not in months.
+**Nothing fails when two copies of a version number drift.** If you copy
 these into a repo, do not reintroduce a literal tag.
 
 The derivation reads the `ref` **key** rather than grepping the file for something version-shaped —

--- a/recipes/examples/github-actions-darnlink-gate.yml
+++ b/recipes/examples/github-actions-darnlink-gate.yml
@@ -6,9 +6,12 @@
 # with zero files validated.
 #
 # INSTALL: save as `.github/workflows/darnlink-gate.yml`. Per-repo policy (excludes, mode, scope)
-#          AND the version live in `darnlink-gate.json` — ONE pin, derived below, never copied here.
-#          Do not set `DARNLINK_REF`: the recipe reads it as an ENV OVERRIDE THAT WINS over the json,
-#          so a tag left in a committed workflow silently overrides what the repo asked for.
+#          lives in `darnlink-gate.json` — INCLUDING the pin, which this file DERIVES rather than
+#          repeats. Two copies of a version number is one copy too many: this file carried its own
+#          tag and it went stale, because nothing fails when two copies drift. Deriving makes the
+#          drift impossible instead of asking you to remember. Bump `darnlink-gate.json` and both CI
+#          surfaces move with it. (Not the local hooks: those `exec darnlink-gate` off your PATH, so
+#          `ref` moves the CLI they run, not the recipe script itself.)
 name: darnlink-gate
 
 on: [push, pull_request]
@@ -24,15 +27,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
+      - name: Derive the pin from darnlink-gate.json (single source)
+        run: |
+          # Read the `ref` KEY, not the file. A grep for a version-shaped string takes the first
+          # match anywhere in the json — an excluded path or a comment that happens to contain one
+          # would win silently, which is the same "silently picks a version" failure this step exists
+          # to prevent, one layer up. Any ref the recipe accepts works here: tag, branch or SHA.
+          # python3 is already a hard dependency of the recipe itself (it parses this same file).
+          VER=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json"))["ref"].rsplit("@",1)[1])') \
+            || { echo "::error::cannot derive the pin: darnlink-gate.json has no ref key, or its ref has no @version"; exit 1; }
+          echo "DARNLINK_GATE_VERSION=$VER" >> "$GITHUB_ENV"
       - name: Fetch the pinned recipe (public repo → no token)
         run: |
-          # THE pin, parsed as JSON. Do NOT grep the file for a version: a regex happily matches one
-          # inside some OTHER key (an `excludes` entry, say) and fetches a real-but-wrong tag.
-          # `has("ref")` on purpose: without it a missing key dies on jq's internal type error,
-          # which is loud but says nothing about what to fix.
-          VER=$(jq -re 'if has("ref") then .ref else error("darnlink-gate.json has no \"ref\": pin the version there, not in this workflow") end | split("@") | last' darnlink-gate.json)
           # -f: fail on a 404 (a moved/typo'd tag), instead of silently writing "404: Not Found".
-          curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate" \
+          curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/${DARNLINK_GATE_VERSION}/recipes/darnlink-gate" \
             -o "$RUNNER_TEMP/darnlink-gate"
           chmod +x "$RUNNER_TEMP/darnlink-gate"
       - name: darnlink gate (whole repo)

--- a/src/darnlink/__init__.py
+++ b/src/darnlink/__init__.py
@@ -8,4 +8,35 @@ Plain Markdown, no database, no editor lock-in. Dry-run by default.
 See the project Constitution in .specify/memory/constitution.md.
 """
 
-__version__ = "0.5.0"
+# DERIVED from the installed package metadata, never written by hand. Hand-written, it said "0.5.0"
+# while pyproject.toml said 0.22.0 — seventeen minors adrift, and nothing failed, because nothing
+# reads it yet. That is exactly the shape of a mine: harmless until the day someone adds `--version`
+# or trusts `darnlink.__version__`, at which point the tool lies about itself with a straight face.
+#
+# LAZY (PEP 562), and that is not premature optimisation: `importlib.metadata` drags in the whole
+# `email` stack, and importing it at module level cost **+33 ms, +34 %** on `import darnlink.cli`
+# (median of interleaved runs, same tree, only this file swapped). darnlink runs as a pre-commit hook
+# on every commit across a fleet, so a third of the startup for an attribute nothing reads yet is the
+# wrong trade. This way the cost lands only on whoever actually asks for the version.
+__all__ = ["__version__"]
+
+
+def __getattr__(name: str) -> str:
+    if name != "__version__":
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        # NOTE: this is the version of the INSTALLED distribution, which is not necessarily the
+        # source tree you are importing — running from a checkout against an older installed wheel
+        # reports the wheel's. Right for "what am I running as a tool", wrong for "what is this code".
+        return version("darnlink")
+    except PackageNotFoundError:  # a source tree that was never installed — say so, don't guess
+        return "0+unknown"
+
+
+def __dir__() -> list:
+    # PEP 562 asks for this alongside `__getattr__`: without it the attribute exists and answers
+    # `hasattr`, but `dir(darnlink)` does not list it — so tab-completion and introspection say the
+    # version is not there while `darnlink.__version__` happily returns it.
+    return sorted(set(globals()) | {"__version__"})

--- a/src/darnlink/__init__.py
+++ b/src/darnlink/__init__.py
@@ -14,9 +14,11 @@ See the project Constitution in .specify/memory/constitution.md.
 # or trusts `darnlink.__version__`, at which point the tool lies about itself with a straight face.
 #
 # LAZY (PEP 562), and that is not premature optimisation: `importlib.metadata` drags in the whole
-# `email` stack, and importing it at module level cost **+33 ms, +34 %** on `import darnlink.cli`
-# (median of interleaved runs, same tree, only this file swapped). darnlink runs as a pre-commit hook
-# on every commit across a fleet, so a third of the startup for an attribute nothing reads yet is the
+# `email` stack, and importing it at module level cost **+34 %** on `import darnlink.cli` (median of
+# interleaved runs, same tree, only this file swapped). Quoted as a percentage on purpose: two
+# independent runs of the same A/B agreed on ~34 % and disagreed on the absolute (+33 ms vs +45 ms),
+# so the milliseconds are the machine's, not the change's. darnlink runs as a pre-commit hook on
+# every commit across a fleet, so a third of the startup for an attribute nothing reads yet is the
 # wrong trade. This way the cost lands only on whoever actually asks for the version.
 __all__ = ["__version__"]
 

--- a/tests/test_recipe_examples.py
+++ b/tests/test_recipe_examples.py
@@ -99,7 +99,7 @@ def test_the_two_examples_derive_the_pin_identically():
 ], ids=lambda p: p.name)
 def test_no_shipped_recipe_doc_carries_a_literal_pin(path):
     """The failure this whole approach exists to prevent: a second copy of the version number.
-    Measured on the day it was replaced — one file was 2 releases stale, the other 22 — and nothing
+    Measured on the day it was replaced — one file was 3 releases stale, the other 23 — and nothing
     had ever checked, which is exactly why both drifted."""
     literal = re.findall(r"darnlink[/@]v\d+\.\d+\.\d+", path.read_text(encoding="utf-8"))
     assert not literal, f"{path.name} reintroduced a literal pin: {literal}"
@@ -116,6 +116,37 @@ def test_the_actions_example_is_valid_yaml_and_wires_the_derivation_through():
     assert "GITHUB_ENV" in derive["run"]
     assert "${DARNLINK_GATE_VERSION}" in fetch["run"]
     assert steps.index(derive) < steps.index(fetch)
+
+
+def test_the_jenkins_example_fetches_the_version_it_derived():
+    """The Actions example had this check and Jenkins did not, so the Jenkins file could derive
+    `$VER` correctly and then fetch a hard-coded tag with the whole suite green — the exact failure
+    this PR exists to prevent, surviving in the file it claimed to have covered. Measured: pointing
+    its curl at a fixed tag left every test passing.
+
+    Asserted on the fetch line rather than by parsing Groovy: what matters is that the URL consumes
+    the derived value and nothing else, and no-literal-pin (above) is what stops it being replaced
+    by a tag."""
+    text = JENKINS.read_text(encoding="utf-8")
+    fetch = next((l for l in text.splitlines() if "raw.githubusercontent.com" in l), None)
+    assert fetch, "no curl of the recipe found in the Jenkins example"
+    assert "$VER" in fetch, f"the fetch does not consume the derived version: {fetch.strip()}"
+    assert "-f" in fetch, "curl must fail on a 404 rather than write '404: Not Found' to disk"
+    assert text.index("VER=$(") < text.index("raw.githubusercontent.com"), "derive before fetch"
+
+
+@pytest.mark.parametrize("path", [ACTIONS, JENKINS, EXAMPLES.parent / "README.md"],
+                         ids=lambda p: p.name)
+def test_every_recipe_fetch_points_at_this_repo(path):
+    """These files are copy-paste templates that download a script and run it. Repointing the host
+    or the owner is the highest-consequence single-token edit in the repo and nothing checked it:
+    swapping `txemi/darnlink` for another owner left the whole suite green, in both examples and in
+    the canonical README."""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if "raw.githubusercontent.com" not in line:
+            continue
+        assert "raw.githubusercontent.com/txemi/darnlink/" in line, (
+            f"{path.name} fetches the recipe from somewhere else: {line.strip()}")
 
 
 @pytest.mark.parametrize("ref,expected", [

--- a/tests/test_recipe_examples.py
+++ b/tests/test_recipe_examples.py
@@ -1,0 +1,185 @@
+"""The shipped CI examples are code, and until now nothing parsed or ran them.
+
+This release's own *Fixed* entry is "nothing had ever parsed `recipes/darnlink-gate.ps1`" — and the
+same commit put non-trivial shell into two example files with no gate at all. These are whole working
+files people copy verbatim into a repo, so a syntax error or a wrong pin in them ships straight to an
+adopter, and the adopter has no reason to doubt it.
+
+The pin derivation gets the most attention because it is the piece that decides WHICH gate runs. A
+derivation that quietly resolves to the wrong version is worse than a stale literal: the literal at
+least tells you what it is.
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Only the tests that EXECUTE the derivation need a POSIX shell. The text checks — no literal pin, the
+# two examples agreeing, the YAML wiring, the lazy version — are the ones most likely to rot and cost
+# nothing to run anywhere, so they stay live on Windows rather than being skipped with the rest. A
+# module-wide skip here would have been the easy call and would have left the Windows matrix
+# validating none of this.
+#
+# ⚠️ The platform test comes FIRST and `shutil.which` is only a fallback, because on a GitHub
+# windows-latest runner `bash` IS on PATH: it is the WSL launcher, so `which` finds it and then every
+# invocation exits 1 with "Windows Subsystem for Linux has no installed distributions" — a UTF-16
+# message, which is how it arrived here. A `which("bash") is None` guard alone does not skip; it turns
+# the whole matrix red. Measured on this very PR.
+requires_bash = pytest.mark.skipif(
+    sys.platform.startswith("win") or os.name == "nt" or shutil.which("bash") is None,
+    reason="the derivation is POSIX shell; Windows agents run the .ps1 recipe instead",
+)
+
+EXAMPLES = Path(__file__).resolve().parent.parent / "recipes" / "examples"
+ACTIONS = EXAMPLES / "github-actions-darnlink-gate.yml"
+JENKINS = EXAMPLES / "Jenkinsfile-stage.groovy"
+# Both examples are EXECUTED, not just compared. Running only the Actions one left the Jenkins file
+# effectively ungated: an adversarial round sowed seven defects in it — a deleted failure guard, a
+# silent `VER=v0.7.0` fallback, a `\.` that is a Groovy compile error, a curl repointed at another
+# owner — and the suite stayed green on all seven, while the commit message claimed the mutations
+# were killed. They were killed in the file the tests actually touched.
+EXECUTED = (ACTIONS, JENKINS)
+
+# Two extractions, on purpose. The python3 call is IDENTICAL in both examples and is compared as
+# such; the failure branch is not — Actions wants a `::error::` annotation, Jenkins plain stderr.
+# Both are extracted rather than duplicated here: a copy in the test would let the examples drift
+# while the test kept passing against its own private copy.
+_PY_RE = re.compile(r"(python3 -c '[^']*')")
+_FULL_RE = re.compile(r"^[ \t]*(VER=\$\(python3 -c '[^']*'\)[ \t]*\\\n.*?\})", re.MULTILINE | re.DOTALL)
+
+
+def _py_call(path: Path) -> str:
+    m = _PY_RE.search(path.read_text(encoding="utf-8"))
+    assert m, f"no `python3 -c …` derivation found in {path.name}"
+    return m.group(1)
+
+
+def _derivation(path: Path) -> str:
+    """The WHOLE statement, guard included. Capturing only the assignment would be a test that cannot
+    fail: `VER=$(false)` does not stop a script — the exit status belongs to whatever runs next — so
+    the `|| { …; exit 1; }` branch IS the loudness, and a test that drops it proves nothing."""
+    m = _FULL_RE.search(path.read_text(encoding="utf-8"))
+    assert m, f"no guarded `VER=$(python3 -c …) || {{ … }}` statement found in {path.name}"
+    return m.group(1)
+
+
+def _run_derivation(cmd: str, cwd: Path):
+    return subprocess.run(["bash", "-c", f"{cmd}\nprintf '%s' \"$VER\""],
+                          cwd=cwd, capture_output=True, text=True)
+
+
+def _cfg(tmp_path: Path, payload) -> Path:
+    d = tmp_path / "repo"
+    d.mkdir(exist_ok=True)
+    (d / "darnlink-gate.json").write_text(
+        payload if isinstance(payload, str) else json.dumps(payload), encoding="utf-8")
+    return d
+
+
+def test_the_two_examples_derive_the_pin_identically():
+    """They diverged once already: two hand-escaped regexes doing the same job, one of which was a
+    Groovy compile error away from shipping broken. Identical text is the only cheap guarantee."""
+    assert _py_call(ACTIONS) == _py_call(JENKINS)
+
+
+@pytest.mark.parametrize("path", [
+    ACTIONS, JENKINS,
+    EXAMPLES / "README.md",
+    # The canonical recipe README too, and it is the one that proves the point: the first pass fixed
+    # its `curl` and left two config blocks pinned at v0.7.0 and v0.18.0 — so "there is only one pin"
+    # was documented one directory down while the page people actually copy still shipped a rotten
+    # one. A check that covers only the files you remembered is a check that finds what you already
+    # knew. Concrete tags are placeholders here (`vX.Y.Z`), resolved on paste.
+    EXAMPLES.parent / "README.md",
+], ids=lambda p: p.name)
+def test_no_shipped_recipe_doc_carries_a_literal_pin(path):
+    """The failure this whole approach exists to prevent: a second copy of the version number.
+    Measured on the day it was replaced — one file was 2 releases stale, the other 22 — and nothing
+    had ever checked, which is exactly why both drifted."""
+    literal = re.findall(r"darnlink[/@]v\d+\.\d+\.\d+", path.read_text(encoding="utf-8"))
+    assert not literal, f"{path.name} reintroduced a literal pin: {literal}"
+
+
+def test_the_actions_example_is_valid_yaml_and_wires_the_derivation_through():
+    yaml = pytest.importorskip("yaml")
+    doc = yaml.safe_load(ACTIONS.read_text(encoding="utf-8"))
+    steps = doc["jobs"]["gate"]["steps"]
+    derive = next(s for s in steps if "python3 -c" in s.get("run", ""))
+    fetch = next(s for s in steps if "curl" in s.get("run", ""))
+    # Derived into GITHUB_ENV, and consumed by the fetch — a value written and never read is the
+    # shape this would most plausibly break in, and it looks fine on inspection.
+    assert "GITHUB_ENV" in derive["run"]
+    assert "${DARNLINK_GATE_VERSION}" in fetch["run"]
+    assert steps.index(derive) < steps.index(fetch)
+
+
+@pytest.mark.parametrize("ref,expected", [
+    ("git+https://github.com/txemi/darnlink@v0.22.0", "v0.22.0"),
+    ("git+https://github.com/txemi/darnlink@main", "main"),          # a branch the recipe accepts
+    ("git+https://github.com/txemi/darnlink@aa529ac", "aa529ac"),    # and a SHA
+    ("git+ssh://git@github.com/txemi/darnlink@v0.22.0", "v0.22.0"),  # an @ in the HOST must not win
+])
+@pytest.mark.parametrize("example", EXECUTED, ids=lambda p: p.name)
+@requires_bash
+def test_every_ref_shape_the_recipe_accepts_survives_the_derivation(tmp_path, example, ref, expected):
+    """The first draft matched only `vX.Y.Z`, which hard-failed on a branch or a SHA — shapes both
+    `uvx` and raw.githubusercontent.com accept, and that spec 016 treats as real."""
+    r = _run_derivation(_derivation(example), _cfg(tmp_path, {"ref": ref}))
+    assert r.returncode == 0, r.stderr
+    assert r.stdout.strip() == expected
+
+
+@pytest.mark.parametrize("example", EXECUTED, ids=lambda p: p.name)
+@requires_bash
+def test_a_version_string_elsewhere_in_the_json_does_not_win(tmp_path, example):
+    """The reason it reads the KEY and not the file. A grep takes the first match anywhere, so an
+    excluded path that happens to contain a version silently decides which gate runs — the same
+    'quietly picks a version' failure the step exists to prevent, one layer up."""
+    cfg = _cfg(tmp_path, {"excludes": ["vendor/darnlink@v0.1.0"],
+                          "ref": "git+https://github.com/txemi/darnlink@v0.22.0"})
+    r = _run_derivation(_derivation(example), cfg)
+    assert r.stdout.strip() == "v0.22.0", r.stdout + r.stderr
+
+
+@pytest.mark.parametrize("payload,why", [
+    ({"mode": "max"}, "no ref key at all"),
+    ({"ref": "darnlink"}, "a ref with no @version"),
+    ("{not json", "a file that does not parse"),
+])
+@pytest.mark.parametrize("example", EXECUTED, ids=lambda p: p.name)
+@requires_bash
+def test_it_fails_LOUDLY_rather_than_falling_back(tmp_path, example, payload, why):
+    """Falling back to a default would be the worst outcome: a green gate at an unknown version. The
+    recipe's own default is an ancient tag, so silence here would be actively misleading."""
+    r = _run_derivation(_derivation(example), _cfg(tmp_path, payload))
+    assert r.returncode != 0, f"{why}: expected a loud failure, got rc=0 / {r.stdout!r}"
+
+
+@pytest.mark.parametrize("example", EXECUTED, ids=lambda p: p.name)
+@requires_bash
+def test_a_missing_config_file_fails_too(tmp_path, example):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    r = _run_derivation(_derivation(example), empty)
+    assert r.returncode != 0, r.stdout
+
+
+def test_version_is_derived_and_lazy():
+    """Two properties in one place because they trade off: hand-written it went seventeen minors
+    stale, and eagerly derived it cost a third of the CLI's import time in a pre-commit hook."""
+    import darnlink
+
+    assert darnlink.__version__  # resolves
+    # …and is discoverable. A PEP 562 `__getattr__` without `__dir__` gives an attribute that answers
+    # hasattr but never shows up in dir(), so introspection says it is not there.
+    assert "__version__" in dir(darnlink)
+    probe = subprocess.run(
+        [sys.executable, "-c",
+         "import sys, darnlink; print('importlib.metadata' in sys.modules)"],
+        capture_output=True, text=True)
+    assert probe.stdout.strip() == "False", "importing darnlink must not pull importlib.metadata"


### PR DESCRIPTION
The two shipped CI examples each carried their own copy of the version, and both had rotted.
Counted: the GitHub Actions example was pinned at `v0.20.4` with **3** releases published since, the
Jenkins one at `v0.7.0` with **23**. They are the copy-paste templates for the exact consumption path
a release exists to serve, so a new adopter silently installed a gate far behind the one documented
one directory up. The canonical `recipes/README.md` was worse: its `curl` block *told you* to pin
`v0.7.0`.

Both examples **derive** the version from the `ref` in `darnlink-gate.json` now, reading the **key**
with the JSON parser the recipe already depends on — not grepping the file, where a version string
anywhere else in it would win silently. Any ref shape the recipe accepts works: tag, branch or SHA.
The one it does not cover is a `ref` with no `@version` at all, and the docs say so rather than
papering over it.

*Nothing fails when two copies of a version number drift* — which is why the second copy is gone
rather than synchronised. The previous instruction was literally "keep them in sync, bump both
together".

**`__version__` said `0.5.0` against `0.22.0`** — seventeen minors adrift. Nothing reads it, which is
the shape of a mine rather than a bug. Derived from package metadata now, and **lazily** (PEP 562):
importing `importlib.metadata` eagerly cost **+34 %** on `import darnlink.cli`, and this runs as a
pre-commit hook on every commit. Quoted as a percentage on purpose — three independent runs agreed on
~34 % and disagreed on the absolute, so the milliseconds are the machine's, not the change's.

**`tests/test_recipe_examples.py`** — the examples are code and nothing had ever run them. The tests
*extract* the commands from the example files and execute them: against tag, branch, SHA and
`@`-in-the-host refs, against a decoy version elsewhere in the JSON, and against the four cases that
must fail loudly. Extracted rather than copied, so the examples cannot drift while the test passes
against its own private copy.

**§9 of the ladder**, which never mentioned feature 016 two releases after it shipped — including the
two traps that only show up when measured: the pin and the keys must move in the same commit, and a
bare URL is invisible to the whole web axis.

## What four adversarial rounds caught, and it was almost never code

Recorded because the pattern is the point:

- A `jsonc` fence left **open** while "replacing" it, so eleven lines of prose rendered as a code
  block. The fence *count* stayed balanced, which is the only thing anyone checks.
- **"Seven mutations, all killed"** was true only of the file the tests touched. Seven defects sown in
  the Jenkins example all survived.
- **"Fourteen and twenty releases behind"** was invented. Corrected to "2 and 22" — and *that* was
  invented too: I measured before publishing v0.22.0 and then published it myself. It is **3 and 23**.
- **"Wrong for over a year"** was impossible: `v0.7.0` is 23 days old and the repository is 34 days
  old. A count turned into a duration because it *felt* like a long time.
- The Jenkins example could point its `curl` at a **fixed tag** instead of the version it had just
  derived, with the suite green — the exact failure this PR prevents, alive in the file it claimed to
  cover. It could also be repointed at **another owner** entirely, in both examples and the canonical
  README. Both asserted now.

**386 tests.** Five mutations against the new assertions, five killed.

## Deliberately not here

A CI job that compiles the Jenkins example with a real Groovy parser — so a `\.`, which is a compile
error inside Groovy triple-quotes, is still not caught by anything. It is the right next link and it
is a follow-up, not a claim this PR makes.
