### PR TITLE
test fixture: make the minimal-PATH recipe test work under uvx, and fail honestly when it cannot

### DIFF
--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -260,19 +260,27 @@ def test_unavailable_create_readme_axis_does_not_mask_a_failing_core(tmp_path):
     the pass can't run — but that must NOT turn an ALREADY-failing core gate (integrity/strict) green.
     We simulate python3-missing with a minimal PATH and assert the core strict failure (exit 3) survives."""
     needed = {}
-    # `realpath`/`dirname` are NOT decoration and NOT needed by the recipe: they are needed by the
-    # `darnlink` binary this test injects. Built by `uv run`, that binary is a Python-shebang script
-    # and needs neither; built by `uvx`, it is a /bin/sh wrapper whose first lines call both. Omit
-    # them and the wrapper dies with 127, the recipe takes its designed "can't run darnlink -> SKIP"
-    # path, and this test fails claiming the GATE returned 0 when in fact the FIXTURE never ran it.
-    # That matters here more than it would elsewhere: `uvx` is how the fleet actually consumes
-    # darnlink, so a fixture that only works under `uv run` is blind in the consumption mode that
-    # ships.
-    for t in ("bash", "git", "mktemp", "rm", "tr", "env", "realpath", "dirname"):
+    for t in ("bash", "git", "mktemp", "rm", "tr", "env"):
         p = shutil.which(t)
         if p is None:
             pytest.skip(f"need {t} for this test")
         needed[t] = p
+    # `realpath`/`dirname` are needed by neither the recipe nor this test: they are needed by the
+    # `darnlink` binary the test injects. Built by `uv run`, that binary is a Python-shebang script
+    # and needs neither; built by `uvx`, it is a /bin/sh wrapper whose first lines call both. Omit
+    # them and the wrapper dies with 127, the recipe takes its designed "can't run darnlink -> SKIP"
+    # path, and this test fails claiming the GATE returned 0 when the FIXTURE never ran it. That
+    # matters more here than it would elsewhere: `uvx` is how the tool is actually consumed, so a
+    # fixture that only works under `uv run` is blind in the mode that ships.
+    #
+    # BEST-EFFORT ON PURPOSE, unlike the six above: a host missing them can still run this test
+    # whenever its injected binary does not need them, so requiring them would trade a real failure
+    # for a silent skip -- and losing coverage quietly is the failure mode this whole file exists to
+    # prevent. If they are missing AND the binary needs them, the probe below says so out loud.
+    for t in ("realpath", "dirname"):
+        p = shutil.which(t)
+        if p is not None:
+            needed[t] = p
     dbin = _darnlink_bin()
 
     repo = tmp_path / "repo"

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -260,7 +260,15 @@ def test_unavailable_create_readme_axis_does_not_mask_a_failing_core(tmp_path):
     the pass can't run — but that must NOT turn an ALREADY-failing core gate (integrity/strict) green.
     We simulate python3-missing with a minimal PATH and assert the core strict failure (exit 3) survives."""
     needed = {}
-    for t in ("bash", "git", "mktemp", "rm", "tr", "env"):
+    # `realpath`/`dirname` are NOT decoration and NOT needed by the recipe: they are needed by the
+    # `darnlink` binary this test injects. Built by `uv run`, that binary is a Python-shebang script
+    # and needs neither; built by `uvx`, it is a /bin/sh wrapper whose first lines call both. Omit
+    # them and the wrapper dies with 127, the recipe takes its designed "can't run darnlink -> SKIP"
+    # path, and this test fails claiming the GATE returned 0 when in fact the FIXTURE never ran it.
+    # That matters here more than it would elsewhere: `uvx` is how the fleet actually consumes
+    # darnlink, so a fixture that only works under `uv run` is blind in the consumption mode that
+    # ships.
+    for t in ("bash", "git", "mktemp", "rm", "tr", "env", "realpath", "dirname"):
         p = shutil.which(t)
         if p is None:
             pytest.skip(f"need {t} for this test")
@@ -300,6 +308,16 @@ def test_unavailable_create_readme_axis_does_not_mask_a_failing_core(tmp_path):
     # sanity: python3 really is unreachable through this PATH
     assert subprocess.run([needed["bash"], "-c", "command -v python3"], env=env,
                           capture_output=True).returncode != 0
+    # sanity, the other half: the injected binary must still RUN through this PATH. The premise
+    # above was asserted from the start and this one was not, which is why an environment shift
+    # surfaced as "the gate returned 0" -- a claim about the product -- instead of "my fixture is
+    # broken". A test may narrow the world it runs in; it must not lie about which half gave way.
+    # `--help` and not `--version`: darnlink has no `--version`, and a probe that fails for its
+    # OWN reason would be the very confusion this assert exists to remove.
+    probe = subprocess.run([dbin, "--help"], env=env, capture_output=True, text=True)
+    assert probe.returncode == 0, (
+        f"the injected darnlink cannot run under this minimal PATH, so the gate below would be "
+        f"skipped rather than exercised:\n{probe.stderr}")
 
     r = subprocess.run([needed["bash"], str(RECIPE)], cwd=repo, env=env, capture_output=True, text=True)
     assert r.returncode == 3, (


### PR DESCRIPTION
## What

The recipe-gate test `test_unavailable_create_readme_axis_does_not_mask_a_failing_core` fails
under `uvx` and passes under `uv run`. Two commits: the fix, plus a follow-up that corrects a
defect in the fix itself.

## Root cause, measured

Under `uvx` the `darnlink` executable is **not a Python script** — it is a `/bin/sh` wrapper whose
first lines call `realpath` and `dirname`. The test builds a minimal PATH holding only
`bash git mktemp rm tr env`, so the wrapper dies with 127:

```
.../bin/darnlink: 2: realpath: not found
.../bin/darnlink: 2: dirname: not found
```

The recipe then takes its by-design "cannot run darnlink → SKIP" path and returns 0 instead of 3,
and the test fails asserting that **the gate** returned 0. Under `uv run` the same entry point has
a Python shebang and needs neither tool.

This is **not a product bug** — `uvx --from . darnlink .` exits 0 — but the fixture was blind in
exactly the mode this tool is consumed in downstream.

## What changed

1. `realpath` and `dirname` are added to the minimal PATH **best-effort**: present, they are
   included; absent, they are skipped. The first attempt put them in the same loop as `bash` and
   `git`, which is a SKIP loop — on a POSIX box without `realpath` that would have turned a
   passing test into a silent loss of coverage. The second commit fixes that.
2. The fixture now asserts **both** of its premises — that the injected binary still executes,
   alongside the pre-existing assertion that `python3` is unreachable. Without the first, an
   environment change surfaces as a claim about the *product* rather than about the *fixture*.
   A test may narrow the world it runs in; it may not lie about which half gave way.

## Verification

- 45 pass under `uvx` (1 failed before), 427 under `uv run`. No regressions.
- The module already skips entirely on Windows via its `pytestmark`, so nothing is lost there —
  checked before claiming it, not after.

## Review

Reviewed by an independent Claude subsession: **0 confirmed defects**. It reproduced the failure
on `main` itself and verified the mechanism by extracting the bytes of the wrapper, rather than
taking the explanation at face value.

## Checks that could not be reproduced locally

- **ps1-syntax** — `pwsh` is not installed on the machine this was written on. Low risk here: this
  branch touches no `.ps1` file.
- **privacy-gate** — its denylist is a secret and unreadable by design. The commit messages name
  no private repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)