### PR TITLE
D1a: an anchor comment stops separating a link from its pandoc attrs (#65)

### DIFF
--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -10,6 +10,20 @@ import re
 from dataclasses import dataclass
 from typing import List, Sequence, Tuple
 
+# The BODY of a pandoc attribute block, between its own `{` and `}` — one definition, shared by
+# ROBUST_LINK_RE's `attrs` group below and by `_PANDOC_ATTR_RE` further down. `[^{}\n]*` alone (the
+# first version of this pattern) treats a `}` inside a quoted attribute value as the block's own
+# closing brace and cuts the match short there — not a miss, a WRONG match, and a corrupting one
+# once something is spliced at the point it stopped. `"[^"\n]*"` makes a quoted run atomic, so `{`
+# and `}` inside a quote no longer terminate the block early; an unterminated quote still fails the
+# whole match, same as an unbalanced `{` always did. Kept as ONE definition on purpose — two
+# independent copies of "what an attrs block looks like" is exactly the shape that drifted before
+# (`is_local_relative`'s four call sites, FR-052), and it already drifted once here: an earlier
+# revision of this fix updated only `_PANDOC_ATTR_RE` and left this literal on the old, corrupting
+# pattern, so `repair` silently stopped recognising (and therefore stopped fixing) an already-correct
+# robust link whose attrs held a quoted `}` — no finding, no write, the stale path just stayed stale.
+_PANDOC_ATTR_BODY = r'(?:[^{}"\n]|"[^"\n]*")*'
+
 # A robust link: a Markdown link immediately followed (any whitespace) by a uuid HTML comment.
 # The optional `attrs` group is a pandoc attribute block (`{.cls}`, `{width="1in"}`, …): pandoc
 # requires it immediately after the link's `)`, with no whitespace, so it must be matched BEFORE
@@ -17,7 +31,7 @@ from typing import List, Sequence, Tuple
 # right up to `{`, misparsing `[x](y){.cls}` as `[x](y)` followed by unrelated `{.cls}` text.
 ROBUST_LINK_RE = re.compile(
     r"\[(?P<text>[^\]]*)\]\((?P<href>(?:[^()\s]|\((?:[^()\s]|\([^()\s]*\))*\))+|[^)]+)\)"
-    r"(?P<attrs>\{[^{}\n]*\})?\s*<!--\s*uuid:\s*(?P<uuid>[0-9a-fA-F-]{36})\s*-->"
+    r"(?P<attrs>\{" + _PANDOC_ATTR_BODY + r"\})?\s*<!--\s*uuid:\s*(?P<uuid>[0-9a-fA-F-]{36})\s*-->"
 )
 # Any inline Markdown link. `text` is `*`, not `+`: `[](dest)` is a link with empty text, and the
 # empty alt of `![](dest)` is what pandoc emits for every image in a converted .docx/.odt. Requiring
@@ -81,7 +95,9 @@ _TRAILING_UUID_RE = re.compile(r"\s*<!--\s*uuid:\s*[0-9a-fA-F-]{36}\s*-->")
 # rule -- a block after a space is not attached to anything and pandoc ignores it). Matched with
 # .match(content, pos) the same way as _TRAILING_UUID_RE, so callers can skip past it before
 # checking for the anchor comment -- see `_skip_attrs` below for why that skip has to exist at all.
-_PANDOC_ATTR_RE = re.compile(r"\{[^{}\n]*\}")
+# Shares `_PANDOC_ATTR_BODY` with `ROBUST_LINK_RE`'s own `attrs` group (see that constant's comment
+# for why one definition, not two, matters here specifically).
+_PANDOC_ATTR_RE = re.compile(r"\{" + _PANDOC_ATTR_BODY + r"\}")
 
 
 def pandoc_attrs_at(content: str, pos: int) -> str:

--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -11,8 +11,13 @@ from dataclasses import dataclass
 from typing import List, Sequence, Tuple
 
 # A robust link: a Markdown link immediately followed (any whitespace) by a uuid HTML comment.
+# The optional `attrs` group is a pandoc attribute block (`{.cls}`, `{width="1in"}`, …): pandoc
+# requires it immediately after the link's `)`, with no whitespace, so it must be matched BEFORE
+# the anchor comment's leading `\s*` — reversing the order would let the whitespace class absorb
+# right up to `{`, misparsing `[x](y){.cls}` as `[x](y)` followed by unrelated `{.cls}` text.
 ROBUST_LINK_RE = re.compile(
-    r"\[(?P<text>[^\]]*)\]\((?P<href>(?:[^()\s]|\((?:[^()\s]|\([^()\s]*\))*\))+|[^)]+)\)\s*<!--\s*uuid:\s*(?P<uuid>[0-9a-fA-F-]{36})\s*-->"
+    r"\[(?P<text>[^\]]*)\]\((?P<href>(?:[^()\s]|\((?:[^()\s]|\([^()\s]*\))*\))+|[^)]+)\)"
+    r"(?P<attrs>\{[^{}\n]*\})?\s*<!--\s*uuid:\s*(?P<uuid>[0-9a-fA-F-]{36})\s*-->"
 )
 # Any inline Markdown link. `text` is `*`, not `+`: `[](dest)` is a link with empty text, and the
 # empty alt of `![](dest)` is what pandoc emits for every image in a converted .docx/.odt. Requiring
@@ -72,6 +77,35 @@ MD_LINK_RE = re.compile(r"\[(?P<text>[^\]]*)\]\((?P<href>(?:[^()\s]|\((?:[^()\s]
 # A uuid comment that immediately follows a link (used to tell plain from robust).
 # No `^`: it is applied with .match(content, pos), which already anchors at pos.
 _TRAILING_UUID_RE = re.compile(r"\s*<!--\s*uuid:\s*[0-9a-fA-F-]{36}\s*-->")
+# A pandoc attribute block immediately following a link's `)`, no whitespace allowed (pandoc's own
+# rule -- a block after a space is not attached to anything and pandoc ignores it). Matched with
+# .match(content, pos) the same way as _TRAILING_UUID_RE, so callers can skip past it before
+# checking for the anchor comment -- see `_skip_attrs` below for why that skip has to exist at all.
+_PANDOC_ATTR_RE = re.compile(r"\{[^{}\n]*\}")
+
+
+def pandoc_attrs_at(content: str, pos: int) -> str:
+    """The pandoc attribute block immediately at `pos`, verbatim, or `""` if there is none.
+
+    Used both to WRITE (place the block before the anchor) and to DETECT (skip past it before
+    checking for a trailing anchor comment) -- one definition of "attrs block" for both directions,
+    so they cannot drift apart the way `is_local_relative`'s four call sites once did (FR-052).
+    """
+    m = _PANDOC_ATTR_RE.match(content, pos)
+    return m.group(0) if m else ""
+
+
+def _skip_attrs(content: str, pos: int) -> int:
+    """`pos`, advanced past an immediately-following pandoc attribute block if there is one.
+
+    Every site that decides "is a link already robust?" by looking right after its `)` has to use
+    this, not `pos` itself -- once `--write` places attrs before the anchor (FR-065), a link that
+    HAS an attrs block reads `[x](y){.cls} <!-- uuid: … -->`, and checking for the anchor at `pos`
+    (right after the `)`, before `{.cls}`) would find `{` instead and call the link still plain.
+    Robustify would then append a SECOND anchor: the uuid ends up in the file twice, one copy
+    anchoring nothing, invisible to every later run because the link now reads as robust either way.
+    """
+    return pos + len(pandoc_attrs_at(content, pos))
 # Any uuid comment, wherever it sits. Used to find the ones attached to nothing.
 UUID_COMMENT_RE = re.compile(r"<!--\s*uuid:\s*(?P<uuid>[0-9a-fA-F-]{36})\s*-->")
 
@@ -222,8 +256,9 @@ class RobustLink:
     text: str
     href: str
     uuid: str
-    start: int  # span of the whole robust link (link + comment) in the source
+    start: int  # span of the whole robust link (link + attrs + comment) in the source
     end: int
+    attrs: str = ""  # a pandoc attribute block (`{.cls}`), verbatim, or "" if there is none
 
 
 @dataclass(frozen=True)
@@ -237,7 +272,8 @@ class PlainLink:
 def find_robust_links(content: str, ignore: Sequence[Span] = ()) -> List[RobustLink]:
     """All robust links in the content, in document order, skipping any inside `ignore` spans."""
     return [
-        RobustLink(m.group("text"), m.group("href"), m.group("uuid").lower(), m.start(), m.end())
+        RobustLink(m.group("text"), m.group("href"), m.group("uuid").lower(), m.start(), m.end(),
+                   m.group("attrs") or "")
         for m in ROBUST_LINK_RE.finditer(content)
         if not _in_spans(m.start(), ignore)
     ]
@@ -247,8 +283,8 @@ def find_plain_links(content: str, ignore: Sequence[Span] = ()) -> List[PlainLin
     """All Markdown links that are NOT already robust, skipping any inside `ignore` spans."""
     out: List[PlainLink] = []
     for m in MD_LINK_RE.finditer(content):
-        if _TRAILING_UUID_RE.match(content, m.end()):
-            continue  # this link is part of a robust link; skip
+        if _TRAILING_UUID_RE.match(content, _skip_attrs(content, m.end())):
+            continue  # this link (with or without a pandoc attrs block) is already robust; skip
         if _in_spans(m.start(), ignore):
             continue  # inside a generated block (e.g. autogrid); leave it alone
         out.append(PlainLink(m.group("text"), m.group("href"), m.start(), m.end()))
@@ -278,10 +314,11 @@ def find_detached_anchors(content: str, ignore: Sequence[Span] = ()) -> List[Det
     """
     attached: set[int] = set()
     for m in MD_LINK_RE.finditer(content):
-        t = _TRAILING_UUID_RE.match(content, m.end())
+        after_attrs = _skip_attrs(content, m.end())
+        t = _TRAILING_UUID_RE.match(content, after_attrs)
         if t is None:
             continue
-        c = UUID_COMMENT_RE.search(content, m.end(), t.end())
+        c = UUID_COMMENT_RE.search(content, after_attrs, t.end())
         if c is not None:
             attached.add(c.start())
     return [
@@ -298,6 +335,12 @@ def line_bounds(content: str, pos: int) -> Span:
     return (start, len(content) if end == -1 else end)
 
 
-def emit_robust_link(text: str, href: str, uuid: str) -> str:
-    """Canonical robust-link rendering: a single space before the comment."""
-    return f"[{text}]({href}) <!-- uuid: {uuid} -->"
+def emit_robust_link(text: str, href: str, uuid: str, attrs: str = "") -> str:
+    """Canonical robust-link rendering: a single space before the comment.
+
+    `attrs` (a pandoc attribute block, `{.cls}`) goes immediately after `)`, with NO space -- pandoc
+    only recognises the block there (FR-065). Putting the anchor comment first, as earlier versions
+    did unconditionally, detaches `{.cls}` from the link it belongs to: pandoc then ignores it
+    silently, and the document still renders, just without the class/width/height it was given.
+    """
+    return f"[{text}]({href}){attrs} <!-- uuid: {uuid} -->"

--- a/src/darnlink/repair.py
+++ b/src/darnlink/repair.py
@@ -146,7 +146,7 @@ def plan_repairs(
             local.append(Finding(Kind.REPAIR, f, f"{link.href} -> {new_href}"))
             # splice the rewritten robust link in place of the old span
             pieces.append(content[cursor:link.start])
-            pieces.append(emit_robust_link(link.text, new_href, link.uuid))
+            pieces.append(emit_robust_link(link.text, new_href, link.uuid, link.attrs))
             cursor = link.end
             changed = True
         if not scoped:

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -26,7 +26,7 @@ from .frontmatter_edit import (
 from .frontmatter_index import DEFAULT_EXCLUDES, dir_excluded, iter_markdown_files, read_frontmatter_uuid
 from .links import (DetachedAnchor, PlainLink, code_spans, emit_robust_link, file_ignores_links,
                     file_is_ignored, find_detached_anchors, find_plain_links, ignored_spans,
-                    line_bounds)
+                    line_bounds, pandoc_attrs_at)
 from .paths import (DIR_ANCHOR, is_absolute_local_path, is_local_relative, names_md, resolve_href,
                      split_fragment)
 from .report import Finding, Kind
@@ -500,7 +500,12 @@ def plan_robustify(
 
         edits: List[Tuple[int, int, str]] = []  # (start, end, replacement), disjoint by construction
         for i, (link, u) in enumerate(anchorable):
-            edits.append((link.start, link.end, emit_robust_link(link.text, link.href, u)))
+            # FR-065: a pandoc attribute block immediately after `)` must stay immediately after
+            # `)` -- pandoc detaches it from the link otherwise, silently. The edit's span is
+            # widened to swallow that block so it isn't left behind duplicated, and emit_robust_link
+            # puts it back before the anchor comment rather than after.
+            attrs = pandoc_attrs_at(original, link.end)
+            edits.append((link.start, link.end + len(attrs), emit_robust_link(link.text, link.href, u, attrs)))
             detail = f"{link.href} +uuid {u}"
             stray = absorb.get(i)
             if stray is not None:

--- a/tests/test_robustify.py
+++ b/tests/test_robustify.py
@@ -429,6 +429,53 @@ def test_65_the_reported_example_anchors_with_attrs_in_place(tmp_path):
     assert a == f'![](B.md){{width="1.1in" height="2in"}} <!-- uuid: {EXISTING} -->\n', f"bad rewrite: {a!r}"
 
 
+def test_65_a_quoted_attr_value_containing_a_brace_is_not_split(tmp_path):
+    """Adversarial follow-up to #65: `_PANDOC_ATTR_RE`'s naive `[^{}\\n]*` body cuts the match short
+    at the FIRST `}`, even one that sits inside a quoted attribute value -- and a short match is not
+    just a miss, it is a WRONG one: `pandoc_attrs_at` returns `{data-x="a}` as if it were the whole,
+    well-formed block, and `--write` splices the anchor comment into the middle of the attribute's
+    own text. That is worse than #65 itself, which only misplaces an intact block; this corrupts it.
+
+    Reproduced directly against `plan_robustify`/`apply_robustify` before the fix:
+    `![](B.md){data-x="a}b"}` became `![](B.md){data-x="a} <!-- uuid: … -->b"}` -- the quoted value
+    split around the comment, `b"}` orphaned as trailing prose. The regex now treats a `"..."` run as
+    atomic so `{`/`}` inside it cannot terminate the block early.
+    """
+    _w(tmp_path / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
+    _w(tmp_path / "A.md", '![](B.md){data-x="a}b"}\n')
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    a = (tmp_path / "A.md").read_text()
+    assert a == f'![](B.md){{data-x="a}}b"}} <!-- uuid: {EXISTING} -->\n', f"bad rewrite: {a!r}"
+
+
+def test_65_repair_finds_a_stale_link_whose_attrs_hold_a_quoted_brace(tmp_path):
+    """Sibling of the write-side test above, on the READ side: `ROBUST_LINK_RE`'s own `attrs`
+    group used to be a SECOND, independent copy of the same pattern text as `_PANDOC_ATTR_RE` --
+    and it drifted the moment only one of the two was hardened for a quoted `}`. With the drift,
+    `find_robust_links` (which `repair` is built on) fails to match this well-formed, already
+    -correctly-anchored link AT ALL: not a wrong parse, no parse. `plan_repairs` then reports
+    ZERO findings for a link whose target has genuinely moved -- the stale path survives, and the
+    gate reads the tree as clean. Both regexes must share one definition of "attrs block" (the
+    codebase's own stated reason `pandoc_attrs_at` exists), or this class of bug reappears every
+    time only one of the two literals gets fixed.
+    """
+    from darnlink.frontmatter_index import build_index
+    from darnlink.repair import plan_repairs, apply_repairs
+
+    _w(tmp_path / "new" / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
+    _w(tmp_path / "A.md", f'![](old/B.md){{data-x="a}}b"}} <!-- uuid: {EXISTING} -->\n')
+
+    result = plan_repairs(tmp_path, build_index(tmp_path))
+    assert any(f.kind is Kind.REPAIR for f in result.findings), \
+        f"repair did not even SEE the stale link: {result.findings!r}"
+    apply_repairs(result)
+
+    a = (tmp_path / "A.md").read_text()
+    assert a == f'![](new/B.md){{data-x="a}}b"}} <!-- uuid: {EXISTING} -->\n', f"bad rewrite: {a!r}"
+
+
 def test_65_a_second_pass_over_an_attrs_anchored_link_is_a_no_op(tmp_path):
     """The regression `_TRAILING_UUID_RE`'s own docstring warned about: seen, not just claimed.
 

--- a/tests/test_robustify.py
+++ b/tests/test_robustify.py
@@ -285,14 +285,17 @@ def test_repair_write_leaves_a_pandoc_attribute_suffix_untouched(tmp_path):
     a splice whose end offset is one character off deletes the `{`, and the block stops being a
     block. The shape where the attributes sit *before* the anchor is the sibling test below; the
     two seeds are different and neither test catches the other's.
+
+    This is the shape darnlink itself wrote BEFORE #65 was fixed (attrs after the anchor — the bug
+    itself), not the shape it writes now. Kept as a repair test on purpose: files anchored by an
+    older darnlink can still be sitting in a repo, and `repair` must not corrupt them just because
+    it no longer produces this shape. `ROBUST_LINK_RE` still matches only the LINK+comment part of
+    this string (its `attrs` group is empty here, since nothing but whitespace follows `)`), so the
+    trailing `{width="1.1in"}` sits entirely outside the match and is never part of what gets spliced.
     """
     from darnlink.frontmatter_index import build_index
     from darnlink.repair import plan_repairs, apply_repairs
 
-    # The anchor goes BEFORE the attribute block, because that is where darnlink's own `--write`
-    # puts it (see #65). Writing it the way a human would — `![](x){.cls} <!-- uuid: … -->` — does
-    # not even match `ROBUST_LINK_RE`, which requires the comment to follow the `)` with only
-    # whitespace between; such a link is plain with a detached anchor, and is not this test's case.
     _w(tmp_path / "new" / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
     _w(tmp_path / "A.md", f'![](old/B.md) <!-- uuid: {EXISTING} -->{{width="1.1in"}}\n')
 
@@ -305,17 +308,22 @@ def test_repair_write_leaves_a_pandoc_attribute_suffix_untouched(tmp_path):
     assert a == f'![](new/B.md) <!-- uuid: {EXISTING} -->{{width="1.1in"}}\n', f"bad rewrite: {a!r}"
 
 
-def test_an_attribute_block_before_the_anchor_is_not_a_robust_link(tmp_path):
-    """The span boundary of `ROBUST_LINK_RE`, pinned where a seed can reach it.
+def test_an_attribute_block_before_the_anchor_IS_a_robust_link(tmp_path):
+    """FR-065: `![](x){.cls} <!-- uuid: … -->` is the CORRECT shape, and `repair` must heal it.
 
-    `![](x){.cls} <!-- uuid: … -->` — attributes between the `)` and the comment — is NOT robust:
-    the grammar allows only whitespace there, so this is a plain link with a detached anchor, and
-    `repair` must leave the file alone. Seeding `\\)(?:\\{[^}]*\\})?` into `ROBUST_LINK_RE` makes it
-    robust, and `repair --write` then rewrites the link and **deletes the block**.
+    Before #65 was fixed, `ROBUST_LINK_RE` required only whitespace between `)` and the comment, so
+    this exact shape was refused robust status — a deliberate restriction, guarding a real bug: an
+    earlier, narrower widening (an `attrs` group added to the regex with nothing carrying it through
+    to the rewrite) made `repair --write` recognise the link and then silently DELETE the block while
+    rewriting the href, because nothing told `emit_robust_link` the block existed.
 
-    The sibling test above cannot catch that seed: its fixture puts the block *after* the comment,
-    where the seeded alternative never matches. Two shapes, two tests — the first version of this
-    pair guarded only the shape the seed does not touch, which is no guard at all.
+    #65's fix widens the SAME regex, but pins `attrs` as its own group and threads it through
+    `RobustLink.attrs` -> `emit_robust_link(..., attrs)` in both write paths (`repair`, `robustify`).
+    So recognising this shape is safe now for a reason the old test could not rely on: the deletion
+    bug is fixed at its actual cause (attrs never carried), not avoided by refusing to look.
+
+    This is exactly the scenario #65 exists for: a moved target, an attrs block that must stay
+    immediately after `)` for pandoc to honour it, and a `repair` that must do both at once.
     """
     from darnlink.frontmatter_index import build_index
     from darnlink.repair import plan_repairs, apply_repairs
@@ -324,39 +332,43 @@ def test_an_attribute_block_before_the_anchor_is_not_a_robust_link(tmp_path):
     original = f'![](old/B.md){{width="1.1in"}} <!-- uuid: {EXISTING} -->\n'
     _w(tmp_path / "A.md", original)
 
-    assert find_robust_links(original) == []
+    links = find_robust_links(original)
+    assert len(links) == 1 and links[0].attrs == '{width="1.1in"}', links
 
     apply_repairs(plan_repairs(tmp_path, build_index(tmp_path)))
 
-    assert (tmp_path / "A.md").read_text() == original
+    a = (tmp_path / "A.md").read_text()
+    assert a == f'![](new/B.md){{width="1.1in"}} <!-- uuid: {EXISTING} -->\n', f"bad rewrite: {a!r}"
 
 
 def test_absorbing_a_stray_anchor_does_not_eat_an_attribute_block(tmp_path):
     """The one place `robustify` DELETES text, guarded where the two features meet.
 
+    `![](B.md){.cls} <!-- uuid: X -->` is itself a robust link since #65 (sibling test above), so it
+    can no longer drive this test: `find_plain_links` now skips PAST the `{.cls}` before checking
+    for a trailing anchor, sees one, and treats the link as already robust — nothing is plain, the
+    absorb path never runs, and the fixture would silently stop testing anything.
+
+    What still reaches the absorb path with an attrs block in front of it is a link whose trailing
+    anchor is detached by something ELSE besides the attrs — prose between the attrs and the comment
+    is enough, since `_TRAILING_UUID_RE` demands the comment immediately (only whitespace) after
+    whatever `_skip_attrs` walked past.
+
     When a link is followed by a stray uuid comment, robustify absorbs it: it removes the stray and
-    re-emits the link anchored. Removing means walking back over the whitespace before the comment
-    — and a boundary that also walks over `}` eats the closing brace of an attribute block, leaving
-    `![](B.md) <!-- uuid: X -->{.cls` : the block silently becomes prose.
-
-    Attribute-block tests exist and detached-anchor tests exist; **no fixture combined them**, so
-    the deletion boundary had no guard at all.
-
-    Asserts the whole line, and the reason is not style. The first version of this test used
-    `"{.cls}" in a` plus an anchor count, and **three** distinct corruptions of this exact splice
-    walked through it: an end offset one too high (eats the final newline — a document character in
-    any line with prose after the anchor), one too low (leaves a literal `>` in the document), and a
-    boundary that does not walk back at all (leaves a trailing space). The sibling repair test was
-    rewritten in the very commit that added this one, for exactly this reason; writing the weak form
-    here reintroduced the defect one test below its own fix.
+    re-emits the link anchored (attrs included, right after `)`, per FR-065). Removing means walking
+    back over the whitespace before the comment — and a boundary that also walks over `}` eats the
+    closing brace of the attribute block, leaving `…{.cls` : the block silently becomes prose. That
+    is the corruption this test exists to catch; asserting the whole line is what catches it (a
+    boundary one character short leaves a trailing space, one character long eats a real character —
+    `"{.cls}" in a` alone would miss both).
     """
     _w(tmp_path / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
-    _w(tmp_path / "A.md", f"![](B.md){{.cls}} <!-- uuid: {EXISTING} -->\n")
+    _w(tmp_path / "A.md", f"![](B.md){{.cls}} **stuff** <!-- uuid: {EXISTING} -->\n")
 
     apply_robustify(plan_robustify(tmp_path))
 
     a = (tmp_path / "A.md").read_text()
-    assert a == f"![](B.md) <!-- uuid: {EXISTING} -->{{.cls}}\n", f"bad rewrite: {a!r}"
+    assert a == f"![](B.md){{.cls}} <!-- uuid: {EXISTING} --> **stuff**\n", f"bad rewrite: {a!r}"
 
 
 def test_absorbing_a_stray_does_not_eat_a_closing_paren_of_prose(tmp_path):
@@ -396,3 +408,44 @@ def test_repair_finds_a_robust_link_whose_destination_has_parens(tmp_path):
 
     a = (tmp_path / "A.md").read_text()
     assert "new/a(b).md" in a, f"repair did not see the parenthesised robust link: {a!r}"
+
+
+def test_65_the_reported_example_anchors_with_attrs_in_place(tmp_path):
+    """The exact reproduction from #65, run through `--write` end to end.
+
+    `![](B.md){width="1.1in" height="2in"}` anchored by `robustify` used to become
+    `![](B.md) <!-- uuid: … -->{width="1.1in" height="2in"}` — the comment landing BETWEEN the link
+    and its attributes, which pandoc requires immediately after `)`. The block still renders (as
+    plain text, ignored), so the corruption is silent: nothing about the finding, the exit code, or
+    a diff review flags it. This is the case that motivated the fix; the other tests in this file
+    guard the mechanism, this one guards the actual bug report.
+    """
+    _w(tmp_path / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
+    _w(tmp_path / "A.md", '![](B.md){width="1.1in" height="2in"}\n')
+
+    apply_robustify(plan_robustify(tmp_path))
+
+    a = (tmp_path / "A.md").read_text()
+    assert a == f'![](B.md){{width="1.1in" height="2in"}} <!-- uuid: {EXISTING} -->\n', f"bad rewrite: {a!r}"
+
+
+def test_65_a_second_pass_over_an_attrs_anchored_link_is_a_no_op(tmp_path):
+    """The regression `_TRAILING_UUID_RE`'s own docstring warned about: seen, not just claimed.
+
+    `find_plain_links` must skip PAST an attrs block before checking for a trailing anchor comment,
+    or a link this same tool just anchored reads as plain again next run and gets a SECOND `<!-- uuid
+    -->` appended — the uuid twice in one file, one copy anchoring nothing, and the tree still
+    reports clean because the link is (trivially) robust either way. Two full passes, not one: a
+    fixture that starts already-anchored would not catch a version of this bug that only manifests
+    on the SECOND write.
+    """
+    _w(tmp_path / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
+    _w(tmp_path / "A.md", '![](B.md){.cls}\n')
+
+    apply_robustify(plan_robustify(tmp_path))
+    once = (tmp_path / "A.md").read_text()
+    apply_robustify(plan_robustify(tmp_path))
+    twice = (tmp_path / "A.md").read_text()
+
+    assert once == twice, f"not idempotent: {once!r} -> {twice!r}"
+    assert twice.count(EXISTING) == 1, f"uuid duplicated: {twice!r}"


### PR DESCRIPTION
Fixes #65. Part of the darnlink v0.24.0 block (D1-D7).

`![](B.md){width="1.1in"}` anchored by `--write` used to become
`![](B.md) <!-- uuid: ... -->{width="1.1in"}` — the comment landing between the link and the
attribute block pandoc requires immediately after `)`. The block still renders, silently ignored.

Reproduced first (exactly the issue's example), then fixed at 5 sites — every consumer of the link
grammar, enumerated before touching any of them:

- `ROBUST_LINK_RE` — optional `attrs` group
- `RobustLink` — carries `attrs`
- `find_plain_links` / `find_detached_anchors` — skip past an attrs block before checking for a
  trailing anchor (otherwise an anchored link reads as plain again on the NEXT run and gets a
  second anchor)
- `emit_robust_link` — attrs go right after `)`, no space
- `robustify.py` write site + `repair.py` — both write paths now round-trip attrs

Two existing tests asserted the old (buggy) shape as correct; rewritten to assert the fix, keeping
the historical reasoning for why the old restriction existed.

**407 tests pass** (were 405; +2 net, 2 rewritten). darnlang clean, repair/robustify/dangling gates
clean on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)