### PR TITLE
lang: adopt v0.9.0 — configuration and CI files are judged now

### DIFF
--- a/.darnlang-baseline.json
+++ b/.darnlang-baseline.json
@@ -2,8 +2,13 @@
   "count": 0,
   "note": "Legacy foreign-language lines. This number may only DECREASE.",
   "scanned_exts": [
+    ".bash",
+    ".cfg",
+    ".gradle",
+    ".groovy",
     ".htm",
     ".html",
+    ".ini",
     ".j2",
     ".jinja",
     ".markdown",
@@ -11,7 +16,11 @@
     ".py",
     ".pyi",
     ".rst",
-    ".txt"
+    ".sh",
+    ".toml",
+    ".txt",
+    ".yaml",
+    ".yml"
   ],
   "files": {}
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ that is only broken where nobody measures.
 
 | Surface | What checks it | Can it block? |
 |---|---|---|
-| every text file (19 extensions: source, docs, and configuration/CI — comments only in the latter two), file NAMES | `darnlang check` (`tools/check.sh`, `lang` CI job), pinned by `tools/darnlang_ref.sh` | yes — pre-commit, pre-push, CI |
+| every text file (19 extensions). **Source and config/CI** (`.py` `.pyi` `.yml` `.toml` `.sh` `.groovy` …, `Jenkinsfile`, `Dockerfile`): **comments only** — a value is data. **Documents** (`.md` `.rst` `.txt` `.html` …): **all prose** except fenced blocks. Plus file NAMES | `darnlang check` (`tools/check.sh`, `lang` CI job), pinned by `tools/darnlang_ref.sh` | yes — pre-commit, pre-push, CI |
 | Commit message | `hooks/commit-msg` + the CI step, one message at a time | **conditionally** — the hook SKIPS when `uvx` is absent or the pin cannot be resolved (offline). CI is the wall that always runs |
 | PR title / description | CI step in the `lang` job | yes — the merge is blocked |
 | Issue title / body | `.github/workflows/lang-issue.yml` | **no** — GitHub cannot gate an issue before it is published, so it labels `needs-english` and comments once |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ that is only broken where nobody measures.
 
 | Surface | What checks it | Can it block? |
 |---|---|---|
-| every text file (10 extensions: `.py` `.pyi` `.md` `.markdown` `.rst` `.txt` `.html` `.htm` `.jinja` `.j2`), file NAMES | `darnlang check` (`tools/check.sh`, `lang` CI job), pinned by `tools/darnlang_ref.sh` | yes — pre-commit, pre-push, CI |
+| every text file (19 extensions: source, docs, and configuration/CI — comments only in the latter two), file NAMES | `darnlang check` (`tools/check.sh`, `lang` CI job), pinned by `tools/darnlang_ref.sh` | yes — pre-commit, pre-push, CI |
 | Commit message | `hooks/commit-msg` + the CI step, one message at a time | **conditionally** — the hook SKIPS when `uvx` is absent or the pin cannot be resolved (offline). CI is the wall that always runs |
 | PR title / description | CI step in the `lang` job | yes — the merge is blocked |
 | Issue title / body | `.github/workflows/lang-issue.yml` | **no** — GitHub cannot gate an issue before it is published, so it labels `needs-english` and comments once |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,10 +39,11 @@ CI (`.github/workflows/ci.yml`) runs on every PR; please make sure it's green. A
 commit messages, PR titles/descriptions, and issues. [`darnlang`](https://github.com/txemi/darnlang) enforces it on four surfaces, pinned by
 `tools/darnlang_ref.sh`:
 
-- **tracked files** — `.py`/`.pyi` (comments and docstrings only) and
-  `.md`/`.markdown`/`.rst`/`.txt`/`.html`/`.htm`/`.jinja`/`.j2` (all prose except fenced code
-  blocks). Config and CI files — `.yml`, `.toml`, `.sh`, `Jenkinsfile` — are **not** judged, so a
-  comment in them is on you. `tools/check.sh` and the `lang` CI job. File NAMES are judged too;
+- **tracked files**, in three families: `.py`/`.pyi` and configuration/CI
+  (`.yml` `.yaml` `.toml` `.cfg` `.ini` `.sh` `.bash` `.groovy` `.gradle`, plus `Jenkinsfile`,
+  `Dockerfile`, `Makefile`) — **comments only**, because a config VALUE is data; and documents
+  (`.md` `.markdown` `.rst` `.txt` `.html` `.htm` `.jinja` `.j2`) — all prose except fenced code
+  blocks. `tools/check.sh` and the `lang` CI job. File NAMES are judged too;
 - **commit messages** — `hooks/commit-msg`, plus a CI step over every commit the PR adds;
 - **PR title and description** — a CI step, so a non-English title blocks the merge;
 - **issues** — `.github/workflows/lang-issue.yml`. GitHub offers no way to gate an issue before it

--- a/tools/darnlang_ref.sh
+++ b/tools/darnlang_ref.sh
@@ -14,4 +14,4 @@
 # shared and none of them had a test for. This repo is where the prose surfaces were invented and
 # where they were most complete, so migrating it is not a downgrade in any axis -- verified before
 # switching, surface by surface.
-export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.7.0"
+export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.9.0"


### PR DESCRIPTION
Adopts darnlang v0.9.0, which judges `.yml` `.yaml` `.toml` `.cfg` `.ini` `.sh` `.bash` `.groovy` `.gradle` and the extensionless CI files by name (`Jenkinsfile`, `Dockerfile`, …). Being **code**, only their **comments** are judged — a YAML value is data, and firing on data is how a gate gets switched off.

Measured on this tree **before** adopting: **zero findings** at the new coverage, so it costs nothing today and freezes it there. The reseeded baseline records all nineteen extensions, so a later narrowing reports as a coverage change instead of passing as clean.

Proved by mutation rather than by trusting the flag: a tracked `.yml` whose **comment** is in the other language is `rc=1` under the new coverage.

> The first attempt at this reseed was done with a **stale darnlang on PATH** and silently recorded ten extensions instead of nineteen. It was caught by reading the baseline back — which is why the number is stated here rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)