### PR TITLE
lang: pin v0.9.1, and record the basename coverage the baseline could not express

### DIFF
--- a/.darnlang-baseline.json
+++ b/.darnlang-baseline.json
@@ -22,5 +22,12 @@
     ".yaml",
     ".yml"
   ],
+  "scanned_names": [
+    "Containerfile",
+    "Dockerfile",
+    "Jenkinsfile",
+    "Makefile",
+    "Vagrantfile"
+  ],
   "files": {}
 }

--- a/tools/darnlang_ref.sh
+++ b/tools/darnlang_ref.sh
@@ -14,4 +14,4 @@
 # shared and none of them had a test for. This repo is where the prose surfaces were invented and
 # where they were most complete, so migrating it is not a downgrade in any axis -- verified before
 # switching, surface by surface.
-export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.9.0"
+export DARNLANG_REF="git+https://github.com/txemi/darnlang@v0.9.1"


### PR DESCRIPTION
Adopts **darnlang v0.9.1**, which adds `scanned_names` to the baseline.

Until now the record held **extensions only**, so the extensionless CI files it judges — `Jenkinsfile`, `Dockerfile`, `Makefile` — had **no representation at all**. If that branch of the scan ever narrowed, the count would *fall* and the ratchet would announce *“it went DOWN, lock the win in”*: a congratulation for losing coverage, in the one dimension the format could not describe.

Reseeded so this repo records both. **The count itself is unchanged** — this is a record of *what is covered*, not a change to *what is judged*.

Found by adversarial review; worth noting that no measurement would have caught it, because it is a gap in what the format can express rather than a wrong number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)