### PR TITLE
D2: write_text_keep_newlines refuses a symlink path, verified rather than assumed

### DIFF
--- a/src/darnlink/frontmatter_edit.py
+++ b/src/darnlink/frontmatter_edit.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import re
 import uuid as _uuid
+from pathlib import Path
 from typing import Optional, Tuple
 
 # A leading YAML frontmatter block: ---\n <body> \n---\n <rest>
@@ -51,6 +52,23 @@ def write_text_keep_newlines(path, content: str) -> None:
     paths at once. The CI matrix exists for *"Windows-authored files (BOM, CRLF, path separators)"*
     and could not see it: its BOM fixtures only ever covered files that are **read**. #68.
     """
+    # #65/#85's invariant, checked here rather than assumed: every caller reaches this function with
+    # a path that came from `iter_markdown_files` (directly, or via `resolve_href`/`_anchor_target`
+    # resolving an href against a file that did) -- and `iter_markdown_files` yields
+    # `Path.resolve(strict=True)`, which dereferences every symlink component. Verified empirically
+    # (not just read): writing through a symlinked AGENTS.md -> CLAUDE.md pair, this function is only
+    # ever called with the CANONICAL path, never the alias -- `path.is_symlink()` is unreachably
+    # False today. Kept as a live assertion rather than silently trusted, because the failure mode if
+    # a FUTURE caller ever bypasses that resolution is not a crash but a silent write through an
+    # alias into a file darnlink was never told about -- exactly the class of bug #65/#85 exist to
+    # remove, just one layer deeper. Fail loud, here, once, rather than corrupt quietly wherever the
+    # unresolved path happened to point.
+    assert not Path(path).is_symlink(), (
+        f"refusing to write through a symlink: {path} -- resolve the path before calling "
+        "write_text_keep_newlines (see iter_markdown_files, which every existing caller goes "
+        "through); writing through an unresolved alias could silently touch a file this run "
+        "never scanned or reported on"
+    )
     with open(path, "w", encoding=_encoding_preserving_bom(path), newline="") as f:
         f.write(content)
 

--- a/tests/test_symlink_dedup.py
+++ b/tests/test_symlink_dedup.py
@@ -129,3 +129,66 @@ def test_every_cli_output_path_reports_it_not_just_the_human_one(tmp_path, capsy
         main(argv)
         out = capsys.readouterr().out
         assert "out_of_root" in out or "out-of-root" in out, f"silent path: darnlink {' '.join(argv)}"
+
+
+def test_write_never_touches_a_symlink_path_in_real_use(tmp_path):
+    """D2: the invariant that makes writing through a symlink safe, PROVEN by driving the actual
+    real-world layout end to end (AGENTS.md -> CLAUDE.md), not just read off the code.
+
+    Every path that reaches `write_text_keep_newlines` comes from `iter_markdown_files`, directly
+    or via an href resolved against a file that did -- and that function yields
+    `Path.resolve(strict=True)`, which dereferences every symlink. So a write driven through the
+    symlink NAME still lands on the canonical file, and never on the link itself.
+    """
+    import darnlink.robustify as rb  # the name as bound in THIS module -- patching
+    from darnlink.frontmatter_edit import write_text_keep_newlines as orig
+    from darnlink.robustify import apply_robustify, plan_robustify
+
+    # `darnlink.frontmatter_edit.write_text_keep_newlines` here would not work: `robustify.py`
+    # imported the function by name at module load, so it holds its own reference.
+
+    seen: list[tuple[str, bool]] = []
+
+    def spy(path, content):
+        seen.append((str(path), Path(path).is_symlink()))
+        return orig(path, content)
+
+    rb.write_text_keep_newlines = spy
+    try:
+        (tmp_path / "CLAUDE.md").write_text("# Instrucciones\n", encoding="utf-8")
+        (tmp_path / "AGENTS.md").symlink_to("CLAUDE.md")
+        (tmp_path / "A.md").write_text("[ver](AGENTS.md)\n", encoding="utf-8")
+
+        apply_robustify(plan_robustify(tmp_path, create_frontmatter=True))
+    finally:
+        rb.write_text_keep_newlines = orig
+
+    assert seen, "the spy never fired -- the fixture stopped exercising a write at all"
+    assert not any(is_link for _, is_link in seen), f"a symlink path reached the write site: {seen!r}"
+    # And the write really did go through: CLAUDE.md (the canonical file) carries the new uuid,
+    # readable through either name since they are the same inode.
+    assert "uuid:" in (tmp_path / "CLAUDE.md").read_text()
+    assert (tmp_path / "CLAUDE.md").read_text() == (tmp_path / "AGENTS.md").read_text()
+
+
+def test_write_text_keep_newlines_refuses_a_symlink_path_directly(tmp_path):
+    """The other half: prove the assertion actually FIRES, not just that real use never trips it.
+
+    No caller in this codebase can reach `write_text_keep_newlines` with a symlink path today (the
+    test above proves that for the one real layout this project cares about) -- so the only way to
+    exercise the guard itself is to call the function directly with one, bypassing
+    `iter_markdown_files` on purpose. That is exactly the scenario the guard exists for: some FUTURE
+    caller that bypasses the resolution `iter_markdown_files` normally guarantees.
+    """
+    import pytest
+
+    from darnlink.frontmatter_edit import write_text_keep_newlines
+
+    (tmp_path / "CLAUDE.md").write_text("# Instrucciones\n", encoding="utf-8")
+    (tmp_path / "AGENTS.md").symlink_to("CLAUDE.md")
+
+    with pytest.raises(AssertionError, match="refusing to write through a symlink"):
+        write_text_keep_newlines(tmp_path / "AGENTS.md", "new content\n")
+
+    # And the guard did its job: nothing was touched through either name.
+    assert (tmp_path / "CLAUDE.md").read_text() == "# Instrucciones\n"


### PR DESCRIPTION
Part of the darnlink v0.24.0 block (D2). Fixes/relates: #91 (filed, not fixed here — see below).

The block asked for a defensive `is_symlink()` check at the write site (PR #85's own risk note: the
indexer follows symlinks on purpose now, so a future symlink pattern could point somewhere writes
should not silently follow).

**Measured before writing anything**: every path that reaches `write_text_keep_newlines` comes from
`iter_markdown_files`, directly or via an href resolved against a file that did — and
`iter_markdown_files` yields `Path.resolve(strict=True)`, dereferencing every symlink component.
Drove the real `AGENTS.md -> CLAUDE.md` layout end to end with a spy on the write call: `is_symlink()`
is `False` on every single call today. A literal check-and-branch here would be provably unreachable.

Implemented as a **live assertion** instead — same protection, honest about nothing changing today.
Its value is for a future caller that bypasses `iter_markdown_files`'s resolution.

Two tests: one drives the real bridge scenario and asserts the guard stays silent (proves it for the
right reason); the other calls the function directly with a symlink path, bypassing the normal call
graph on purpose, and asserts the guard actually fires.

**Filed [darnlink#91](https://github.com/txemi/darnlink/issues/91)** for the hardlinks half of D2:
same symptom as #85 (uuid in multiple files), different mechanism (`Path.resolve()` doesn't collapse
hardlinks). Verified live with `os.link()`, not speculative — repro included in the issue. Scoped
separately on purpose: no known live case, and a fix needs its own review.

**411 tests pass** (were 409; +2). darnlang clean, repair/robustify/dangling gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)