### PR TITLE
frontmatter_edit: --write no longer deletes a file's UTF-8 BOM (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,15 @@ All notable changes to darnlink are documented here. The format is based on
     destination with no uuid — turns into **0** under the default, with the suite green.
 
 ### Fixed
+- **`--write` no longer deletes a file's UTF-8 BOM** (#68). The read side uses `utf-8-sig`, which
+  consumes the mark so it cannot sit before the `---`; writing the resulting string back as plain
+  utf-8 removed it from the file, on **all four write paths**. This module's contract is byte
+  preservation — it keeps CRLF meticulously — so dropping the BOM contradicted it.
+
+  Worth recording *why it survived*: the CI Windows matrix exists for *"Windows-authored files
+  (BOM, CRLF, path separators)"* and could not see this, because every BOM fixture put the mark on
+  a file that gets **read**, never on one that gets **rewritten**. Coverage on the wrong side of an
+  operation still reads as coverage.
 - **Nothing had ever parsed `recipes/darnlink-gate.ps1`.** The recipe tests skip on Windows and no CI
   job ran `pwsh`, so a syntax error in the shipped PowerShell recipe would have reached consumers as
   a script that does not start. CI now parses it. Parsing is not testing — it never runs the gate —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ All notable changes to darnlink are documented here. The format is based on
 ### Fixed
 - **`--write` no longer deletes a file's UTF-8 BOM** (#68). The read side uses `utf-8-sig`, which
   consumes the mark so it cannot sit before the `---`; writing the resulting string back as plain
-  utf-8 removed it from the file, on **all four write paths**. This module's contract is byte
+  utf-8 removed it from the file, on **all five write paths**, including `web-check --online --write` — a call site in another module that none of the original fixtures reached. This module's contract is byte
   preservation — it keeps CRLF meticulously — so dropping the BOM contradicted it.
 
   Worth recording *why it survived*: the CI Windows matrix exists for *"Windows-authored files

--- a/src/darnlink/frontmatter_edit.py
+++ b/src/darnlink/frontmatter_edit.py
@@ -35,9 +35,33 @@ def read_text_keep_newlines(path) -> str:
 
 
 def write_text_keep_newlines(path, content: str) -> None:
-    r"""Write text verbatim — do NOT translate '\n' to the platform's os.linesep."""
-    with open(path, "w", encoding="utf-8", newline="") as f:
+    r"""Write text verbatim — do NOT translate '\n' to the platform's os.linesep, and keep the BOM.
+
+    The read side uses `utf-8-sig`, which *consumes* a leading BOM so it cannot sit before the `---`
+    and break frontmatter detection. That is right, but it means the BOM is absent from the string
+    handed back — and writing that string as plain utf-8 silently deleted it from the file.
+
+    The BOM is recovered from the file **on disk** rather than threaded through every caller: this
+    function already knows the path, and the flag would have to cross four write paths to arrive at
+    the same answer. A file that does not exist yet (`--create-readme`, `--create-frontmatter`) has
+    no BOM to preserve, which is also correct.
+
+    Worth the three lines because this module's whole contract is byte preservation — it goes to
+    real trouble to keep CRLF exactly — and dropping the BOM contradicted that on all four write
+    paths at once. The CI matrix exists for *"Windows-authored files (BOM, CRLF, path separators)"*
+    and could not see it: its BOM fixtures only ever covered files that are **read**. #68.
+    """
+    with open(path, "w", encoding=_encoding_preserving_bom(path), newline="") as f:
         f.write(content)
+
+
+def _encoding_preserving_bom(path) -> str:
+    """`utf-8-sig` if the file on disk already starts with a BOM, else plain `utf-8`."""
+    try:
+        with open(path, "rb") as f:
+            return "utf-8-sig" if f.read(3) == b"\xef\xbb\xbf" else "utf-8"
+    except OSError:
+        return "utf-8"          # a file that does not exist yet has no BOM to keep
 
 
 def read_uuid_from_content(content: str) -> Optional[str]:

--- a/tests/test_bom_write.py
+++ b/tests/test_bom_write.py
@@ -1,0 +1,89 @@
+"""#68 — a UTF-8 BOM must survive a WRITE, on every path that writes.
+
+`tests/test_bom.py` already covers the read side. That is why the defect lived: every BOM fixture
+in this repo put the mark on a file that gets **read**, never on one that gets **rewritten**, so
+the CI matrix — whose stated purpose is *"Windows-authored files (BOM, CRLF, path separators)"* —
+could not see it. The fixtures below put the BOM where the writing happens.
+"""
+from pathlib import Path
+
+from darnlink.frontmatter_index import build_index
+from darnlink.repair import plan_repairs, apply_repairs
+from darnlink.robustify import plan_robustify, apply_robustify
+
+U = "11111111-2222-3333-4444-555555555555"
+BOM = "﻿"
+
+
+def _w(p: Path, text: str, bom: bool = False) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text((BOM if bom else "") + text, encoding="utf-8")
+
+
+def _has_bom(p: Path) -> bool:
+    return p.read_bytes()[:3] == b"\xef\xbb\xbf"
+
+
+def test_robustify_keeps_the_bom_of_the_rewritten_source(tmp_path):
+    _w(tmp_path / "B.md", f"---\nuuid: {U}\n---\n# B\n")
+    _w(tmp_path / "A.md", "see [B](B.md)\n", bom=True)
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    assert _has_bom(tmp_path / "A.md"), "the source lost its BOM"
+    assert "<!-- uuid:" in (tmp_path / "A.md").read_text(encoding="utf-8-sig")
+
+
+def test_robustify_keeps_the_bom_of_a_target_given_a_uuid(tmp_path):
+    """The target is rewritten too — it receives the uuid — and it is a different write call."""
+    _w(tmp_path / "B.md", "---\ntitle: B\n---\n# B\n", bom=True)      # frontmatter, no uuid
+    _w(tmp_path / "A.md", "see [B](B.md)\n")
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    assert _has_bom(tmp_path / "B.md"), "the target lost its BOM when it was given a uuid"
+
+
+def test_create_frontmatter_keeps_the_bom(tmp_path):
+    """A target with NO frontmatter gets a block prepended — the write most likely to eat a BOM."""
+    _w(tmp_path / "B.md", "# B (no frontmatter)\n", bom=True)
+    _w(tmp_path / "A.md", "see [B](B.md)\n")
+
+    apply_robustify(plan_robustify(tmp_path, create_frontmatter=True))
+
+    b = tmp_path / "B.md"
+    assert _has_bom(b), "the target lost its BOM when frontmatter was created"
+    assert b.read_text(encoding="utf-8-sig").startswith("---\nuuid: "), "the BOM displaced the block"
+
+
+def test_repair_keeps_the_bom_of_the_rewritten_source(tmp_path):
+    """The fourth write path, reached through a different module."""
+    _w(tmp_path / "new" / "B.md", f"---\nuuid: {U}\n---\n# B\n")
+    _w(tmp_path / "A.md", f"see [B](old/B.md) <!-- uuid: {U} -->\n", bom=True)
+
+    apply_repairs(plan_repairs(tmp_path, build_index(tmp_path)))
+
+    a = tmp_path / "A.md"
+    assert _has_bom(a), "repair lost the BOM"
+    assert "new/B.md" in a.read_text(encoding="utf-8-sig"), "repair did not move the link"
+
+
+def test_a_file_without_a_bom_does_not_gain_one(tmp_path):
+    """The mirror half: preserving must not mean inventing."""
+    _w(tmp_path / "B.md", f"---\nuuid: {U}\n---\n# B\n")
+    _w(tmp_path / "A.md", "see [B](B.md)\n")
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    assert not _has_bom(tmp_path / "A.md"), "a BOM was invented"
+
+
+def test_a_created_readme_has_no_bom(tmp_path):
+    """A file that did not exist has no BOM to preserve — and must not be given one."""
+    _w(tmp_path / "A.md", f"---\nuuid: {U}\n---\n\nsee [d](sub/)\n")
+    (tmp_path / "sub").mkdir()
+
+    apply_robustify(plan_robustify(tmp_path, create_readme=True))
+
+    readme = tmp_path / "sub" / "README.md"
+    assert readme.exists() and not _has_bom(readme)

--- a/tests/test_bom_write.py
+++ b/tests/test_bom_write.py
@@ -87,3 +87,44 @@ def test_a_created_readme_has_no_bom(tmp_path):
 
     readme = tmp_path / "sub" / "README.md"
     assert readme.exists() and not _has_bom(readme)
+
+
+# --- the FIFTH write path. The commit that opened this file said "all four"; `web-check --online
+# --write` is a fifth call site, in a different module, and none of the six fixtures above reached
+# it. The fix covers it because it lives in the shared writer -- but the COUNT is the audit trail
+# the next person trusts, and it was wrong. Verified live: under a plain-utf-8 seed this path did
+# delete the BOM_BYTES.
+import json
+
+from darnlink.cli import _run_web_check_cli
+
+UUID = "3f9c1a2b-4d5e-6f70-8192-a3b4c5d6e7f8"
+URL = "https://github.com/example-org/handbook/blob/main/docs/living/service-topology.md"
+BOM_BYTES = b"\xef\xbb\xbf"
+
+
+def _fetcher(responses):
+    def f(gu, token):
+        key = f"https://github.com/{gu.owner}/{gu.repo}/blob/{gu.ref}/{gu.path}"
+        return responses.get(key, (404, None))
+    return f
+
+
+def test_web_check_write_keeps_the_bom(tmp_path, capsys):
+    (tmp_path / "conta.md").write_bytes(BOM_BYTES + f"see [topo]({URL})\n".encode())
+    fetch = _fetcher({URL: (200, f"---\nuuid: {UUID}\n---\n")})
+    code = _run_web_check_cli([str(tmp_path), "--online", "--write", "--json"], fetcher=fetch)
+    out = json.loads(capsys.readouterr().out)
+    assert code == 0 and out["wrote"] == 1
+    raw = (tmp_path / "conta.md").read_bytes()
+    assert raw.startswith(BOM_BYTES), "web-check --write deleted the BOM_BYTES"
+    assert not raw[3:].startswith(BOM_BYTES), "web-check --write doubled the BOM_BYTES"
+    assert raw == BOM_BYTES + f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n".encode()
+
+
+def test_web_check_write_does_not_invent_a_bom(tmp_path, capsys):
+    (tmp_path / "conta.md").write_bytes(f"see [topo]({URL})\n".encode())
+    fetch = _fetcher({URL: (200, f"---\nuuid: {UUID}\n---\n")})
+    _run_web_check_cli([str(tmp_path), "--online", "--write", "--json"], fetcher=fetch)
+    capsys.readouterr()
+    assert not (tmp_path / "conta.md").read_bytes().startswith(BOM_BYTES), "a BOM_BYTES was invented"


### PR DESCRIPTION
frontmatter_edit: --write no longer deletes a file's UTF-8 BOM (#68)

The read side uses `utf-8-sig`, which CONSUMES a leading BOM so it cannot sit
before the `---` and break frontmatter detection. That is right. But the string
handed back no longer contains it, and writing that back as plain utf-8 removed
the mark from the file -- on all four write paths at once:

    robustify, the rewritten SOURCE
    robustify, a TARGET given a uuid
    robustify --create-frontmatter
    repair, the rewritten SOURCE

This module's whole contract is byte preservation -- `write_text_keep_newlines`
goes to real trouble to keep CRLF exactly -- so keeping one and silently dropping
the other was not a decision anybody appears to have taken.

The BOM is recovered from the file ON DISK rather than threaded through callers:
the write already knows the path, and a flag would have to cross four write paths
to arrive at the same answer. A file that does not exist yet (--create-readme,
--create-frontmatter on a new target) has no BOM to preserve, which is also right.

WHY IT SURVIVED, WHICH IS THE PART WORTH KEEPING

`.github/workflows/ci.yml` justifies the whole Windows matrix with "Windows-authored
files (BOM, CRLF, path separators) are exactly where this kind of tool breaks". The
matrix ran, and could not see this: every BOM fixture in `tests/test_bom.py` puts
the mark on a file that gets READ, never on one that gets REWRITTEN. A test suite
can cover a property on the wrong side of the operation and read as coverage.

The new file puts the BOM where the writing happens, one test per write path, plus
both negatives: a file without a BOM must not gain one, and a created README must
not be born with one.

346 tests pass (was 340). Two seeds, both caught: writing plain utf-8 again (4
failures) and writing utf-8-sig unconditionally (18).

Closes #68.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
