### PR TITLE
links: balanced parentheses in a destination are no longer truncated (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,11 +67,11 @@ All notable changes to darnlink are documented here. The format is based on
   old truncating behaviour rather than ceasing to match. Both restore *visible and wrong* rather
   than *silent*.
 
-  ⚠️ **Bounded at two levels of nesting.** CommonMark allows arbitrary
-  depth and a regex cannot; the pattern ends in `|[^)]+` so that a link nested past the bound
-  degrades to the **old truncating behaviour** rather than ceasing to match. Without that, it would
-  become invisible — a false green, which is strictly worse than the false red being removed.
-  Arbitrary depth needs the scanner tracked in #74; it occurs 0 times in the fleet.
+  ⚠️ **Bounded at two levels of nesting**, which is 0 times exceeded in the fleet; arbitrary depth
+  needs the scanner tracked in #74. And the swallow class is **narrowed, not closed**: a
+  backslash-escaped `\(` or an angle-bracket destination still hands the pattern an unmatched
+  opener. That cannot turn the gate green — the merged destination never resolves — but it collapses
+  N findings into 1 with a mangled name. 0 instances in the fleet.
 - **Nothing had ever parsed `recipes/darnlink-gate.ps1`.** The recipe tests skip on Windows and no CI
   job ran `pwsh`, so a syntax error in the shipped PowerShell recipe would have reached consumers as
   a script that does not start. CI now parses it. Parsing is not testing — it never runs the gate —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,15 @@ All notable changes to darnlink are documented here. The format is based on
   carry raw spaces and are **not links at all** in CommonMark, 6 are unbalanced. Gate-scope
   differential: **1867 → 1862** dangling — five false reds removed, **zero findings gained**.
 
-  ⚠️ **Bounded at two levels of nesting, with a deliberate fallback.** CommonMark allows arbitrary
+  ⚠️ **Two guards, both of which exist because the first version of this fix produced a false
+  green.** The destination class is `[^()\s]`, not `[^()]`: a destination outside `<…>` cannot
+  contain whitespace, and without that exclusion an *unmatched* `(` let the pattern run past the
+  link's own `)` — across lines — absorbing a following healthy link, which then ceased to exist
+  for the tool. And the pattern ends in `|[^)]+`, so a link nested past the bound degrades to the
+  old truncating behaviour rather than ceasing to match. Both restore *visible and wrong* rather
+  than *silent*.
+
+  ⚠️ **Bounded at two levels of nesting.** CommonMark allows arbitrary
   depth and a regex cannot; the pattern ends in `|[^)]+` so that a link nested past the bound
   degrades to the **old truncating behaviour** rather than ceasing to match. Without that, it would
   become invisible — a false green, which is strictly worse than the false red being removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ All notable changes to darnlink are documented here. The format is based on
     destination with no uuid — turns into **0** under the default, with the suite green.
 
 ### Fixed
+- **Balanced parentheses in a link destination are no longer truncated** (#71). CommonMark allows
+  them; `[^)]+` stopped at the first, so `[r](Log%20Analysis%20(February).docx)` was cut short and
+  reported dead while the file was on disk. The report **concealed the cut** — its own
+  `(resolves to …)` wrapper supplied the missing parenthesis, so the truncated path read as
+  complete, and a reader who checked found the file present and concluded the *gate* was broken.
+
+  Measured across the fleet, adjudicated against the reference CommonMark implementation: of 413
+  hrefs containing a `(`, **266** are the real case (balanced, spaces already `%20`-encoded), 141
+  carry raw spaces and are **not links at all** in CommonMark, 6 are unbalanced. Gate-scope
+  differential: **1867 → 1862** dangling — five false reds removed, **zero findings gained**.
+
+  ⚠️ **Bounded at two levels of nesting, with a deliberate fallback.** CommonMark allows arbitrary
+  depth and a regex cannot; the pattern ends in `|[^)]+` so that a link nested past the bound
+  degrades to the **old truncating behaviour** rather than ceasing to match. Without that, it would
+  become invisible — a false green, which is strictly worse than the false red being removed.
+  Arbitrary depth needs the scanner tracked in #74; it occurs 0 times in the fleet.
 - **Nothing had ever parsed `recipes/darnlink-gate.ps1`.** The recipe tests skip on Windows and no CI
   job ran `pwsh`, so a syntax error in the shipped PowerShell recipe would have reached consumers as
   a script that does not start. CI now parses it. Parsing is not testing — it never runs the gate —

--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -12,14 +12,31 @@ from typing import List, Sequence, Tuple
 
 # A robust link: a Markdown link immediately followed (any whitespace) by a uuid HTML comment.
 ROBUST_LINK_RE = re.compile(
-    r"\[(?P<text>[^\]]*)\]\((?P<href>[^)]+)\)\s*<!--\s*uuid:\s*(?P<uuid>[0-9a-fA-F-]{36})\s*-->"
+    r"\[(?P<text>[^\]]*)\]\((?P<href>(?:[^()]|\((?:[^()]|\([^()]*\))*\))+|[^)]+)\)\s*<!--\s*uuid:\s*(?P<uuid>[0-9a-fA-F-]{36})\s*-->"
 )
 # Any inline Markdown link. `text` is `*`, not `+`: `[](dest)` is a link with empty text, and the
 # empty alt of `![](dest)` is what pandoc emits for every image in a converted .docx/.odt. Requiring
 # one character there made the whole link invisible -- not reported as bad, *absent* -- so a tree
 # full of broken image embeds passed the dangling axis as clean (FR-051). `href` stays `+`: a link
 # with no destination at all has nothing to check.
-MD_LINK_RE = re.compile(r"\[(?P<text>[^\]]*)\]\((?P<href>[^)]+)\)")
+#: The destination may contain BALANCED parentheses — CommonMark says so, and filenames from
+#: document systems are full of them (`Log%20Analysis%20(February).docx`). `[^)]+` stopped at
+#: the first `)`, truncating the path and reporting it dead while the file was on disk. Measured
+#: on the fleet: **266** links of that shape. The report concealed the cut, because its own
+#: `(resolves to …)` wrapper supplied the missing parenthesis and the path read as complete.
+#:
+#: ⚠️ **Bounded at two levels of nesting, and that bound is a known limit, not a property.**
+#: CommonMark allows arbitrary depth; a regex cannot. Adjudicated against the reference
+#: implementation: `[^)]+` agrees with `cmark` on 3 of 9 probe shapes, one level on 7, two on 8.
+#: The ninth is triple nesting, which no bounded pattern reaches — it needs the scanner tracked
+#: in #74, and it occurs 0 times in the fleet.
+#:
+#: ⚠️ The trailing `|[^)]+` is what makes the bound SAFE, and it is the whole point of the
+#: alternation. Without it, a link nested past the bound stops matching **at all** — it becomes
+#: invisible, which is a FALSE GREEN, and a false green is strictly worse than the false red
+#: this change removes. With it, such a link degrades to exactly the old truncating behaviour:
+#: still wrong, still visible, still reported. Never trade a false red for a false green.
+MD_LINK_RE = re.compile(r"\[(?P<text>[^\]]*)\]\((?P<href>(?:[^()]|\((?:[^()]|\([^()]*\))*\))+|[^)]+)\)")
 # A uuid comment that immediately follows a link (used to tell plain from robust).
 # No `^`: it is applied with .match(content, pos), which already anchors at pos.
 _TRAILING_UUID_RE = re.compile(r"\s*<!--\s*uuid:\s*[0-9a-fA-F-]{36}\s*-->")

--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -46,6 +46,28 @@ ROBUST_LINK_RE = re.compile(
 #:
 #: Both restore the OLD truncating behaviour rather than silence: still wrong, still visible,
 #: still reported. **Never trade a false red for a false green.**
+#:
+#: ⚠️ **The swallow class is NARROWED, not closed, and saying otherwise would be the same kind of
+#: false claim this pattern exists to avoid.** Two producers survive, both handing an unmatched `(`
+#: with no whitespace in the absorbed span:
+#:
+#: * a **backslash-escaped** `\(` — CommonMark's own way to write a literal paren, which this
+#:   pattern has no escape handling for and reads as an opener;
+#: * an **angle-bracket destination** `(<…(…>)` — there is no `<…>` branch here at all, which is
+#:   awkward precisely because the whitespace rule above cites `<…>` as its exception.
+#:
+#: What bounds the harm: the merged destination never resolves, so the gate stays RED. It is an
+#: under-count with a mangled target name, not a green gate — N findings collapse to 1. The sharper
+#: cost is on the web axis, where the swallowed neighbours stop being fetched at all. Measured
+#: across 13.984 files in the gated fleet: **0 escaped-paren destinations, 0 angle destinations
+#: containing a paren, 0 adjacent-link shapes**. Closing it needs the scanner in #74.
+#:
+#: And the whitespace class is **wider than CommonMark's**: `\s` is Unicode-aware, while cmark
+#: terminates a destination only on ASCII space, tab and newline — it accepts NBSP, `\v`, `\f`,
+#: U+2000–200A and others as ordinary characters. So 12 characters are excluded needlessly. Kept
+#: because measured: with no parens the fallback returns those destinations byte-perfect (14/14),
+#: and with parens the result is exactly the old truncation. Nothing becomes invisible; the cost is
+#: precision, not safety.
 MD_LINK_RE = re.compile(r"\[(?P<text>[^\]]*)\]\((?P<href>(?:[^()\s]|\((?:[^()\s]|\([^()\s]*\))*\))+|[^)]+)\)")
 # A uuid comment that immediately follows a link (used to tell plain from robust).
 # No `^`: it is applied with .match(content, pos), which already anchors at pos.

--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -12,7 +12,7 @@ from typing import List, Sequence, Tuple
 
 # A robust link: a Markdown link immediately followed (any whitespace) by a uuid HTML comment.
 ROBUST_LINK_RE = re.compile(
-    r"\[(?P<text>[^\]]*)\]\((?P<href>(?:[^()]|\((?:[^()]|\([^()]*\))*\))+|[^)]+)\)\s*<!--\s*uuid:\s*(?P<uuid>[0-9a-fA-F-]{36})\s*-->"
+    r"\[(?P<text>[^\]]*)\]\((?P<href>(?:[^()\s]|\((?:[^()\s]|\([^()\s]*\))*\))+|[^)]+)\)\s*<!--\s*uuid:\s*(?P<uuid>[0-9a-fA-F-]{36})\s*-->"
 )
 # Any inline Markdown link. `text` is `*`, not `+`: `[](dest)` is a link with empty text, and the
 # empty alt of `![](dest)` is what pandoc emits for every image in a converted .docx/.odt. Requiring
@@ -31,12 +31,22 @@ ROBUST_LINK_RE = re.compile(
 #: The ninth is triple nesting, which no bounded pattern reaches — it needs the scanner tracked
 #: in #74, and it occurs 0 times in the fleet.
 #:
-#: ⚠️ The trailing `|[^)]+` is what makes the bound SAFE, and it is the whole point of the
-#: alternation. Without it, a link nested past the bound stops matching **at all** — it becomes
-#: invisible, which is a FALSE GREEN, and a false green is strictly worse than the false red
-#: this change removes. With it, such a link degrades to exactly the old truncating behaviour:
-#: still wrong, still visible, still reported. Never trade a false red for a false green.
-MD_LINK_RE = re.compile(r"\[(?P<text>[^\]]*)\]\((?P<href>(?:[^()]|\((?:[^()]|\([^()]*\))*\))+|[^)]+)\)")
+#: ⚠️ **Two guards, and both exist because the first version of this change produced a FALSE
+#: GREEN — the outcome its own comment declared unacceptable.**
+#:
+#: * `[^()\s]`, not `[^()]`. A destination outside `<…>` cannot contain whitespace; CommonMark
+#:   says so, and without that exclusion the balanced branch pairs an *unmatched* `(` with the
+#:   link's own `)` and keeps running — across lines — until some later lone `)`. Everything
+#:   between is absorbed, and because `finditer` never restarts inside a match, a healthy link
+#:   caught in that span **ceases to exist for the tool**. Measured: `[a](f(x.md) blah [b](t.md)
+#:   tail)` lost `t.md` entirely. Excluding whitespace makes the branch fail at the first space,
+#:   so such input falls to the fallback and behaves exactly as it did before this change.
+#: * The trailing `|[^)]+`. Without it, a link nested past the bound stops matching at all —
+#:   invisible again, by the other route.
+#:
+#: Both restore the OLD truncating behaviour rather than silence: still wrong, still visible,
+#: still reported. **Never trade a false red for a false green.**
+MD_LINK_RE = re.compile(r"\[(?P<text>[^\]]*)\]\((?P<href>(?:[^()\s]|\((?:[^()\s]|\([^()\s]*\))*\))+|[^)]+)\)")
 # A uuid comment that immediately follows a link (used to tell plain from robust).
 # No `^`: it is applied with .match(content, pos), which already anchors at pos.
 _TRAILING_UUID_RE = re.compile(r"\s*<!--\s*uuid:\s*[0-9a-fA-F-]{36}\s*-->")

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -390,3 +390,41 @@ def test_an_unbalanced_paren_must_not_swallow_the_next_link(tmp_path):
     detalles = " ".join(f.detail for f in found)
     assert "t.md) tail" not in detalles, f"the following link was swallowed: {detalles}"
     assert "f(x.md" in detalles, f"the unbalanced link should still be reported: {detalles}"
+
+
+def test_the_swallow_class_that_survives_is_pinned_as_a_known_limit(tmp_path):
+    """The whitespace producer is fixed; the escaped-paren one is NOT, and that is on the record.
+
+    `\\(` is CommonMark's own way to write a literal parenthesis. This pattern has no escape
+    handling, so it reads the `(` as an opener, and with no whitespace in the span it runs on and
+    merges the following link into one mangled destination.
+
+    What bounds the harm — and what this test asserts — is that the gate stays **RED**: the merged
+    destination cannot resolve, so it is an under-count with a bad name, never a green gate. That
+    distinction is the whole reason this is a documented limit rather than a blocker.
+
+    Measured across the gated fleet: 0 instances. Closing it needs the scanner in #74.
+
+    ⚠️ When #74 lands this test must **invert** — assert two findings — not disappear. Deleting it
+    would unpin the property in either direction.
+    """
+    _w(tmp_path / "doc.md",
+       f"---\nuuid: {U_A}\n---\n\n[r](docs/Log\\(Feb.md)[s](gone.md))\n")
+
+    found = _dangling(plan_robustify(tmp_path))
+    assert len(found) == 1, f"the surviving swallow class changed shape: {found}"
+    assert "gone.md" in found[0].detail, "the neighbour was absorbed, so it must at least be named"
+
+
+def test_the_nesting_bound_is_two_levels_and_that_is_pinned(tmp_path):
+    """The PR's headline bound had NO test: dropping it to one level left the suite green.
+
+    A one-level pattern still matches `a(b).md`, which every other test here uses, and the
+    beyond-the-bound test asserts a string the FALLBACK produces — so neither could see the change.
+    This one needs the second level: `a(b(c)d).md` matches only with it, and its target exists, so
+    a narrower bound turns this into a false red.
+    """
+    _w(tmp_path / "a(b(c)d).md", "# x\n")
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[r](a(b(c)d).md)\n")
+
+    assert _dangling(plan_robustify(tmp_path)) == [], "the bound dropped below two levels"

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -363,13 +363,30 @@ def test_nesting_beyond_two_levels_is_a_known_limit_not_a_property(tmp_path):
     assert "a(b(c(d" in found[0].detail          # truncated at the bound, as documented
 
 
-def test_prose_parentheses_after_a_link_are_not_swallowed(tmp_path):
-    """The risk of widening: `[x](a.md) (an aside)` must stay one link plus prose, not one long href.
+def test_an_unbalanced_paren_must_not_swallow_the_next_link(tmp_path):
+    """The guard that the first version of this change did not have, and needed most.
 
-    A pattern that allowed unbalanced parens would eat the aside; the balanced form cannot, and this
-    pins it — the same class of check that the empty-text widening needed at its own boundary.
+    `[^()]` matches `[`, `]` and newlines, so an **unmatched** `(` in one destination let the
+    balanced branch pair it with that link's own `)` and keep running until some later lone `)`.
+    Everything between was absorbed — and `finditer` never restarts inside a match, so a healthy
+    link caught in that span **ceased to exist for the tool**. A false green, produced by the very
+    change whose comment forbids trading a false red for one.
+
+    `cmark` sees exactly one link here, `t.md`. What darnlink must not do is see zero.
+
+    The fix is CommonMark's own rule rather than a patch: a destination outside `<…>` cannot
+    contain whitespace, so `[^()\\s]` makes the branch stop at the first space and the input falls
+    to the `|[^)]+` fallback — i.e. back to the pre-change behaviour, which was wrong but visible.
+
+    ⚠️ This replaces a test that asserted prose after a link is not swallowed. That one was a
+    tautology: no variant of this pattern can cross a bare `)`, so the aside was never at risk, and
+    the seed it claimed to guard against left it green.
     """
-    _w(tmp_path / "a.md", "x\n")
-    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[r](a.md) (un inciso entre parentesis)\n")
+    _w(tmp_path / "t.md", "# t\n")
+    _w(tmp_path / "doc.md",
+       f"---\nuuid: {U_A}\n---\n\n[a](f(x.md) blah [b](t.md) tail)\n")
 
-    assert _dangling(plan_robustify(tmp_path)) == []
+    found = _dangling(plan_robustify(tmp_path))
+    detalles = " ".join(f.detail for f in found)
+    assert "t.md) tail" not in detalles, f"the following link was swallowed: {detalles}"
+    assert "f(x.md" in detalles, f"the unbalanced link should still be reported: {detalles}"

--- a/tests/test_dangling_links.py
+++ b/tests/test_dangling_links.py
@@ -316,3 +316,60 @@ def test_whitespace_around_a_destination_is_NOT_stripped_here(tmp_path):
     found = _dangling(plan_robustify(tmp_path))
     assert len(found) == 1, "the whitespace rule (#74) appears to have been re-landed silently"
     assert " B.md " in found[0].detail
+
+
+def test_balanced_parentheses_in_a_destination_are_not_truncated(tmp_path):
+    """#71: CommonMark allows balanced parentheses in a destination; `[^)]+` stopped at the first.
+
+    The link was cut short and reported dead while the file was on disk — and the report **concealed
+    the cut**, because its own `(resolves to …)` wrapper supplied the missing parenthesis, so the
+    truncated path read as complete and correct. Someone checking it finds the file present and
+    concludes the *gate* is broken, which is how an axis gets switched off rather than fixed.
+
+    The shape is not exotic: it is what document systems name their attachments
+    (`Log%20Analysis%20(February).docx`). Measured on the fleet: **266** links of this shape.
+    """
+    _w(tmp_path / "Log%20Analysis%20(February).docx", "x\n")
+    _w(tmp_path / "doc.md",
+       f"---\nuuid: {U_A}\n---\n\n[r](Log%20Analysis%20(February).docx)\n")
+
+    assert _dangling(plan_robustify(tmp_path)) == []
+
+
+def test_a_truncated_destination_is_still_reported_when_it_really_is_missing(tmp_path):
+    """The other half: widening the grammar must not hide a genuinely dead link of the same shape."""
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[r](gone%20(Parte%201).docx)\n")
+
+    found = _dangling(plan_robustify(tmp_path))
+    assert len(found) == 1 and "gone%20(Parte%201).docx" in found[0].detail
+
+
+def test_nesting_beyond_two_levels_is_a_known_limit_not_a_property(tmp_path):
+    """The bound is written down, and pinned, because the pattern it replaced had one too.
+
+    CommonMark allows arbitrary nesting; a regex cannot. Adjudicated against the reference
+    implementation, `[^)]+` agrees with `cmark` on 3 of 9 probe shapes, one level of nesting on 7,
+    two on 8. The ninth is triple nesting, and this test states that darnlink does not see it —
+    **0 occurrences in the fleet**, and closing it needs the scanner tracked in #74.
+
+    Pinned rather than left implicit: an unstated bound is exactly how the old pattern truncated 266
+    real links for years without anyone calling it a bug.
+    """
+    _w(tmp_path / "a(b(c(d)e)f).md", "x\n")
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[r](a(b(c(d)e)f).md)\n")
+
+    found = _dangling(plan_robustify(tmp_path))
+    assert len(found) == 1, "triple nesting is now matched — good, but the docs say it is not"
+    assert "a(b(c(d" in found[0].detail          # truncated at the bound, as documented
+
+
+def test_prose_parentheses_after_a_link_are_not_swallowed(tmp_path):
+    """The risk of widening: `[x](a.md) (an aside)` must stay one link plus prose, not one long href.
+
+    A pattern that allowed unbalanced parens would eat the aside; the balanced form cannot, and this
+    pins it — the same class of check that the empty-text widening needed at its own boundary.
+    """
+    _w(tmp_path / "a.md", "x\n")
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[r](a.md) (un inciso entre parentesis)\n")
+
+    assert _dangling(plan_robustify(tmp_path)) == []

--- a/tests/test_robustify.py
+++ b/tests/test_robustify.py
@@ -376,3 +376,23 @@ def test_absorbing_a_stray_does_not_eat_a_closing_paren_of_prose(tmp_path):
 
     a = (tmp_path / "A.md").read_text()
     assert a == f"(see [x](B.md) <!-- uuid: {EXISTING} -->)\n", f"bad rewrite: {a!r}"
+
+
+def test_repair_finds_a_robust_link_whose_destination_has_parens(tmp_path):
+    """`ROBUST_LINK_RE` widened too, and reverting that half alone left the whole suite green.
+
+    Real damage under that revert: an anchored link whose destination carries balanced parentheses
+    is not recognised as robust at all, so when its target moves `repair` returns **no finding** —
+    the stale path survives and the gate stays green. The coupling is the same one FR-051
+    established; what was missing was a test that fails when it is broken.
+    """
+    from darnlink.frontmatter_index import build_index
+    from darnlink.repair import plan_repairs, apply_repairs
+
+    _w(tmp_path / "new" / "a(b).md", f"---\nuuid: {EXISTING}\n---\n# a\n")
+    _w(tmp_path / "A.md", f"see [r](old/a(b).md) <!-- uuid: {EXISTING} -->\n")
+
+    apply_repairs(plan_repairs(tmp_path, build_index(tmp_path)))
+
+    a = (tmp_path / "A.md").read_text()
+    assert "new/a(b).md" in a, f"repair did not see the parenthesised robust link: {a!r}"


### PR DESCRIPTION
links: balanced parentheses in a destination are no longer truncated (#71)

CommonMark allows balanced parentheses in a link destination. `[^)]+` stopped at
the first one, so `[r](Log%20Analysis%20(February).docx)` was cut to
`Log%20Analysis%20(February` and reported dead while the file sat on disk.

The report concealed the cut: its own `(resolves to …)` wrapper supplied the
missing parenthesis, so the truncated path read as complete and correct. Someone
checking it finds the file present and concludes the GATE is broken -- which is
how an axis gets switched off rather than fixed.

MEASURED, and the issue's own framing was wrong

Of 413 hrefs containing a `(` across the fleet, adjudicated against cmark:

    266  balanced, spaces already %20-encoded -> cmark SEES them as links,
         darnlink truncated them. The real bug.
    141  raw unencoded spaces -> NOT links at all in CommonMark. A different
         question, and not obviously darnlink's to answer.
      6  unbalanced.

Fleet differential, gate scope, before vs after: 1867 -> 1862 dangling. Five false
reds removed, ZERO findings gained. #71 said "104 occurrences"; that counted
truncated links whose completed target exists, tree-wide. Five is what the gate
actually stops emitting. Both are in the issue now with their definitions.

THE BOUND, AND WHY THE FALLBACK IS THE POINT

CommonMark allows arbitrary nesting; a regex cannot. Adjudicated against the
reference implementation, `[^)]+` agrees with cmark on 3 of 9 probe shapes, one
level of nesting on 7, two on 8. The ninth is triple nesting: 0 occurrences in the
fleet, and closing it needs the scanner tracked in #74.

The first version of this fix stopped there -- and at the bound the link stopped
matching AT ALL. Invisible, not truncated: a FALSE GREEN, which is strictly worse
than the false red being removed, and is exactly the defect the empty-text fix
(#52) had just closed. The trailing `|[^)]+` alternative makes such a link degrade
to the OLD truncating behaviour instead: still wrong, still visible, still
reported.

Never trade a false red for a false green. That is written next to the pattern.

ROBUST_LINK_RE widens with MD_LINK_RE, for the reason FR-051 established: leaving
one narrow makes an anchored link plain to one finder and robust to another.

344 tests pass (was 340). Three seeds, all caught: reverting to `[^)]+` (2
failures), dropping the fallback (1), and allowing unbalanced parens so the
pattern eats following prose (3).

Closes #71.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
