### PR TITLE
Absolute local paths are now a named finding, not an unchecked blind spot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ All notable changes to darnlink are documented here. The format is based on
   so the milliseconds belong to the machine and are not quoted as a property of the change.
 
 ### Added
+- **A plain link written as an absolute filesystem path (`/home/user/x.md`) is now a named finding
+  (`absolute_local_path`), instead of receiving no check at all.** `is_local_relative` excludes
+  anything starting with `/`, so such a link was invisible to every existing axis: not `dangling`
+  (that one shares the exclusion), not `out_of_scope` (that one names a real location outside
+  `--root`; an absolute path names none). Unlike a relative link — which resolves to "this repo" on
+  any clone — an absolute path can only ever resolve on the one machine that wrote it, and silently,
+  since it was never reported either. Same treatment as `dangling` (FR-049): report-only, its own
+  axis in `check --json`, and deliberately absent from the exit code, so no consumer's gate goes red
+  on the day it upgrades.
+
 - **`tests/test_recipe_examples.py` — the examples are code, and nothing had ever run them.** The
   release that added a `ps1-syntax` job on exactly that argument then put non-trivial shell into two
   example files with no gate at all. The tests **extract** the commands from the example files and

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -185,6 +185,12 @@ def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple,
     # gate is the caller's policy; the core just names what it sees.
     dangling = [f for f in rob.findings if f.kind is Kind.DANGLING]
 
+    # Absolute-local-path axis (017): plain links written as an absolute filesystem path. Same
+    # treatment as dangling and for the same reason (FR-049) — reported, never folded into `code`,
+    # so no consumer's gate goes red on the day it upgrades. Whether to gate on it is the recipe's
+    # ratchet, once it grows one for this axis; the core just names what it sees.
+    abs_local = [f for f in rob.findings if f.kind is Kind.ABSOLUTE_LOCAL_PATH]
+
     code = 2 if integrity_fail else (3 if strict_fail else 0)
 
     if as_json:
@@ -222,6 +228,13 @@ def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple,
                               "line": f.line}
                              for f in dangling],
             },
+            # 017: same shape and same non-gating treatment as `dangling`, above.
+            "absolute_local_path": {
+                "count": len(abs_local),
+                "findings": [{"kind": f.kind.value, "file": str(f.file), "detail": f.detail,
+                              "line": f.line}
+                             for f in abs_local],
+            },
         }, indent=2))
     else:
         outcome = {0: "clean", 2: "integrity failure", 3: "strict failure"}[code]
@@ -236,6 +249,9 @@ def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple,
         if dangling:
             print(f"  [dangling]  targets that do not exist: {len(dangling)} "
                   f"-> informational (does not affect the exit code)")
+        if abs_local:
+            print(f"  [absolute-local-path] links written as an absolute filesystem path: "
+                  f"{len(abs_local)} -> informational (does not affect the exit code)")
         for f in repairs + conflicts + unresolved:
             print(f"  [integrity/{f.kind.value}] {f.file}: {f.detail}")
         for p in invalid:

--- a/src/darnlink/paths.py
+++ b/src/darnlink/paths.py
@@ -64,6 +64,19 @@ def is_local_md(href: str) -> bool:
     return is_local_relative(href) and path_part.lower().endswith(".md")
 
 
+def is_absolute_local_path(href: str) -> bool:
+    """True if href names an absolute filesystem path (`/home/user/x.md`), not a URL.
+
+    `is_local_relative` excludes this shape (it starts with `/`), so it falls out of the scan
+    silently: not dangling-checked (`_dangling_target` shares the same exclusion) and not
+    `out_of_scope` (that axis names a target outside `--root`, which presumes a relative path
+    resolved from the linking file — an absolute path names no root-relative location at all).
+    A protocol-relative URL (`//example.com/x`) is excluded too; it is a scheme, not a path.
+    """
+    path_part, _ = split_fragment(href)
+    return bool(path_part) and path_part.startswith("/") and not path_part.startswith("//")
+
+
 def names_md(href: str) -> bool:
     """True if the href's path part names a `.md` file (by suffix). Used to tell a link that points
     at a file (`foo/README.md`) from one that points at a directory (`foo/`), independent of disk."""

--- a/src/darnlink/report.py
+++ b/src/darnlink/report.py
@@ -20,6 +20,7 @@ class Kind(str, Enum):
     INVALID_FRONTMATTER = "invalid_frontmatter"  # frontmatter present but not valid YAML; reported, never touched
     DANGLING = "dangling"              # (015) a plain link whose target does not exist at all — not `unresolvable` (that is a robust link whose uuid died) and not `robustify` (there is nothing to anchor); reported, never touched
     OUT_OF_SCOPE = "out_of_scope"      # robustify target exists but was never scanned (outside the root, or excluded): its uuid is unknown, so the link is left plain — NOT the same as having no frontmatter (FR-009)
+    ABSOLUTE_LOCAL_PATH = "absolute_local_path"  # (017) a plain link written as an absolute filesystem path (`/home/user/x.md`): invisible to `is_local_relative`, so never dangling-checked and never anchorable — it names no location relative to any repo, so it can only ever resolve on the one machine that wrote it
     TARGET_UUID_WRITE = "target_uuid_write"      # (--only) a uuid was written into a target outside the write scope, so the link could be anchored (FR-006)
     TARGET_WRITE_REFUSED = "target_write_refused"  # (--only --no-target-writes) target outside the write scope needs a uuid; refused, link left plain (FR-006)
 

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -27,7 +27,8 @@ from .frontmatter_index import DEFAULT_EXCLUDES, dir_excluded, iter_markdown_fil
 from .links import (DetachedAnchor, PlainLink, code_spans, emit_robust_link, file_ignores_links,
                     file_is_ignored, find_detached_anchors, find_plain_links, ignored_spans,
                     line_bounds)
-from .paths import DIR_ANCHOR, is_local_relative, names_md, resolve_href, split_fragment
+from .paths import (DIR_ANCHOR, is_absolute_local_path, is_local_relative, names_md, resolve_href,
+                     split_fragment)
 from .report import Finding, Kind
 from .scope import in_scope
 
@@ -102,6 +103,24 @@ def _dangling_target(href: str, linking_file: Path) -> Path | None:
         # Report the DECODED path: it is the one the link denotes, and the one to look for on disk.
         return None if d.exists() else d
     return t
+
+
+def _absolute_local_target(href: str) -> str | None:
+    """The decoded path an href names, when it is an absolute local filesystem path — or None.
+
+    Feature 017: `is_local_relative` excludes this shape (it starts with `/`), so it never reaches
+    `_anchor_target` or `_dangling_target` — an absolute path receives no check of any kind today,
+    silently, even though it can only ever resolve on the one machine that wrote it. Mirrors
+    `_dangling_target`'s FR-047 handling: an encoded href can decode into an absolute path
+    (`%2Fetc%2Fpasswd`) that reads as local-relative while encoded, so both spellings are judged.
+    """
+    path_part, _ = split_fragment(href)
+    if not path_part:
+        return None
+    decoded = unquote(path_part)
+    if is_absolute_local_path(path_part) or is_absolute_local_path(decoded):
+        return decoded
+    return None
 
 
 def _dir_link_missing_readme(href: str, linking_file: Path) -> Path | None:
@@ -389,6 +408,20 @@ def plan_robustify(
                         Kind.DANGLING, f,
                         f"line {lineno}: {link.href}: target does not exist (resolves to {dead})",
                         line=lineno))
+                elif t is None:
+                    # 017: the other `None` a `.md`/directory link this pass could never name —
+                    # `_dangling_target` shares the same `is_local_relative` exclusion, so this href
+                    # is not "not there", it is not a path relative to anything. Distinct from
+                    # OUT_OF_SCOPE (that one names a real root-relative location the scan didn't
+                    # read; this one names none).
+                    abs_path = _absolute_local_target(link.href)
+                    if abs_path is not None:
+                        lineno = original.count("\n", 0, link.start) + 1
+                        result.findings.append(Finding(
+                            Kind.ABSOLUTE_LOCAL_PATH, f,
+                            f"line {lineno}: {link.href}: absolute local path ({abs_path}) — "
+                            "resolves only on the machine that wrote it; never checked or anchorable",
+                            line=lineno))
                 continue  # skip non-md/external and self-links
             tr = t.resolve()
             if tr in ignored_targets or tr in invalid_fm:

--- a/tests/test_absolute_local_links.py
+++ b/tests/test_absolute_local_links.py
@@ -1,0 +1,144 @@
+"""Feature 017 — `absolute_local_path`: a plain link written as an absolute filesystem path.
+
+`is_local_relative` excludes anything starting with `/` (FR-046 draws that line for `_dangling_target`
+too), so a link like `[x](/home/user/notes.md)` fell out of the scan silently: not `dangling` (that
+axis shares the same exclusion) and not `out_of_scope` (that one names a real location outside
+`--root`; an absolute path names no root-relative location at all). It received no check of any kind
+— even though, unlike a relative link, it can never resolve on any clone but the one that wrote it.
+
+Report-only, same as `dangling`: nothing is ever written in response to this finding, and it is
+deliberately absent from `check`'s exit code (FR-049's reasoning applies here unchanged — folding a
+brand-new axis into the exit code would turn every consumer's next `darnlink check` red with no
+ratchet to climb down from).
+"""
+from pathlib import Path
+
+from darnlink.report import Kind
+from darnlink.robustify import plan_robustify, apply_robustify
+
+U_A = "aaaaaaaa-1111-2222-3333-444444444444"
+
+
+def _w(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _abs_local(result, f: Path | None = None):
+    return [x for x in result.findings
+            if x.kind is Kind.ABSOLUTE_LOCAL_PATH and (f is None or x.file == f)]
+
+
+def test_absolute_local_path_is_reported(tmp_path):
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[x](/home/user/notes.md)\n")
+
+    result = plan_robustify(tmp_path)
+    apply_robustify(result)
+    found = _abs_local(result)
+
+    assert len(found) == 1
+    assert "/home/user/notes.md" in found[0].detail
+    # report-only: byte-for-byte, like dangling (FR-042's guarantee extends to this axis)
+    assert (tmp_path / "doc.md").read_text(encoding="utf-8") == \
+        f"---\nuuid: {U_A}\n---\n\n[x](/home/user/notes.md)\n"
+
+
+def test_relative_link_is_not_reported(tmp_path):
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[x](sibling.md)\n")
+    _w(tmp_path / "sibling.md", "# s\n")
+
+    assert _abs_local(plan_robustify(tmp_path)) == []
+
+
+def test_protocol_relative_url_is_not_reported(tmp_path):
+    """`//example.com/x` starts with `/` but is a scheme, not a filesystem path."""
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[x](//example.com/notes.md)\n")
+
+    assert _abs_local(plan_robustify(tmp_path)) == []
+
+
+def test_web_and_mailto_links_are_not_reported(tmp_path):
+    _w(tmp_path / "doc.md",
+       f"---\nuuid: {U_A}\n---\n\n[a](https://example.com/x.md)\n[b](mailto:x@y.z)\n")
+
+    assert _abs_local(plan_robustify(tmp_path)) == []
+
+
+def test_bare_fragment_is_not_reported(tmp_path):
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[x](#section)\n")
+
+    assert _abs_local(plan_robustify(tmp_path)) == []
+
+
+def test_encoded_absolute_path_is_caught_too(tmp_path):
+    """The mirror of dangling's FR-047 case: `%2Fetc%2Fpasswd` decodes to an absolute path.
+
+    Dangling deliberately does NOT report this href (it decodes away from `is_local_relative`
+    before existence is even checked). This axis exists to catch exactly what that one lets go:
+    the decoded shape is still an absolute path, so it must not escape via encoding either.
+    """
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[x](%2Fetc%2Fpasswd)\n")
+
+    found = _abs_local(plan_robustify(tmp_path))
+    assert len(found) == 1
+    assert "/etc/passwd" in found[0].detail
+
+
+def test_out_of_scope_relative_link_is_not_absolute_local_path(tmp_path):
+    """A `../`-escaping RELATIVE link that lands outside root is `out_of_scope`, a different axis.
+
+    This is the case the analysis that led to this feature was actually about: a relative link
+    that escapes the scanned root and happens to resolve to something that exists (e.g. a sibling
+    repo cloned next to this one). It is not this axis's business — it names a real root-relative
+    path, unlike an absolute one, which names none.
+    """
+    outside = tmp_path.parent / "sibling_repo"
+    _w(outside / "README.md", f"---\nuuid: bbbbbbbb-1111-2222-3333-444444444444\n---\n# sibling\n")
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[x](../sibling_repo/README.md)\n")
+
+    result = plan_robustify(tmp_path)
+    assert _abs_local(result) == []
+    assert [f for f in result.findings if f.kind is Kind.OUT_OF_SCOPE]
+
+
+def test_code_spans_and_fences_are_not_links(tmp_path):
+    _w(tmp_path / "doc.md",
+       f"---\nuuid: {U_A}\n---\n\n`[a](/home/user/x.md)`\n\n```\n[b](/home/user/y.md)\n```\n")
+
+    assert _abs_local(plan_robustify(tmp_path)) == []
+
+
+def test_finding_carries_the_line_number(tmp_path):
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\nfiller\n\n[x](/etc/passwd)\n")
+
+    found = _abs_local(plan_robustify(tmp_path))
+    assert len(found) == 1 and found[0].detail.startswith("line 7:") and found[0].line == 7
+
+
+def test_check_reports_it_without_changing_the_exit_code(tmp_path, capsys):
+    """FR-049's reasoning, unchanged for this axis: it must not gate the day it lands."""
+    from darnlink.cli import main
+
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[x](/home/user/notes.md)\n")
+
+    code = main(["check", str(tmp_path)])
+    out = capsys.readouterr().out
+
+    assert code == 0
+    assert "absolute-local-path" in out
+    assert "/home/user/notes.md" not in out  # counted, not enumerated in the text report
+
+
+def test_check_json_carries_it_on_its_own_axis(tmp_path, capsys):
+    import json as _json
+
+    from darnlink.cli import main
+
+    _w(tmp_path / "doc.md", f"---\nuuid: {U_A}\n---\n\n[x](/home/user/notes.md)\n")
+
+    code = main(["check", str(tmp_path), "--json"])
+    payload = _json.loads(capsys.readouterr().out)
+
+    assert code == 0 and payload["exit_code"] == 0
+    assert payload["absolute_local_path"]["count"] == 1
+    assert payload["integrity"]["failed"] is False and payload["strict"]["failed"] is False


### PR DESCRIPTION
## Summary

`[x](/home/user/notes.md)` currently receives no check of any kind. `is_local_relative` excludes
anything starting with `/`, so such a link is invisible to both `dangling` (shares the exclusion)
and `out_of_scope` (that axis names a real location outside `--root`; an absolute path names none).
Unlike a relative link — which resolves to "this repo" on any clone — an absolute path can only
ever resolve on the one machine that wrote it, and until now, silently.

- New `Kind.ABSOLUTE_LOCAL_PATH`, detected in `robustify.py` alongside the existing dangling check
  (same `is_local_relative` gap, same FR-047 encoded-href handling).
- Surfaced in `darnlink check` as its own axis (`absolute_local_path` in `--json`, an
  `[absolute-local-path]` line in text output) — same treatment as `dangling` (FR-049): report-only,
  **deliberately absent from the exit code**, so no consumer's gate goes red the day it upgrades.
- 12 new tests in `tests/test_absolute_local_links.py`, mirroring `test_dangling_links.py`'s style,
  including the case this is easiest to confuse with an existing axis
  (`test_out_of_scope_relative_link_is_not_absolute_local_path`).

## Why

Grew out of auditing whether a gate hardening (fail on any local link that escapes the repo root)
would be safe to turn on across the repos that run `darnlink-gate.json`. Absolute local paths turned
out to be a separate, pre-existing blind spot with near-zero adoption cost — verified by running
`darnlink check --json` against the 9 real repos currently gated by darnlink: every one reports
`exit_code: 0` unchanged, with `absolute_local_path.count` ranging from 0 to 84 (mostly
`/wiki/...`/`/media/...`-style paths baked into Confluence/SharePoint mirror exports — legitimate
things to *see*, not things that should ever fail a build).

## Test plan
- [x] `uv run pytest` — 397 passed (full suite, including the 12 new tests)
- [x] `bash tools/check.sh` — darnlang, tests, repair/robustify/dangling gate all green
- [x] `darnlink check .` on darnlink's own tree — clean
- [x] `darnlink check --json` against 9 external repos that run `darnlink-gate.json` — exit code
      unchanged at 0 in all of them