### PR TITLE
D1c: a freshly-minted dry-run uuid is no longer printed as if it were final (#41)

### DIFF
--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -498,6 +498,17 @@ def plan_robustify(
                     why.append("it sits before the link, where the grammar could never have put it")
                 leftover[i] = (remaining, " / ".join(why))
 
+        # FR-041: a uuid this run MINTS (target had no frontmatter uuid yet) is a draft -- new_uuid()
+        # is called again on the next run and gives a DIFFERENT value, discarded unless --write also
+        # runs. Printing it looked identical to printing a REUSED existing uuid (stable across runs),
+        # and the shape `+uuid <value>` reads as an instruction to copy. A hand-copied draft becomes
+        # an orphan anchor: a link claiming a uuid no file declares, which does not self-heal (the
+        # whole point of a robust link) and does not get flagged either, because the gate cannot
+        # tell a good anchor from this one at a glance. Reused uuids are unaffected: `target_uuid[t]`
+        # for a target NOT in `needs_uuid_write` is the value read from that file's OWN frontmatter,
+        # true on every run and safe to show and copy.
+        created_uuids = {target_uuid[t] for t in needs_uuid_write}
+
         edits: List[Tuple[int, int, str]] = []  # (start, end, replacement), disjoint by construction
         for i, (link, u) in enumerate(anchorable):
             # FR-065: a pandoc attribute block immediately after `)` must stay immediately after
@@ -506,7 +517,8 @@ def plan_robustify(
             # puts it back before the anchor comment rather than after.
             attrs = pandoc_attrs_at(original, link.end)
             edits.append((link.start, link.end + len(attrs), emit_robust_link(link.text, link.href, u, attrs)))
-            detail = f"{link.href} +uuid {u}"
+            shown_uuid = "<will be generated on write>" if u in created_uuids else u
+            detail = f"{link.href} +uuid {shown_uuid}"
             stray = absorb.get(i)
             if stray is not None:
                 edits.append((_hspace_start(original, stray.start), stray.end, ""))

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -32,6 +32,10 @@ from .paths import (DIR_ANCHOR, is_absolute_local_path, is_local_relative, names
 from .report import Finding, Kind
 from .scope import in_scope
 
+# FR-041: shown instead of a uuid this run only MINTED (never written unless --write follows), so a
+# reader of the dry-run report never mistakes a draft for a stable value worth copying by hand.
+_DRAFT_UUID_PLACEHOLDER = "<will be generated on write>"
+
 
 @dataclass
 class RobustifyResult:
@@ -507,7 +511,14 @@ def plan_robustify(
         # tell a good anchor from this one at a glance. Reused uuids are unaffected: `target_uuid[t]`
         # for a target NOT in `needs_uuid_write` is the value read from that file's OWN frontmatter,
         # true on every run and safe to show and copy.
-        created_uuids = {target_uuid[t] for t in needs_uuid_write}
+        #
+        # `planned_readmes` (feature 012, --create-readme) is a SECOND source of freshly-minted
+        # uuids, minted above at the "plan a README.md" step and never added to `needs_uuid_write`
+        # (that set is populated only inside `decide()`, which a not-yet-created README never goes
+        # through). Without it here, a link anchored to a README this same run is about to create
+        # would print that draft uuid as if final -- the exact #41 bug, just reached by a second
+        # path instead of `decide()`.
+        created_uuids = {target_uuid[t] for t in needs_uuid_write} | {target_uuid[t] for t in planned_readmes}
 
         edits: List[Tuple[int, int, str]] = []  # (start, end, replacement), disjoint by construction
         for i, (link, u) in enumerate(anchorable):
@@ -517,7 +528,7 @@ def plan_robustify(
             # puts it back before the anchor comment rather than after.
             attrs = pandoc_attrs_at(original, link.end)
             edits.append((link.start, link.end + len(attrs), emit_robust_link(link.text, link.href, u, attrs)))
-            shown_uuid = "<will be generated on write>" if u in created_uuids else u
+            shown_uuid = _DRAFT_UUID_PLACEHOLDER if u in created_uuids else u
             detail = f"{link.href} +uuid {shown_uuid}"
             stray = absorb.get(i)
             if stray is not None:
@@ -549,11 +560,18 @@ def plan_robustify(
 
     # Feature 012: schedule the created READMEs and name each one (in the dry-run report too, so the
     # caller sees the file that will be born before --write does it).
+    #
+    # FR-041: every entry here is, by construction, a uuid `new_uuid()` just minted above (a README
+    # this run is *proposing* to create has no prior frontmatter to reuse a uuid from) -- so it is
+    # exactly the same kind of draft the ROBUSTIFY placeholder above exists to protect: unwritten
+    # until --write runs, and a different value on the next dry-run pass. No `created_uuids`
+    # membership check is needed here (unlike the ROBUSTIFY finding, which mixes reused and
+    # freshly-minted targets): everything in `created_readmes` is freshly minted, always.
     for readme in sorted(created_readmes):
         result.new_content[readme] = created_readmes[readme]
         result.findings.append(Finding(
             Kind.CREATE_README, readme,
-            f"created {DIR_ANCHOR} with uuid {target_uuid[readme]} to anchor a directory link"))
+            f"will create {DIR_ANCHOR} with uuid {_DRAFT_UUID_PLACEHOLDER} to anchor a directory link"))
 
     # FR-006: name every uuid write that lands OUTSIDE the write scope — in the dry-run report too,
     # so the caller sees it before it happens and can refuse it with --no-target-writes.

--- a/tests/test_create_readme.py
+++ b/tests/test_create_readme.py
@@ -42,6 +42,39 @@ def test_create_readme_anchors_a_folder_without_one(tmp_path):
     assert any(f.kind is Kind.CREATE_README for f in result.findings)
 
 
+def test_41_create_readme_uuid_is_not_printed_as_if_final_either(tmp_path):
+    """#41's fix (robustify.py) guards `needs_uuid_write`, populated only inside `decide()`. A
+    README this run is about to CREATE (feature 012) mints its uuid in a separate pre-pass (before
+    `decide()` runs at all) and was never added to that set -- so both findings that mention it, the
+    ROBUSTIFY finding for the link and the CREATE_README finding for the README itself, kept
+    printing the raw, freshly-minted (and therefore unstable-across-dry-run-passes) uuid exactly
+    like the original #41 bug, just reached through a second code path instead of `decide()`.
+
+    Three dry-run passes, none applied: both finding texts must be identical and carry the
+    placeholder every time, not merely "different each time".
+    """
+    (tmp_path / "hub").mkdir()
+    _w(tmp_path / "A.md", "[hub](hub/)\n")
+
+    robustify_details = []
+    create_readme_details = []
+    for _ in range(3):
+        result = plan_robustify(tmp_path, create_readme=True)
+        upgrades = [f for f in result.findings if f.kind is Kind.ROBUSTIFY]
+        creates = [f for f in result.findings if f.kind is Kind.CREATE_README]
+        assert len(upgrades) == 1, upgrades
+        assert len(creates) == 1, creates
+        robustify_details.append(upgrades[0].detail)
+        create_readme_details.append(creates[0].detail)
+
+    assert len(set(robustify_details)) == 1, f"not stable across dry-run passes: {robustify_details!r}"
+    assert len(set(create_readme_details)) == 1, f"not stable across dry-run passes: {create_readme_details!r}"
+    assert "+uuid <will be generated on write>" in robustify_details[0], robustify_details[0]
+    assert "<will be generated on write>" in create_readme_details[0], create_readme_details[0]
+    # Nothing on disk was touched by any of the three passes above.
+    assert not (tmp_path / "hub" / "README.md").exists()
+
+
 def test_create_readme_is_dry_run_by_default(tmp_path):
     (tmp_path / "hub").mkdir()
     _w(tmp_path / "A.md", "[hub](hub/)\n")

--- a/tests/test_robustify.py
+++ b/tests/test_robustify.py
@@ -496,3 +496,63 @@ def test_65_a_second_pass_over_an_attrs_anchored_link_is_a_no_op(tmp_path):
 
     assert once == twice, f"not idempotent: {once!r} -> {twice!r}"
     assert twice.count(EXISTING) == 1, f"uuid duplicated: {twice!r}"
+
+
+def test_41_a_freshly_minted_uuid_is_not_printed_as_if_final(tmp_path):
+    """#41: a dry-run's `+uuid X` for a target with NO existing uuid mints a fresh one on every
+    single call to `plan_robustify` — never written unless `apply_robustify` follows. Printing the
+    concrete value read as an instruction to copy, and copying it by hand creates an ORPHAN anchor:
+    a link claiming a uuid no file declares. It does not self-heal (the whole point of a robust
+    link) and the gate cannot tell it apart from a good anchor, so nothing ever flags it.
+
+    Three full plan passes, none applied: the printed text must be identical and non-numeric-looking
+    every time, not merely "different each time" (a test that only checked for CHANGE across passes
+    would not catch a version of this bug that mints once and then caches, which is still wrong for
+    the same reason -- the value shown is not what ends up on disk until --write actually runs).
+    """
+    _w(tmp_path / "B.md", "# B (no frontmatter)\n")
+    _w(tmp_path / "A.md", "[B](B.md)\n")
+
+    details = []
+    for _ in range(3):
+        result = plan_robustify(tmp_path, create_frontmatter=True)
+        upgrades = [f for f in result.findings if f.kind is Kind.ROBUSTIFY]
+        assert len(upgrades) == 1, upgrades
+        details.append(upgrades[0].detail)
+
+    assert len(set(details)) == 1, f"not stable across dry-run passes: {details!r}"
+    assert "+uuid <will be generated on write>" in details[0], details[0]
+    # Nothing on disk was touched by any of the three passes above.
+    assert (tmp_path / "B.md").read_text() == "# B (no frontmatter)\n"
+
+
+def test_41_a_reused_existing_uuid_is_still_printed_for_real(tmp_path):
+    """The other half of #41's fix: a target that ALREADY has a uuid is not affected. That value is
+    read from the target's own frontmatter, identical on every run whether or not `--write` follows
+    — showing it is accurate, not a promise the tool cannot keep, and hiding it would be a needless
+    regression for anyone reading the dry-run report to confirm which uuid a link will get.
+    """
+    _w(tmp_path / "B.md", f"---\nuuid: {EXISTING}\n---\n# B\n")
+    _w(tmp_path / "A.md", "[B](B.md)\n")
+
+    result = plan_robustify(tmp_path)
+    upgrades = [f for f in result.findings if f.kind is Kind.ROBUSTIFY]
+    assert len(upgrades) == 1
+    assert f"+uuid {EXISTING}" in upgrades[0].detail, upgrades[0].detail
+
+
+def test_41_write_still_anchors_with_the_real_minted_uuid(tmp_path):
+    """The placeholder is a REPORTING change only -- `--write` must still mint and persist a real
+    uuid, and the file and the link that anchors it must agree on which one.
+    """
+    from darnlink.frontmatter_edit import read_uuid_from_content
+
+    _w(tmp_path / "B.md", "# B (no frontmatter)\n")
+    _w(tmp_path / "A.md", "[B](B.md)\n")
+
+    apply_robustify(plan_robustify(tmp_path, create_frontmatter=True))
+
+    written = read_uuid_from_content((tmp_path / "B.md").read_text())
+    assert written is not None
+    a_link = find_robust_links((tmp_path / "A.md").read_text())[0]
+    assert a_link.uuid == written


### PR DESCRIPTION
Fixes #41. Part of the darnlink v0.24.0 block (D1-D7).

`new_uuid()` mints a genuinely random value every time `plan_robustify()` decides a target needs
one — called fresh on EVERY dry-run pass, discarded unless `apply_robustify()` actually follows. The
finding text `+uuid X` looked identical whether `X` was this draft or a real, stable uuid being
reused. Measured: three consecutive dry-run passes over the same fixture produced three different
uuids for the same target. Copying one by hand creates an orphan anchor — happened for real on
2026-08-09, cost half an hour and a wrong attribution.

Fix: `needs_uuid_write` (targets this run decided to mint a uuid for) already existed internally;
`created_uuids` is built from it and the shown value swaps to a placeholder when the finding's uuid
is one of them. Reused uuids are unaffected — shown as before, because showing them is accurate.
Text and `--json` output share `Finding.detail`, so one change covers both.

The concrete uuid that gets WRITTEN is untouched — only the report text changes. Verified with a
dedicated end-to-end test that `--write` still produces a file and a link that agree.

Three tests added: placeholder stability across repeated dry-run passes, reused uuids still shown
for real, and `--write` still correct end to end.

**412 tests pass** (were 409; +3). darnlang clean, repair/robustify/dangling gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)