### PR TITLE
recipes: one pin, in darnlink-gate.json — and an unparseable config must never become a policy nobody wrote

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -104,7 +104,7 @@ whole-repo where it's the wall.
 
 ```json
 {
-  "ref": "git+https://github.com/txemi/darnlink@v0.7.0",
+  "ref": "git+https://github.com/txemi/darnlink@<latest-tag>",   // see /releases; a pin, never a branch
   "excludes": ["secrets", "external_repos"],
   "ignore_blocks": ["txmd-autogrid"],
   "mode": "check",
@@ -119,7 +119,7 @@ the mirror. Two keys make that expressible:
 
 ```json
 {
-  "ref": "git+https://github.com/txemi/darnlink@v0.18.0",
+  "ref": "git+https://github.com/txemi/darnlink@<latest-tag>",   // create_readme needs >= v0.18.0
   "mode": "check",
   "create_readme": true,
   "create_readme_excludes": ["mirrors"],
@@ -174,12 +174,41 @@ not snippets to assemble (assembling the CI one wrong yields a wall that fails *
 any CI can fetch it **without a token** (no private checkout, no cred):
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/txemi/darnlink/v0.7.0/recipes/darnlink-gate -o darnlink-gate
+VER=$(jq -re '.ref | split("@") | last' darnlink-gate.json)   # THE pin, read from the json
+curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate" -o darnlink-gate
 chmod +x darnlink-gate
 ```
 
-Pin the tag (`v0.7.0`) so the gate is deterministic. Windows agents fetch `darnlink-gate.ps1` the same
+The tag comes from your `darnlink-gate.json`, so the gate is deterministic and there is only ever
+one place to bump. **A moving ref (`main`, or a major alias like `v1`) is not a pin** — both resolve
+and both fetch different code over time. Do not grep the json for a version either: a regex happily
+matches one inside some OTHER key and fetches a real-but-wrong tag with no error at all. Windows agents fetch `darnlink-gate.ps1` the same
 way. Locally, drop it on your `PATH` (e.g. `~/.local/bin`).
+
+## If your CI reuses its workspace, clean up after every other stage
+
+The gate scans the tree **recursively** from `git rev-parse --show-toplevel`. On hosted runners that
+never matters — the workspace is fresh each run. On a **self-hosted agent it persists between
+builds**, so anything another stage leaves behind (a report directory, a clone of some other repo)
+is inside your tree by the time the gate looks, and the gate fails on files that are not yours.
+
+Two habits fix it, and both belong to the stages that create the mess, not to this one:
+
+- **clone foreign repos OUTSIDE the workspace** — a sibling directory, not a subdirectory;
+- **remove generated directories after archiving them** (in Jenkins, `post { always { … } }`).
+
+⚠️ **Do not reach for `excludes` here** — and note this is the one case where it is wrong, which is
+why the distinction matters:
+
+| What it is | Lives in | Right tool |
+|---|---|---|
+| **Vendored** — a foreign repo or generated tree you **committed** on purpose | in git, every clone | `excludes` ✅ (that is what the examples above do) |
+| **CI litter** — what another stage wrote into the workspace this build | nowhere, only on that agent | **clean it up** ❌ not `excludes` |
+
+Excluding litter silences *this* gate and leaves every other tree-scanning check in your pipeline
+broken: you have not removed the foreign files, only stopped one tool from mentioning them. And the
+exclude then sits in the config of every clone, describing a mess that only ever existed on one
+agent.
 
 ## Notes
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -100,11 +100,17 @@ The gate runs at three layers, each at the scope that fits — **deliberate, not
 [`docs/elevating-your-link-gate.md §7`](../docs/elevating-your-link-gate.md) <!-- uuid: e95eaed1-9866-4c48-a0d7-99a6382f5bf9 -->): staged & fast locally,
 whole-repo where it's the wall.
 
-**1. Config** — `darnlink-gate.json` at the repo root (all keys optional):
+**1. Config** — `darnlink-gate.json` at the repo root (all keys optional). Replace `<latest-tag>`
+with a real tag from [releases](https://github.com/txemi/darnlink/releases) — a pin, never a branch.
+
+⚠️ **Do not add `//` comments to it.** JSON has none, and a config that does not parse does not fail
+loudly on every surface: the local hooks revert *every* key to its default and go green having
+validated a policy written in no file. (This very document shipped two commented examples for
+exactly one commit. Copied verbatim, they ran an old pinned version with zero excludes, green.)
 
 ```json
 {
-  "ref": "git+https://github.com/txemi/darnlink@<latest-tag>",   // see /releases; a pin, never a branch
+  "ref": "git+https://github.com/txemi/darnlink@<latest-tag>",
   "excludes": ["secrets", "external_repos"],
   "ignore_blocks": ["txmd-autogrid"],
   "mode": "check",
@@ -119,7 +125,7 @@ the mirror. Two keys make that expressible:
 
 ```json
 {
-  "ref": "git+https://github.com/txemi/darnlink@<latest-tag>",   // create_readme needs >= v0.18.0
+  "ref": "git+https://github.com/txemi/darnlink@<latest-tag>",
   "mode": "check",
   "create_readme": true,
   "create_readme_excludes": ["mirrors"],

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -188,7 +188,9 @@ chmod +x darnlink-gate
 The tag comes from your `darnlink-gate.json`, so the gate is deterministic and there is only ever
 one place to bump. **A moving ref (`main`, or a major alias like `v1`) is not a pin** — both resolve
 and both fetch different code over time. Do not grep the json for a version either: a regex happily
-matches one inside some OTHER key and fetches a real-but-wrong tag with no error at all. Windows agents fetch `darnlink-gate.ps1` the same
+matches one inside some OTHER key and fetches a real-but-wrong tag with no error at all.
+
+Windows agents fetch `darnlink-gate.ps1` the same
 way. Locally, drop it on your `PATH` (e.g. `~/.local/bin`).
 
 ## If your CI reuses its workspace, clean up after every other stage

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -174,7 +174,7 @@ not snippets to assemble (assembling the CI one wrong yields a wall that fails *
 any CI can fetch it **without a token** (no private checkout, no cred):
 
 ```bash
-VER=$(jq -re '.ref | split("@") | last' darnlink-gate.json)   # THE pin, read from the json
+VER=$(jq -re 'if has("ref") then .ref else error("darnlink-gate.json has no \"ref\"") end | split("@") | last' darnlink-gate.json)
 curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate" -o darnlink-gate
 chmod +x darnlink-gate
 ```
@@ -202,7 +202,7 @@ why the distinction matters:
 
 | What it is | Lives in | Right tool |
 |---|---|---|
-| **Vendored** — a foreign repo or generated tree you **committed** on purpose | in git, every clone | `excludes` ✅ (that is what the examples above do) |
+| **Vendored or generated everywhere** — a foreign repo you committed, or a tree every machine regenerates (`.pytest_cache`, `output`) | in git, or in every clone alike | `excludes` ✅ |
 | **CI litter** — what another stage wrote into the workspace this build | nowhere, only on that agent | **clean it up** ❌ not `excludes` |
 
 Excluding litter silences *this* gate and leaves every other tree-scanning check in your pipeline

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -111,6 +111,34 @@ set -euo pipefail
 root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 cfg="$root/darnlink-gate.json"
 
+# A config that EXISTS but does not parse is a hard error, in both fail modes.
+#
+# Every reader below swallows a parse error into an empty dict, which is the right thing for a
+# MISSING file -- all keys are optional -- and a silent disaster for a BROKEN one: every key reverts
+# to its default, so the gate runs an old pinned version at mode=check with no excludes and reports
+# a verdict about a policy that is written in no file. Green, and about nothing.
+#
+# It is NOT a `bail`: bail exists for "I cannot run here" (no uv, no network) and skips when
+# fail-open, because CI still covers the wall. A malformed config is not that -- CI would hit the
+# same broken file. So it fails loudly on every surface, fail-open included.
+#
+# Fixing the encoding alone (utf-8-sig, for a BOM) closed one shape and left the class open: a
+# trailing comma, a UTF-16 file -- which is what PowerShell 5.1 writes by default, the very source
+# the BOM fix cites -- and a truncated write all still defaulted in silence.
+# ⚠️ `command -v python3` primero, y NO es defensivo de mas: sin el, `! python3 …` es cierto por
+# ausencia del interprete y esto acusaria de config invalida a un fichero perfecto. Son dos
+# condiciones distintas -"no puedo validar" vs "esto esta roto"- y la de arriba ya la trata el
+# `bail` de mas abajo. Lo cazo un test que simula python3 ausente: convertia un exit 3 en 127.
+if [ -f "$cfg" ] && command -v python3 >/dev/null 2>&1 \
+   && ! python3 -c 'import json,sys; json.load(open(sys.argv[1], encoding="utf-8-sig"))' "$cfg" 2>/dev/null; then
+  echo "darnlink-gate: $cfg exists but is not valid JSON -> FAILING." >&2
+  echo "  Nothing was validated. Every key would have silently reverted to its default," >&2
+  echo "  including the pinned version, mode and excludes. Parse error:" >&2
+  python3 -c 'import json,sys; json.load(open(sys.argv[1], encoding="utf-8-sig"))' "$cfg" 2>&1 \
+    | tail -1 | sed 's/^/    /' >&2
+  exit 1
+fi
+
 # --- read config (JSON, all optional) via python; env wins over file ---
 read_cfg() { python3 - "$cfg" "$1" "$2" <<'PY' 2>/dev/null || printf '%s' "$2"
 import json, sys

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -116,7 +116,8 @@ read_cfg() { python3 - "$cfg" "$1" "$2" <<'PY' 2>/dev/null || printf '%s' "$2"
 import json, sys
 cfg, key, default = sys.argv[1], sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else ""
 try:
-    d = json.load(open(cfg, encoding="utf-8"))
+    d = json.load(open(cfg, encoding="utf-8-sig"))   # -sig: reads plain UTF-8 identically, but
+    # a BOM would otherwise raise -> the except below silently reverts EVERY key to its default
 except Exception:
     d = {}
 v = d.get(key, default)
@@ -131,7 +132,7 @@ PY
 read_cfg_len() { python3 - "$cfg" "$1" <<'PY' 2>/dev/null || printf '0'
 import json, sys
 try:
-    d = json.load(open(sys.argv[1], encoding="utf-8"))
+    d = json.load(open(sys.argv[1], encoding="utf-8-sig"))   # -sig: same reason as read_cfg above
 except Exception:
     d = {}
 v = d.get(sys.argv[2])

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -46,7 +46,12 @@
 #       gh release view -R txemi/darnlink --json tagName -q .tagName
 #   A concrete tag written into this comment is exactly how the example rotted last time: it sat at
 #   v0.7.0 for thirteen releases and quietly recommended two rungs below what its own author was
-#   running. Any pin printed here ages the moment it is committed, so nothing is printed.
+#   running. Any pin printed here ages the moment it is committed, so no pin is RECOMMENDED here.
+#
+#   The one tag this file does print -- the `ref` fallback further down -- is not a recommendation:
+#   it is the version this script runs when a repo declares none, and it is frozen at whatever it
+#   was when written, which is precisely why an unpinned gate is not a wall. Do not read it as
+#   "the current version": read it as the cost of not pinning.
 #
 #   ADOPTING AN EXISTING REPO? Do not paste the above on day one; it will fail on contact with a
 #   tree that has never been gated, and a gate that fails on arrival gets deleted. Climb instead,

--- a/recipes/examples/Jenkinsfile-stage.groovy
+++ b/recipes/examples/Jenkinsfile-stage.groovy
@@ -1,28 +1,55 @@
 // EXAMPLE Jenkins stage — darnlink link gate, the SERVER-SIDE wall (piece 4, self-hosted).
 //
 // The natural home for the wall on a PRIVATE repo where hosted CI minutes are billed or branch
-// protection is unavailable: a self-hosted agent runs the same check with no billing. Fetches the
-// PINNED recipe from the PUBLIC darnlink repo — no credentials — and runs it FAIL-CLOSED.
+// protection is unavailable: a self-hosted agent runs the same check with no billing.
 //
 // INSTALL: drop this stage into your declarative Jenkinsfile's `stages { … }`.
-// ASSUMES: `uvx` is available on the agent. `astral-sh` installs `uv` into ~/.local/bin; if it isn't
-//          on PATH, prepend it (e.g. `export PATH="$HOME/.local/bin:$PATH"`) inside the sh block.
-// Keep the pinned tag in sync with darnlink-gate.json's `ref`.
+// ASSUMES: `uvx` and `python3` on the agent (the recipe needs python3 anyway to read the json).
+//          `astral-sh` installs `uv` into ~/.local/bin; if that is not on PATH, prepend it inside
+//          the sh block. The optional token block needs the Credentials Binding plugin.
+//
+// ONE PIN, and it lives in darnlink-gate.json. Do not hardcode a version here and do not set
+// `DARNLINK_REF`: the recipe reads that variable as an ENV OVERRIDE THAT WINS over the json, so a
+// tag left in a committed Jenkinsfile silently overrides what the repo asked for, and bumping the
+// json does nothing. (The override itself is useful — to try an unreleased build from one branch —
+// just never leave it committed.)
 
+// ⚠️ IF your darnlink-gate.json sets `"web": true`, WRAP the `sh` block below in:
+//
+//     withCredentials([string(credentialsId: 'your-github-readonly-pat', variable: 'GITHUB_TOKEN')]) {
+//       sh ''' … '''
+//     }
+//
+// Without a token the web check does NOT fail — every link comes back `web_unverifiable` and the
+// stage goes GREEN having verified ZERO web links. A gate that cannot do its job should say so, not
+// pass quietly. It is left OUT of the code below so the example runs as copy-pasted: an unresolvable
+// credentialsId aborts the stage, and `"web": false` is the default.
 stage('darnlink gate (links)') {
   environment {
-    DARNLINK_REF              = 'git+https://github.com/txemi/darnlink@v0.7.0'
     DARNLINK_GATE_FAIL_CLOSED = '1'   // the wall must fail closed
   }
   steps {
     sh '''
       set -eu
+      ROOT=$(git rev-parse --show-toplevel)
+
+      # `ref` is optional to the recipe (it falls back to a default frozen at v0.7.0 — old, and NOT
+      # the version you fetched), but this example insists on it: an unpinned gate is not a wall.
+      VER=$(python3 -c 'import json,sys
+cfg = json.load(open(sys.argv[1]))
+if "ref" not in cfg:
+    sys.exit("darnlink-gate.json has no \\"ref\\": pin the version there, not in the Jenkinsfile")
+print(cfg["ref"].rsplit("@", 1)[1])' "$ROOT/darnlink-gate.json")
+
+      # OUTSIDE the workspace on purpose: this gate scans the tree recursively, and a stage that
+      # litters the workspace is exactly what the section below warns about.
+      GATE="${WORKSPACE_TMP:-${TMPDIR:-/tmp}}/.darnlink-gate.$$"
+      trap 'rm -f "$GATE"' EXIT        # `set -e` would otherwise skip the cleanup on a red gate
+
       # -f: fail on a 404 (moved/typo'd tag) instead of writing "404: Not Found" and running garbage.
-      curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/v0.7.0/recipes/darnlink-gate" \
-        -o "$WORKSPACE/.darnlink-gate"
-      chmod +x "$WORKSPACE/.darnlink-gate"
-      "$WORKSPACE/.darnlink-gate"          # scope=repo from darnlink-gate.json
-      rm -f "$WORKSPACE/.darnlink-gate"
+      curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/${VER}/recipes/darnlink-gate" -o "$GATE"
+      chmod +x "$GATE"
+      "$GATE"                            # scope=repo from darnlink-gate.json
     '''
   }
 }

--- a/recipes/examples/Jenkinsfile-stage.groovy
+++ b/recipes/examples/Jenkinsfile-stage.groovy
@@ -36,7 +36,7 @@ stage('darnlink gate (links)') {
       # `ref` is optional to the recipe (it falls back to a default frozen at v0.7.0 — old, and NOT
       # the version you fetched), but this example insists on it: an unpinned gate is not a wall.
       VER=$(python3 -c 'import json,sys
-cfg = json.load(open(sys.argv[1]))
+cfg = json.load(open(sys.argv[1], encoding="utf-8-sig"))   # -sig: jq tolerates a BOM; python must too
 if "ref" not in cfg:
     sys.exit("darnlink-gate.json has no \\"ref\\": pin the version there, not in the Jenkinsfile")
 print(cfg["ref"].rsplit("@", 1)[1])' "$ROOT/darnlink-gate.json")

--- a/recipes/examples/README.md
+++ b/recipes/examples/README.md
@@ -20,8 +20,14 @@ recipe ([`../darnlink-gate`](../darnlink-gate)) at the scope that fits each laye
 staged locally so parallel contributors don't block each other; whole-repo where the gate is the wall.
 A whole-repo **pre-commit** would deadlock — don't; that's what pre-push is for.
 
-**Keep the pinned tag in sync.** Every example pins `@v0.7.0`; that must match your
-`darnlink-gate.json`'s `ref`. Bump both together.
+**ONE pin, and it lives in `darnlink-gate.json`.** No example here hardcodes a version: the two CI
+ones derive it from that file's `ref`, and the two hooks never pinned anything. So a `ref` bump takes
+effect everywhere the moment you commit it — there is nothing to "keep in sync".
+
+⚠️ **Do not reach for `DARNLINK_REF` to pin instead.** The recipe reads it as an env override that
+**wins over the json**, so a tag left in a committed workflow silently overrides what the repo asked
+for, and bumping the json does nothing. It is for trying an unreleased build from one branch; never
+commit it.
 
 **Raising to fail-closed links (`mode=max`)** is a one-line change in `darnlink-gate.json`
 (`"mode": "max"`) once the repo's gap is 0 — the hooks and CI here need no edit. Follow

--- a/recipes/examples/github-actions-darnlink-gate.yml
+++ b/recipes/examples/github-actions-darnlink-gate.yml
@@ -6,7 +6,9 @@
 # with zero files validated.
 #
 # INSTALL: save as `.github/workflows/darnlink-gate.yml`. Per-repo policy (excludes, mode, scope)
-#          lives in `darnlink-gate.json`; keep the pinned tag here in sync with that file's `ref`.
+#          AND the version live in `darnlink-gate.json` — ONE pin, derived below, never copied here.
+#          Do not set `DARNLINK_REF`: the recipe reads it as an ENV OVERRIDE THAT WINS over the json,
+#          so a tag left in a committed workflow silently overrides what the repo asked for.
 name: darnlink-gate
 
 on: [push, pull_request]
@@ -18,15 +20,19 @@ jobs:
   gate:
     runs-on: ubuntu-latest
     env:
-      DARNLINK_REF: git+https://github.com/txemi/darnlink@v0.20.4
       DARNLINK_GATE_FAIL_CLOSED: "1"     # ← the wall MUST fail closed (prefer the env var; see recipe)
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
       - name: Fetch the pinned recipe (public repo → no token)
         run: |
+          # THE pin, parsed as JSON. Do NOT grep the file for a version: a regex happily matches one
+          # inside some OTHER key (an `excludes` entry, say) and fetches a real-but-wrong tag.
+          # `has("ref")` on purpose: without it a missing key dies on jq's internal type error,
+          # which is loud but says nothing about what to fix.
+          VER=$(jq -re 'if has("ref") then .ref else error("darnlink-gate.json has no \"ref\": pin the version there, not in this workflow") end | split("@") | last' darnlink-gate.json)
           # -f: fail on a 404 (a moved/typo'd tag), instead of silently writing "404: Not Found".
-          curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/v0.20.4/recipes/darnlink-gate" \
+          curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate" \
             -o "$RUNNER_TEMP/darnlink-gate"
           chmod +x "$RUNNER_TEMP/darnlink-gate"
       - name: darnlink gate (whole repo)

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -835,3 +835,33 @@ def test_a_bom_does_not_silently_turn_the_config_into_defaults(sandbox, tmp_path
     assert log.exists(), run_again.stdout + run_again.stderr
     assert log.read_text() != check_argv, (
         "a BOM'd config reverted to the defaults instead of being honoured:\n" + log.read_text())
+
+
+def test_a_bom_is_honoured_by_the_LENGTH_reader_too(sandbox, tmp_path):
+    """The sibling reader, which the first BOM test did NOT gate.
+
+    `read_cfg_len` is a second, separate python block, and mutating ONLY its encoding left the other
+    test green -- a surviving mutant: a line that read as covered and was not.
+
+    ⚠️ It cannot be asserted on the argv. `--own` reaches the CLI through `read_cfg` (which works),
+    so the invocation is byte-identical whether or not `read_cfg_len` parsed. The only observable
+    that depends on it is the WARNING it guards: `OWN_WEB_N` is the total the gate compares against
+    the owners it actually used, so with `OWN_WEB_N = 0` the "some entries were empty" warning never
+    fires -- and fewer owners get enforced than the config lists, silently, in green. Two mutants had
+    to be hunted here to find an assertion that fails for the right reason.
+    """
+    repo, run = sandbox
+    cfg = {"mode": "max", "web": True, "own_web": ["", "owned"]}   # 1 of 2 entries empty -> warns
+
+    r = run(cfg)
+    assert "empty entry/entries" in r.stderr, "el caso base ya no avisa: " + r.stderr
+
+    run(cfg)                                                        # reescribe el config...
+    f = repo / "darnlink-gate.json"
+    f.write_bytes(b"\xef\xbb\xbf" + f.read_bytes())                # ...y se le antepone el BOM
+    r2 = subprocess.run(["bash", str(RECIPE)], cwd=repo, capture_output=True, text=True,
+                        env={**_clean_env(), "DARNLINK_BIN": _darnlink_bin(),
+                             "PATH": f"{repo.parent / 'shimbin'}{os.pathsep}"
+                                     + _clean_env().get("PATH", "")})
+    assert "empty entry/entries" in r2.stderr, (
+        "con BOM, read_cfg_len devolvio 0 y el aviso de owners vacios no salio:\n" + r2.stderr)

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -801,3 +801,37 @@ def test_own_web_of_only_empty_entries_still_trips_the_pass_never_runs_warning(s
     r = run({"mode": "check", "web": True, "own_web": [""]})
 
     assert "NOT being applied" in (r.stdout + r.stderr), r.stdout + r.stderr
+
+
+def test_a_bom_does_not_silently_turn_the_config_into_defaults(sandbox, tmp_path):
+    """A config the gate CANNOT PARSE must not become a policy nobody wrote.
+
+    `read_cfg` swallows any parse error into an empty dict, so before this test a UTF-8 BOM -- which
+    `json` rejects and `jq` (and the PowerShell recipe) accept -- did not fail: it reverted EVERY key
+    to its default. The gate then ran an old pinned version at mode=check with no excludes and
+    reported a verdict about a file it had never read.
+
+    Asserted on the INVOCATION, not the verdict: a silently-defaulted run is still green, which is
+    precisely why this went unnoticed. Windows is the realistic source -- the repo ships a PowerShell
+    recipe, and PowerShell writes a BOM by default.
+    """
+    repo, run = sandbox
+    log = tmp_path / "argv.log"
+
+    run({"mode": "check"}, argv_log=log)                       # baseline: what `check` looks like
+    check_argv = log.read_text()
+    log.unlink()
+
+    # Same helper, then overwrite the file with the BOM'd bytes the helper cannot produce.
+    run({"mode": "max"}, argv_log=log)
+    cfg = repo / "darnlink-gate.json"
+    cfg.write_bytes(b"\xef\xbb\xbf" + cfg.read_bytes())
+    log.unlink()
+    run_again = subprocess.run(["bash", str(RECIPE)], cwd=repo, env={**_clean_env(),
+                               "DARNLINK_ARGV_LOG": str(log), "DARNLINK_BIN": _darnlink_bin(),
+                               "PATH": f"{cfg.parent.parent / 'shimbin'}{os.pathsep}"
+                                       + _clean_env().get("PATH", "")},
+                               capture_output=True, text=True)
+    assert log.exists(), run_again.stdout + run_again.stderr
+    assert log.read_text() != check_argv, (
+        "a BOM'd config reverted to the defaults instead of being honoured:\n" + log.read_text())


### PR DESCRIPTION
## One pin, and it lives in `darnlink-gate.json`

Both CI examples wrote the version **twice** — once in the `curl` URL and once in `DARNLINK_REF` —
with a comment asking you to keep them in sync. The second one is not decorative: the recipe reads
it as an **env override that WINS over the json**, so the tag committed in the workflow silently
overrode whatever the repo asked for, and bumping the json did nothing.

Both now derive the version from the json, and **parse it as JSON instead of grepping the file** — a
regex matches a version inside any other key just as happily, and since such a tag usually *exists*,
`curl -f` returns 200 and the wrong recipe runs green.

Along the way, three things that were worse than the bug being fixed:

| | What it did |
|---|---|
| **A config the gate could not parse became a policy nobody wrote** | Every reader swallowed a parse error into an empty dict, so a BOM / a trailing comma / a UTF-16 file reverted **every** key to its default. The gate ran an old pinned version at `mode=check` with no excludes and reported a verdict about a file it never read. **Green.** |
| **The docs sent the reader back to the bug** | The examples index still ordered *"keep the pinned tag in sync"* when no example pins anything — so the reader goes looking for a pin, finds none, and reaches for the one knob left: the override. |
| **This branch introduced the same bug it is about** | Replacing the hardcoded tags left `//` comments inside the documented ```json blocks. Copied verbatim — which is what an example is for — the gate ran an old version scanning a directory the config excludes, green, zero warnings. |

Now: the config is parsed **once, up front**, and a file that exists but does not parse is a **hard
error on every surface**. Deliberately not a `bail` — bail means *"I cannot run here"* and skips when
fail-open because CI still covers the wall; a malformed config is not that, CI would hit the same
broken file.

### Measured, end to end

| Config shape | Before | After |
|---|---|---|
| clean | `rc=0` | `rc=0` |
| **BOM** | `rc=0`, all keys defaulted, silent | `rc=0`, honoured |
| **malformed** | `rc=0`, all keys defaulted, silent | **`rc=1`, loud** |
| **UTF-16LE** | `rc=0`, all keys defaulted, silent | **`rc=1`, loud** |

UTF-16LE is the one that matters most: it is what **PowerShell 5.1 writes by default**, which is the
very source the BOM fix cited.

### Review: 4 adversarial rounds, and the loop was STOPPED on purpose

Copilot could not review this (quota) and Actions is down for billing on this account, so review was
done by adversarial subsessions. Every round found something **new**, and three of the four found a
defect *introduced by the previous round's fix*:

| Round | Findings | Notable |
|---|---|---|
| 1 | 2 P0 | a regex that fetched a real-but-wrong tag; a private credential ID in a public repo |
| 2 | 8 | the fix left the docs pointing back at the P0 |
| 3 | 2 HIGH | the BOM silently defaulting the whole config |
| 4 | 2 HIGH | **this branch had reintroduced the same class**, and the regression test had a surviving mutant |

The workflow rule says: *if the mechanism is still changing after three rounds, stop — split what is
verified and defer the rest with the history written*. That is what this PR is. **What ships here has
a deterministic gate behind it**, which is an explicit closing criterion:

- the config validation, with `utf-8-sig` in both readers;
- **two regression tests, each checked by mutation** — reverting the encoding turns them red.

⚠️ The second test needed **two attempts**. The obvious assertion (on the CLI invocation) passes for
the wrong reason: the owner flags reach the CLI through the *other* reader, so the argv is
byte-identical whether or not the length reader parsed. The only observable that depends on it is
the warning it guards — and with it broken, that warning silently disappears while fewer owners than
the config lists get enforced.

### Deliberately NOT in this PR

- **N11** — the two examples disagree on a `ref` with no `@`: `jq` returns the whole string and the
  failure surfaces later as a `curl` 404 whose message blames *"a moved/typo'd tag"*; the Jenkins one
  dies immediately naming nothing. Both fail red, no false green, but neither says *"your ref has no
  `@`"*. It needs a **design call** — reject that shape, or accept it — not a patch.
- **N12/N13** — wording: a "nothing is printed" claim contradicted by a default 94 lines below, and
  one over-long line.

### Checks that could NOT be reproduced locally

- **privacy-gate** — its denylist is a CI secret, unreadable by design. The sweep done here is
  pattern-based (repo names, hosts, `/home/…`, RFC1918, identities): **no hits**, but that is a proxy,
  not the real check.
- **A real Jenkins run** — the Groovy `'''` literal was evaluated with a real Groovy install and the
  resulting shell executed, but no agent ran it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
