### PR TITLE
docs: share one instruction file across agents via symlinks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
AGENTS.md and .github/copilot-instructions.md become symlinks to CLAUDE.md, so Copilot — and any agent following the AGENTS.md convention — reads the same conventions as Claude, with no second copy that can drift.

Git stores symlinks natively (mode 120000), so they travel on clone; no build step and no generator involved.

Verified: both resolve to CLAUDE.md, and git records them as 120000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)