### PR TITLE
lang: widen file coverage to the 10 text extensions, and get off the unseeded detector

### DIFF
--- a/.darnlang-baseline.json
+++ b/.darnlang-baseline.json
@@ -2,8 +2,16 @@
   "count": 0,
   "note": "Legacy foreign-language lines. This number may only DECREASE.",
   "scanned_exts": [
+    ".htm",
+    ".html",
+    ".j2",
+    ".jinja",
+    ".markdown",
     ".md",
-    ".py"
+    ".py",
+    ".pyi",
+    ".rst",
+    ".txt"
   ],
   "files": {}
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
           . tools/darnlang_ref.sh
           uv tool install "darnlang[strict] @ $DARNLANG_REF"
       - name: English-only gate — tracked files (fail-closed, baseline pinned at 0)
-        run: darnlang check --ext .py,.md
+        run: darnlang check --ext all
 
       # Commit messages: a surface no file gate can see, and one the local `hooks/commit-msg` cannot
       # be trusted to have covered — hooks are opt-in per clone and one `--no-verify` away. Measured

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ that is only broken where nobody measures.
 
 | Surface | What checks it | Can it block? |
 |---|---|---|
-| `.py` comments/docstrings, `.md` docs, file NAMES | `darnlang check` (`tools/check.sh`, `lang` CI job), pinned by `tools/darnlang_ref.sh` | yes — pre-commit, pre-push, CI |
+| every text file (10 extensions: `.py` `.pyi` `.md` `.markdown` `.rst` `.txt` `.html` `.htm` `.jinja` `.j2`), file NAMES | `darnlang check` (`tools/check.sh`, `lang` CI job), pinned by `tools/darnlang_ref.sh` | yes — pre-commit, pre-push, CI |
 | Commit message | `hooks/commit-msg` + the CI step, one message at a time | **conditionally** — the hook SKIPS when `uvx` is absent or the pin cannot be resolved (offline). CI is the wall that always runs |
 | PR title / description | CI step in the `lang` job | yes — the merge is blocked |
 | Issue title / body | `.github/workflows/lang-issue.yml` | **no** — GitHub cannot gate an issue before it is published, so it labels `needs-english` and comments once |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,10 @@ CI (`.github/workflows/ci.yml`) runs on every PR; please make sure it's green. A
 commit messages, PR titles/descriptions, and issues. [`darnlang`](https://github.com/txemi/darnlang) enforces it on four surfaces, pinned by
 `tools/darnlang_ref.sh`:
 
-- **tracked files** (`.py` comments and docstrings, `.md` prose) — `tools/check.sh` and the `lang`
-  CI job. File NAMES are judged too;
+- **tracked files** — `.py`/`.pyi` (comments and docstrings only) and
+  `.md`/`.markdown`/`.rst`/`.txt`/`.html`/`.htm`/`.jinja`/`.j2` (all prose except fenced code
+  blocks). Config and CI files — `.yml`, `.toml`, `.sh`, `Jenkinsfile` — are **not** judged, so a
+  comment in them is on you. `tools/check.sh` and the `lang` CI job. File NAMES are judged too;
 - **commit messages** — `hooks/commit-msg`, plus a CI step over every commit the PR adds;
 - **PR title and description** — a CI step, so a non-English title blocks the merge;
 - **issues** — `.github/workflows/lang-issue.yml`. GitHub offers no way to gate an issue before it

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -23,7 +23,7 @@ cd "$(git rev-parse --show-toplevel)"
 # CI logs of a public repo are public -- but here the reader is you, and being told "this file gained
 # a line" without being told WHICH WORDS is a gate you argue with instead of fix.
 . tools/darnlang_ref.sh
-uvx --from "$DARNLANG_REF" darnlang check --ext .py,.md --show-text
+uvx --from "$DARNLANG_REF" darnlang check --ext all --show-text
 
 uv sync --extra dev   # set up the environment (project + dev deps), like CI's install step
 uv run pytest -q

--- a/tools/darnlang_ref.sh
+++ b/tools/darnlang_ref.sh
@@ -14,4 +14,4 @@
 # shared and none of them had a test for. This repo is where the prose surfaces were invented and
 # where they were most complete, so migrating it is not a downgrade in any axis -- verified before
 # switching, surface by surface.
-export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.4.0"
+export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.7.0"


### PR DESCRIPTION
## What this changes

1. The file gate judged `.py,.md`. It now judges **all ten extensions darnlang knows**:
   `.py .pyi .md .markdown .rst .txt .html .htm .jinja .j2`. Baseline re-seeded to record them.
2. **The pin moves `v0.4.0` → `v0.7.0`.** This was missed in the first version of this PR and is the
   change with real consequences — see below.
3. `CLAUDE.md` and `CONTRIBUTING.md` described the gate as “`.py` comments and `.md` prose”.

## The pin is the important half, and this repo is the worst place to have got it wrong

`DetectorFactory.seed` is **absent from v0.4.0, v0.5.0 and v0.6.0** and arrives only in `v0.7.0`
(verified with `git show <tag>:src/darnlang/detect.py`). Unseeded, `langdetect` samples internally,
so the same text can be classified differently on two consecutive calls.

This repo is **public**, and `lang-issue.yml` installs `darnlang[strict]`, runs `prose --strict` on
issues, and on a finding adds `needs-english` **and posts a comment on a stranger’s report**. The
label heals when the text is edited; the comment does not.

> ⚠️ Honest limit: the mechanism and the exposure are confirmed; the *frequency* is not. 300 unseeded
> runs over each of this repo’s six most recent issues returned `en` 300/300.

## `--ext all` is not “every file” — and the docs now say so

It resolves to a hand-listed set of **10 extensions**. `.yml`, `.toml`, `.sh` and `Jenkinsfile` stay
unjudged. Measured here: **0** offending lines across the 57 uncovered files, so nothing is hiding —
but the docs no longer claim a coverage the gate does not have. `CONTRIBUTING.md` is the document
the issue bot links strangers to, so it is this project’s public statement of what the gate does.

## Verified by measurement

- Mutation test: a tracked Spanish line in `.md .txt .rst .html .j2 .pyi` → **rc=1 caught**; in
  `.yml .sh .json` → rc=0, which is the documented limit above, not a bug in this PR.
- Coverage direction: old `scanned_exts` is a strict **subset** of the new one — no silent narrowing.
- `tools/check.sh` exit code of the **process** (not the screen text): `rc=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)