### PR TITLE
deps: darnlang v0.4.0 -> v0.7.0, so layer 3 stops being a coin flip

### DIFF
--- a/tools/darnlang_ref.sh
+++ b/tools/darnlang_ref.sh
@@ -14,4 +14,4 @@
 # shared and none of them had a test for. This repo is where the prose surfaces were invented and
 # where they were most complete, so migrating it is not a downgrade in any axis -- verified before
 # switching, surface by surface.
-export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.4.0"
+export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.7.0"


### PR DESCRIPTION
One line: the darnlang pin moves from `v0.4.0` to `v0.7.0`.

## Why this repo in particular

This was the last consumer left on `v0.4.0`. It matters more here than anywhere else because of
what this repo *does* with the answer:

```
.github/workflows/lang-issue.yml
  on: issues            permissions: issues: write
  line 41:  uv tool install "darnlang[strict] @ $DARNLANG_REF"   <- the pin
  line 53:  darnlang prose "$RUNNER_TEMP/issue.txt" --strict --label issue
  line 93:  gh issue comment "$NUMBER" -R "$REPO" --body-file …  <- a PUBLIC comment
```

The repo is public and issues are open, so a false finding is not a red build — it is a comment
telling a stranger that their English bug report is in the wrong language.

## What v0.4.0 was missing

`v0.4.0` installs the `strict` extra and therefore **does** run layer 3, but it never sets
`DetectorFactory.seed`. `langdetect` samples internally, so the same text can come back differently
on consecutive calls. `v0.7.0` sets it (`src/darnlang/detect.py:183`) and ships a test that fails if
the answers ever diverge again.

Upstream's measurement: **300 identical runs over one unchanged ENGLISH issue returned a finding
twice**. And, as its release note points out, unlike the label a comment **does not heal** when the
text is edited.

The jump also picks up:

| Version | What it adds |
|---|---|
| `v0.5.0` | `--extra-words-file` — add words instead of replacing the built-in list |
| `v0.6.0` | a wordlist found *by convention* now EXTENDS and announces itself, instead of silently replacing the built-ins |
| `v0.7.0` | seeded layer 3; an empty `--extra-words-file` is no longer silently ignored |

`v0.6.0` does not bite here: there is no wordlist file anywhere in this tree (checked).

## Verified before proposing

A detector jump can turn a repo red on a day nobody touched it — that is the whole reason the pin
exists. It does not, here:

```
$ uvx --from "git+https://github.com/txemi/darnlang@v0.7.0" darnlang check --ext .py,.md
darnlang: OK -- 0 legacy line(s), unchanged vs the baseline.       rc=0
```

Also confirmed by reading the tags, not by trusting the changelog: `v0.4.0` has no `DetectorFactory`
reference at all, while `v0.7.0` sets the seed at `detect.py:183`.

**Not verified:** the issue workflow has not been fired end to end — that needs a real issue event.
