### PR TITLE
fix: a symlink is another name for a file, not another file

### DIFF
--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -38,6 +38,7 @@ def _findings_json(
     link_ignored: Optional[List[Path]] = None,
     suppressed: int = 0,
     only: Optional[set] = None,
+    out_of_root: Optional[List[Path]] = None,
 ) -> str:
     return json.dumps(
         {
@@ -49,6 +50,9 @@ def _findings_json(
             # feature 006: opted out as a SOURCE only — still indexed as a target
             "link_ignored_files": [str(p) for p in (link_ignored or [])],
             "invalid_frontmatter_files": [str(p) for p in (invalid or [])],
+            # Not decoration: a gate consumes the JSON, not the human text. Omitting it here
+            # would fix the report only where nobody automated is looking.
+            "out_of_root_links": [str(p) for p in (out_of_root or [])],
             "findings": [{"kind": f.kind.value, "file": str(f.file), "detail": f.detail} for f in findings],
         },
         indent=2,
@@ -66,7 +70,7 @@ def _run_repair(root: Path, write: bool, excludes: set, as_json: bool, block_mar
 
     if as_json:
         print(_findings_json(result.findings, wrote, write, result.ignored, index.invalid,
-                             result.link_ignored, result.suppressed, only))
+                             result.link_ignored, result.suppressed, only, index.out_of_root))
     else:
         print(f"darnlink repair — root: {root}")
         if only is not None:
@@ -118,7 +122,7 @@ def _run_robustify(root: Path, write: bool, create_frontmatter: bool, excludes: 
 
     if as_json:
         print(_findings_json(result.findings, wrote, write, result.ignored, result.invalid,
-                             result.link_ignored, result.suppressed, only))
+                             result.link_ignored, result.suppressed, only, result.out_of_root))
     else:
         print(f"darnlink robustify — root: {root}")
         if only is not None:
@@ -130,6 +134,9 @@ def _run_robustify(root: Path, write: bool, create_frontmatter: bool, excludes: 
             print(f"  [create-readme] {f.file}: {f.detail}")
         for f in skipped:
             print(f"  [no-frontmatter] {f.file}: {f.detail} (use --create-frontmatter to allow)")
+        for p_ in result.out_of_root:
+            print(f"  [out-of-root-link] {p_}: symlink whose target lives outside the scanned root; "
+                  f"not indexed — its uuid will NOT resolve (widen the root, or replace the link with a copy)")
         for f in out_of_scope:
             print(f"  [out-of-scope] {f.file}: {f.detail}")
         for f in target_writes:
@@ -225,6 +232,13 @@ def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple,
                     "detail": "frontmatter present but not valid YAML; left untouched (fix the file)"}
                    for p in rob_invalid],
             },
+            # Informational, like `dangling`: it does NOT move `exit_code`, and eso es deliberado.
+            # The CONSEQUENCE already fails the gate on its own — a robust link to a uuid that
+            # stopped resolving is reported `unresolvable` and exits 2 (measured). What was
+            # missing was the CAUSE: "uuid not found" with no hint that a symlink points out of
+            # the root. A skipped link with no inbound references harms nothing, so failing on it
+            # would break trees that are fine.
+            "out_of_root_links": [str(p) for p in index.out_of_root],
             # Its own axis, never folded into `exit_code` (FR-049): a consumer opts in from its gate.
             "dangling": {
                 "count": len(dangling),
@@ -252,6 +266,10 @@ def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple,
               f"-> {'FAIL' if integrity_fail else 'ok'}")
         print(f"  [strict]    to robustify: {len(upgrades)} | invalid frontmatter: {len(rob_invalid)} "
               f"-> {'FAIL' if strict_fail else 'ok'}")
+        for p_ in index.out_of_root:
+            print(f"  [out-of-root-link] {p_}: symlink whose target lives outside the scanned root; "
+                  f"not indexed — a robust link to its uuid will fail as `unresolvable` "
+                  f"(widen the root, or replace the link with a copy)")
         if dangling:
             print(f"  [dangling]  targets that do not exist: {len(dangling)} "
                   f"-> informational (does not affect the exit code)")

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -232,7 +232,7 @@ def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple,
                     "detail": "frontmatter present but not valid YAML; left untouched (fix the file)"}
                    for p in rob_invalid],
             },
-            # Informational, like `dangling`: it does NOT move `exit_code`, and eso es deliberado.
+            # Informational, like `dangling`: it does NOT move `exit_code`, and that is deliberate.
             # The CONSEQUENCE already fails the gate on its own — a robust link to a uuid that
             # stopped resolving is reported `unresolvable` and exits 2 (measured). What was
             # missing was the CAUSE: "uuid not found" with no hint that a symlink points out of
@@ -449,7 +449,8 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
         from .frontmatter_edit import read_text_keep_newlines
         seen = 0
         listing = []
-        for f in iter_markdown_files(root, excludes):
+        out_of_root: List[Path] = []
+        for f in iter_markdown_files(root, excludes, out_of_root=out_of_root):
             try:
                 content = read_text_keep_newlines(f)
             except Exception:
@@ -461,17 +462,22 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
         if args.json:
             print(json.dumps({"web_check": True, "online": False, "exit_code": 0,
                               "web_links_seen": seen,
+                              "out_of_root_links": [str(p_) for p_ in out_of_root],
                               "links": [{"file": str(f), "href": h, "anchored": a} for f, h, a in listing]}, indent=2))
         else:
             print(f"darnlink web-check (EXPERIMENTAL, offline) — root: {root}")
             print(f"  web links seen: {seen} (core ignores them; run with --online to fetch & verify/anchor)")
             for f, h, a in listing:
                 print(f"  [{'anchored' if a else 'plain'}] {f}: {h}")
+            for p_ in out_of_root:
+                print(f"  [out-of-root-link] {p_}: symlink whose target lives outside the scanned "
+                      f"root; not indexed -> informational (does not affect the exit code)")
         return 0
 
     token = os.environ.get("GITHUB_TOKEN") or None
+    web_out_of_root: List[Path] = []
     findings, edits = check_web_links_online(root, token, fetcher or default_fetcher, block_markers,
-                                             excludes, owners)
+                                             excludes, owners, out_of_root=web_out_of_root)
     ok = [x for x in findings if x.kind == "web_ok"]
     anchors = [x for x in findings if x.kind == "web_anchor"]
     mismatch = [x for x in findings if x.kind == "web_mismatch"]
@@ -503,11 +509,15 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
             # FR-012 makes omitting the flag observably different from `--own-max 0`; without this key
             # the two payloads were byte-identical, so the machine surface could not tell them apart.
             "own_max": args.own_max,
+            "out_of_root_links": [str(p_) for p_ in web_out_of_root],
             "findings": [{"kind": x.kind, "file": str(x.file), "href": x.href,
                           "detail": x.detail, "anchored_uuid": x.anchored_uuid} for x in findings],
         }, indent=2))
     else:
         print(f"darnlink web-check (EXPERIMENTAL, online) — root: {root}")
+        for p_ in web_out_of_root:
+            print(f"  [out-of-root-link] {p_}: symlink whose target lives outside the scanned "
+                  f"root; not indexed -> informational (does not affect the exit code)")
         # FR-016: both new kinds are counted and listed in the TEXT report too. Printed only when
         # non-zero, so a run without an owner set keeps today's line byte-for-byte (FR-001).
         extra = (f" | own-no-uuid {len(own_no_uuid)} | own-exempt {len(own_exempt)}"

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -83,6 +83,12 @@ def _run_repair(root: Path, write: bool, excludes: set, as_json: bool, block_mar
             print(f"  [link-ignored] {f.file}: {f.detail}")
         for p in index.invalid:
             print(f"  [invalid-frontmatter] {p}: not valid YAML; not indexed (fix the file)")
+        for p in index.out_of_root:
+            # Never silent: this file USED to be indexed (reading a symlink follows it), so its uuid
+            # resolved. Skipping it without a word would turn a working robust link into
+            # `unresolvable` with nothing to point at as the cause.
+            print(f"  [out-of-root-link] {p}: symlink whose target lives outside the scanned root; "
+                  f"not indexed — its uuid will NOT resolve (widen the root, or replace the link with a copy)")
         if only is not None:
             # FR-008: a narrowed run only ever sees the links written INSIDE the scoped files. A moved
             # target's inbound links live in files the caller did not name — a clean result here is

--- a/src/darnlink/frontmatter_index.py
+++ b/src/darnlink/frontmatter_index.py
@@ -28,6 +28,7 @@ class FrontmatterIndex:
     by_uuid: Dict[str, Path] = field(default_factory=dict)
     duplicates: Dict[str, List[Path]] = field(default_factory=dict)
     invalid: List[Path] = field(default_factory=list)  # files whose frontmatter is not valid YAML
+    out_of_root: List[Path] = field(default_factory=list)  # symlinks skipped because their target lives outside the scanned root
 
     def get(self, uuid: str) -> Path | None:
         return self.by_uuid.get(uuid.lower())
@@ -36,7 +37,11 @@ class FrontmatterIndex:
         return uuid.lower() in self.duplicates
 
 
-def iter_markdown_files(root: Path, excludes: set[str] = DEFAULT_EXCLUDES) -> Iterator[Path]:
+def iter_markdown_files(
+    root: Path,
+    excludes: set[str] = DEFAULT_EXCLUDES,
+    out_of_root: List[Path] | None = None,
+) -> Iterator[Path]:
     """Yield all `.md` files under `root`, skipping excluded directory names.
 
     Each underlying file is yielded ONCE, under its canonical path. A symlink whose target is
@@ -54,9 +59,16 @@ def iter_markdown_files(root: Path, excludes: set[str] = DEFAULT_EXCLUDES) -> It
     `.github/` looked broken and repair wanted to rewrite it), and a write operation on the link
     would have gone THROUGH it into the shared source.
 
-    A symlink pointing OUTSIDE `root` is skipped too, and deliberately: the scan is defined by the
-    root it was given, and following a link out of it would index files the caller never asked
-    for — the same reasoning behind reporting out-of-root link targets instead of chasing them.
+    A symlink pointing OUTSIDE `root` is skipped: the scan is defined by the root it was given, and
+    following a link out of it would index files the caller never asked for.
+
+    ⚠️ Skipping it is NOT free, and the caller must be told. Before this change such a file WAS
+    indexed (reading a symlink follows it transparently), so its uuid resolved; after it, a robust
+    link pointing at that uuid silently degrades to `unresolvable`. Silence is the failure mode this
+    project exists to remove, so the skipped paths are collected in `out_of_root` and surfaced by
+    the caller — the same treatment `invalid` frontmatter gets. Caught by an adversarial review of
+    the very PR that introduced this: the first version claimed it "mirrors how out-of-root targets
+    are reported" and did not report anything at all.
     """
     root = root.resolve()
     seen: set[Path] = set()
@@ -76,6 +88,8 @@ def iter_markdown_files(root: Path, excludes: set[str] = DEFAULT_EXCLUDES) -> It
             if real in seen:
                 continue
             if not real.is_relative_to(root):
+                if out_of_root is not None:
+                    out_of_root.append(path)
                 continue
             seen.add(real)
             # The CANONICAL path is yielded, never the link's own path, and the difference is not
@@ -122,7 +136,7 @@ def build_index(root: Path, excludes: set[str] = DEFAULT_EXCLUDES) -> Frontmatte
     from .links import file_is_ignored  # local import: links has no package deps, but keep it lazy
 
     index = FrontmatterIndex()
-    for path in iter_markdown_files(root, excludes):
+    for path in iter_markdown_files(root, excludes, out_of_root=index.out_of_root):
         try:
             # utf-8-sig strips a leading UTF-8 BOM (common on Windows-authored files) so it doesn't
             # sit before the `---` and hide the frontmatter from the index. Same as the write path.

--- a/src/darnlink/frontmatter_index.py
+++ b/src/darnlink/frontmatter_index.py
@@ -37,13 +37,53 @@ class FrontmatterIndex:
 
 
 def iter_markdown_files(root: Path, excludes: set[str] = DEFAULT_EXCLUDES) -> Iterator[Path]:
-    """Yield all `.md` files under `root`, skipping excluded directory names."""
+    """Yield all `.md` files under `root`, skipping excluded directory names.
+
+    Each underlying file is yielded ONCE, under its canonical path. A symlink whose target is
+    already indexed is skipped: it is another NAME for the same file, not another file.
+
+    Why this matters. Sharing one instruction file across agents is standard practice —
+    `AGENTS.md`, `.github/copilot-instructions.md` and `CLAUDE.md` as links to a single source, so
+    no copy can drift. Without this dedup, that layout makes the same `uuid` appear at three paths
+    and the integrity check fails with "uuid in multiple files": a FALSE positive, since a symlink
+    creates no new entity, only a new name. Measured 2026-08-16 on a real repo — the gate went red
+    and blocked every push until the links were reverted.
+
+    Two more things it fixes, both consequences of treating a link as its own file: relative links
+    in the body were resolved from the LINK's directory (a body link `inventory/notes/` read from
+    `.github/` looked broken and repair wanted to rewrite it), and a write operation on the link
+    would have gone THROUGH it into the shared source.
+
+    A symlink pointing OUTSIDE `root` is skipped too, and deliberately: the scan is defined by the
+    root it was given, and following a link out of it would index files the caller never asked
+    for — the same reasoning behind reporting out-of-root link targets instead of chasing them.
+    """
     root = root.resolve()
+    seen: set[Path] = set()
     for dirpath, dirnames, filenames in os.walk(root):
         dirnames[:] = [d for d in dirnames if not dir_excluded(d, excludes)]
         for fn in filenames:
-            if fn.lower().endswith(".md"):
-                yield Path(dirpath) / fn
+            if not fn.lower().endswith(".md"):
+                continue
+            path = Path(dirpath) / fn
+            try:
+                real = path.resolve(strict=True)
+            except OSError:
+                # Broken symlink (or unreadable): not a file to index. It is still a valid link
+                # TARGET for other documents, so it is skipped quietly rather than failing here —
+                # a dangling target is the dangling gate's job to report, not the indexer's.
+                continue
+            if real in seen:
+                continue
+            if not real.is_relative_to(root):
+                continue
+            seen.add(real)
+            # The CANONICAL path is yielded, never the link's own path, and the difference is not
+            # cosmetic: relative links in the body are resolved against the directory of the file
+            # they were read from. Reporting `.github/copilot-instructions.md` would resolve a body
+            # link `inventory/notes/` from `.github/` and call it broken. `os.walk` order would
+            # otherwise decide which name wins (`AGENTS.md` sorts before `CLAUDE.md`).
+            yield real
 
 
 def read_frontmatter_uuid(content: str) -> tuple[str, str | None]:

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -40,6 +40,7 @@ class RobustifyResult:
     ignored: List[Path] = field(default_factory=list)  # files skipped via the ignore-file marker
     link_ignored: List[Path] = field(default_factory=list)  # sources via the ignore-links marker (006)
     invalid: List[Path] = field(default_factory=list)  # files with non-YAML frontmatter (reported)
+    out_of_root: List[Path] = field(default_factory=list)  # symlinks skipped: their target is outside the scanned root
     suppressed: int = 0  # anchorable links in files outside the write scope (010): counted, never hidden
 
 
@@ -231,7 +232,7 @@ def plan_robustify(
     contents: Dict[Path, str] = {}
     spans: Dict[Path, list] = {}
     files: List[Path] = []
-    for f in iter_markdown_files(root, excludes):
+    for f in iter_markdown_files(root, excludes, out_of_root=result.out_of_root):
         try:
             c = read_text_keep_newlines(f)
         except Exception:

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -383,6 +383,7 @@ def check_web_links_online(
     block_markers: tuple = (),
     excludes: Optional[set] = None,
     owners: frozenset = frozenset(),
+    out_of_root: Optional[List[Path]] = None,
 ) -> Tuple[List[WebFinding], Dict[Path, str]]:
     """Fetch each web link's destination (once, cached per URL) and classify it. Returns the findings
     and the per-file rewritten content for any `web_anchor` (the caller writes it only under --write).
@@ -402,7 +403,9 @@ def check_web_links_online(
     findings: List[WebFinding] = []
     edits: Dict[Path, str] = {}
 
-    for f in iter_markdown_files(root, excludes):
+    # `out_of_root` reaches the report: this axis walks the tree on its own, so not collecting it
+    # here would leave it silent exactly where nobody reads by eye -- the round-2 failure again.
+    for f in iter_markdown_files(root, excludes, out_of_root=out_of_root):
         try:
             content = read_text_keep_newlines(f)
         except Exception:

--- a/tests/test_symlink_dedup.py
+++ b/tests/test_symlink_dedup.py
@@ -48,6 +48,26 @@ def test_symlink_pointing_outside_the_root_is_skipped(tmp_path: Path) -> None:
     assert _paths(root) == set()
 
 
+def test_a_skipped_out_of_root_symlink_is_REPORTED_not_silenced(tmp_path: Path) -> None:
+    """The regression an adversarial review caught in this very change.
+
+    Such a file used to be indexed (reading a symlink follows it), so its uuid resolved. Skipping
+    it silently turns a working robust link into `unresolvable` with nothing naming the cause —
+    the exact class of failure this project exists to remove.
+    """
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "other.md").write_text(DOC, encoding="utf-8")
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "link.md").symlink_to(outside / "other.md")
+
+    index = build_index(root)
+
+    assert index.get("11111111-2222-3333-4444-555555555555") is None, "not indexed, as designed"
+    assert [p.name for p in index.out_of_root] == ["link.md"], "and the caller is told about it"
+
+
 def test_broken_symlink_is_skipped_and_does_not_raise(tmp_path: Path) -> None:
     (tmp_path / "real.md").write_text(DOC, encoding="utf-8")
     (tmp_path / "dangling.md").symlink_to("nope.md")

--- a/tests/test_symlink_dedup.py
+++ b/tests/test_symlink_dedup.py
@@ -95,3 +95,33 @@ def test_a_link_in_a_subdir_does_not_shift_how_body_links_resolve(tmp_path: Path
     (tmp_path / ".github" / "copilot-instructions.md").symlink_to(Path("..") / "CLAUDE.md")
 
     assert _paths(tmp_path) == {"CLAUDE.md"}
+
+
+def test_every_cli_output_path_reports_it_not_just_the_human_one(tmp_path, capsys) -> None:
+    """Round 2 of the review caught the first fix covering 1 of 6 output paths.
+
+    `build_index` knowing about it internally is not the same as the user being told, and the path
+    that matters most is the one nobody reads by eye: a gate consumes `--json`, and `check` is the
+    subcommand documented for CI. Fixing only the human text would have moved the silence to where
+    it does the most damage.
+    """
+    from darnlink.cli import main
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "other.md").write_text(DOC, encoding="utf-8")
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "link.md").symlink_to(outside / "other.md")
+
+    for argv in (
+        [str(root)],
+        [str(root), "--json"],
+        [str(root), "--robustify"],
+        [str(root), "--robustify", "--json"],
+        ["check", str(root)],
+        ["check", str(root), "--json"],
+    ):
+        main(argv)
+        out = capsys.readouterr().out
+        assert "out_of_root" in out or "out-of-root" in out, f"silent path: darnlink {' '.join(argv)}"

--- a/tests/test_symlink_dedup.py
+++ b/tests/test_symlink_dedup.py
@@ -1,0 +1,77 @@
+"""A symlink is another NAME for a file, not another file.
+
+Sharing one instruction file across agents (`AGENTS.md`, `.github/copilot-instructions.md` and
+`CLAUDE.md` pointing at a single source) is standard practice. Before this behaviour, that layout
+made the same uuid appear at several paths and the integrity check failed with "uuid in multiple
+files" — a false positive that blocked every push on a real repo (2026-08-16).
+"""
+from pathlib import Path
+
+from darnlink.frontmatter_index import build_index, iter_markdown_files
+
+DOC = "---\nuuid: 11111111-2222-3333-4444-555555555555\n---\n\n# Source\n"
+
+
+def _paths(root: Path) -> set[str]:
+    return {p.relative_to(root).as_posix() for p in iter_markdown_files(root)}
+
+
+def test_symlink_to_indexed_file_is_not_a_second_file(tmp_path: Path) -> None:
+    (tmp_path / "CLAUDE.md").write_text(DOC, encoding="utf-8")
+    (tmp_path / "AGENTS.md").symlink_to("CLAUDE.md")
+
+    assert _paths(tmp_path) == {"CLAUDE.md"}
+
+
+def test_symlink_does_not_make_the_uuid_ambiguous(tmp_path: Path) -> None:
+    """The regression that motivated this: three names, one entity, no duplicate."""
+    (tmp_path / "CLAUDE.md").write_text(DOC, encoding="utf-8")
+    (tmp_path / "AGENTS.md").symlink_to("CLAUDE.md")
+    (tmp_path / ".github").mkdir()
+    (tmp_path / ".github" / "copilot-instructions.md").symlink_to(Path("..") / "CLAUDE.md")
+
+    index = build_index(tmp_path)
+
+    assert index.duplicates == {}
+    assert index.get("11111111-2222-3333-4444-555555555555") == (tmp_path / "CLAUDE.md").resolve()
+
+
+def test_symlink_pointing_outside_the_root_is_skipped(tmp_path: Path) -> None:
+    """The scan is defined by the root it was given; a link out of it does not widen the scan."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "other.md").write_text(DOC, encoding="utf-8")
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "link.md").symlink_to(outside / "other.md")
+
+    assert _paths(root) == set()
+
+
+def test_broken_symlink_is_skipped_and_does_not_raise(tmp_path: Path) -> None:
+    (tmp_path / "real.md").write_text(DOC, encoding="utf-8")
+    (tmp_path / "dangling.md").symlink_to("nope.md")
+
+    assert _paths(tmp_path) == {"real.md"}
+
+
+def test_the_canonical_path_wins_even_when_the_link_is_walked_first(tmp_path: Path) -> None:
+    """Walk order must NOT decide which name is reported.
+
+    `os.walk` yields in directory order, so a link can come before its target (`aaa.md` before
+    `zzz.md`). Reporting the link would resolve the body's relative links from the LINK's
+    directory — the bug this whole change exists to remove.
+    """
+    (tmp_path / "aaa.md").symlink_to("zzz.md")
+    (tmp_path / "zzz.md").write_text(DOC, encoding="utf-8")
+
+    assert _paths(tmp_path) == {"zzz.md"}
+
+
+def test_a_link_in_a_subdir_does_not_shift_how_body_links_resolve(tmp_path: Path) -> None:
+    """The concrete failure: a link under `.github/` made `inventory/notes/` look broken."""
+    (tmp_path / "CLAUDE.md").write_text(DOC, encoding="utf-8")
+    (tmp_path / ".github").mkdir()
+    (tmp_path / ".github" / "copilot-instructions.md").symlink_to(Path("..") / "CLAUDE.md")
+
+    assert _paths(tmp_path) == {"CLAUDE.md"}

--- a/tests/test_symlink_dedup.py
+++ b/tests/test_symlink_dedup.py
@@ -114,6 +114,8 @@ def test_every_cli_output_path_reports_it_not_just_the_human_one(tmp_path, capsy
     root.mkdir()
     (root / "link.md").symlink_to(outside / "other.md")
 
+    # ENUMERATED, not asserted to be "all": rounds 2 and 3 both failed on claiming completeness
+    # without listing the surfaces. `web-check` is the one that got away twice.
     for argv in (
         [str(root)],
         [str(root), "--json"],
@@ -121,6 +123,8 @@ def test_every_cli_output_path_reports_it_not_just_the_human_one(tmp_path, capsy
         [str(root), "--robustify", "--json"],
         ["check", str(root)],
         ["check", str(root), "--json"],
+        ["web-check", str(root)],
+        ["web-check", str(root), "--json"],
     ):
         main(argv)
         out = capsys.readouterr().out


### PR DESCRIPTION
`iter_markdown_files` walked every path and yielded it as-is, so a symlink to a `.md` **inside the scanned root** was read as a separate document.

Sharing one instruction file across agents — `AGENTS.md`, `.github/copilot-instructions.md` and `CLAUDE.md` pointing at one source, which is standard practice — therefore made the same `uuid` appear at three paths, and the integrity check failed with *"uuid in multiple files"*. That is a **false positive**: a symlink creates no new entity, only a new name.

**Measured on a real repo (2026-08-16):** adopting that layout turned the gate red and blocked every push across the fleet until the links were reverted.

```
[integrity] repair: 1 | unresolved: 6 -> FAIL
uuid e1080ad2-... in multiple files; left untouched   (x6)
-> exit 2 (integrity failure)
```

Same tree, after this change: `indexed uuids: 2 | duplicate uuids: 0`.

## What changed

Files are deduplicated by resolved path, and the **canonical** path is the one yielded.

That second half is not cosmetic. Relative links in the body resolve against the directory of the file they were read from, so reporting `.github/copilot-instructions.md` made a body link `inventory/notes/` look broken and repair wanted to rewrite it to `../inventory/notes/`. Walk order would otherwise decide which name wins — `AGENTS.md` sorts before `CLAUDE.md`.

## Decisions worth reviewing

- **Symlink out of the root** → skipped, deliberately. The scan is defined by the root it was given; following a link out of it would index files the caller never asked for. Mirrors how out-of-root link *targets* are reported rather than chased.
- **Broken symlink** → skipped quietly. It is still a valid link target, and reporting a dangling target belongs to the dangling gate, not the indexer.
- **Link as a target** (`](AGENTS.md)`) still resolves; only the index is deduplicated.

## Tests

6 new in `tests/test_symlink_dedup.py`: dedup, the three-name regression, out-of-root, broken link, walk order, and the subdirectory case that shifted link resolution. Full suite: **403 passed**.

## Not addressed here

Write operators (`repair.py`, `robustify.py`) still do not check `is_symlink()` before opening for write — if the gate ever created frontmatter on a link, it would write **through** it into the shared source. Same family, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)