### PR TITLE
017: let the read axis see the web links inside mermaid diagrams (opt-in, report-only)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/017-mermaid-web-links"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
+### Added
+
+- **Feature 017 — the read axis can see a diagram's `click` destinations** (`--include-mermaid`,
+  recipe key `include_mermaid`). **Off by default, per repository.** A `mermaid` diagram carries
+  its links in `click` directives, which live inside a fenced block: feature 002 hides them from
+  every axis, including the read-only ones, so they die silently when a file moves and no gate ever
+  notices. Measured on a real tree, one folder reorganisation killed 14 of a diagram's destinations
+  at once while everything stayed green.
+
+  - **The write operations are unchanged.** FR-015 is not amended: repair and robustify still
+    ignore every link inside every fence. This is the read axis only.
+  - **These links are never anchored** — they are report-only. The anchor is a trailing HTML
+    comment, and a diagram treats that as a node rather than a comment, so writing one would
+    corrupt the drawing. A diagram destination that stays plain forever is a normal state.
+  - **No new dependency.** The destination grammar was measured over 2,165 real directives and
+    reduces to three single-line shapes, so it is recognised by a pure textual function; the
+    fenced-region computation is reused rather than reimplemented.
+
 ## [0.24.0] — 2026-08-17
 
 > ### ⚠️ Two consumer-visible changes; both informational, neither moves the exit code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,7 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
-shell commands, and other important information, read the current plan
+shell commands, and other important information, read the current plan:
+`specs/017-mermaid-web-links/plan.md`
 <!-- SPECKIT END -->
 
 ## Language: English only

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -68,6 +68,24 @@ is that orchestration in one place; a consumer carries only a tiny config + a 3-
   | `own_web_from_origin` | bool | also count this repo's `origin` owner. A **separate key, not a sentinel** in the list, so an owner literally called `origin` stays expressible |
   | `own_web_max` | int | a budget, so the rung is adoptable before the repo reaches zero. **Non-numeric counts as ABSENT, never as infinite** — widening an allowance is the one direction a config typo must not be able to go |
 
+- `include_mermaid` (opt-in, **needs `web`**) → feature 017. A `mermaid` diagram carries its
+  destinations in `click` directives, which sit inside a fenced block and are therefore invisible to
+  every axis. With this key the **read** axis sees them; the write operations still never look
+  inside a fence.
+
+  | key | Value | Meaning |
+  |---|---|---|
+  | `include_mermaid` | bool | watch the destinations a diagram's `click` directives carry |
+
+  **Absent means off, per repository** — on purpose. Measured across a fleet, switching this on
+  exposed 33 own-repository destinations in one repo (all valid, so it goes green on day one) and
+  over two thousand third-party ones in others, which cannot be fixed from where they are reported.
+  A fail-closed gate that switches itself on everywhere is how every push breaks at once.
+
+  ⚠️ These links are **report-only and never anchored**, so a diagram destination that stays plain
+  forever is a normal state, not a defect: the anchor is an HTML comment and a diagram renders it as
+  a node rather than treating it as a comment.
+
   A misconfiguration (a budget with no owners, an empty owner name, `own_web_from_origin` in a tree
   with no GitHub `origin`) exits `1`, and the recipe reports it as **likely-config** rather than as a
   verdict about the repository — but **only when this run actually passed an `own_*` flag**, because

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -203,6 +203,10 @@ case "${WEB,,}" in ""|0|false|no|off) WEB="" ;; *) WEB=1 ;; esac
 mapfile -t OWN_WEB < <(read_cfg own_web "")
 OWN_WEB_N="$(read_cfg_len own_web)"; [[ "$OWN_WEB_N" =~ ^[0-9]+$ ]] || OWN_WEB_N=0
 OWN_WEB_FROM_ORIGIN="${DARNLINK_GATE_OWN_WEB_FROM_ORIGIN:-$(read_cfg own_web_from_origin "")}"
+# Feature 017 (opt-in, needs `web`): also watch the destinations a mermaid diagram carries in
+# its `click` directives. ABSENT MEANS OFF, per repository: a fleet of fail-closed gates has to
+# be able to switch this on one repo at a time. These links are report-only and never anchored.
+INCLUDE_MERMAID="${DARNLINK_GATE_INCLUDE_MERMAID:-$(read_cfg include_mermaid "")}"
 case "${OWN_WEB_FROM_ORIGIN,,}" in ""|0|false|no|off) OWN_WEB_FROM_ORIGIN="" ;; *) OWN_WEB_FROM_ORIGIN=1 ;; esac
 # A budget, so the rung is adoptable before a repo reaches zero. Non-numeric counts as ABSENT, never as
 # infinite: silently WIDENING an allowance is the one direction a config typo must not be able to go —
@@ -457,6 +461,7 @@ if [ "$SCOPE" != "staged" ]; then
       for o in "${OWN_WEB[@]}"; do
         [ -n "$o" ] && { WEB_ARGS+=(--own "$o"); OWN_PASSED=1; OWN_WEB_USED=$((OWN_WEB_USED + 1)); }
       done
+      [ -n "$INCLUDE_MERMAID" ] && WEB_ARGS+=(--include-mermaid)
       [ -n "$OWN_WEB_FROM_ORIGIN" ] && { WEB_ARGS+=(--own-from-origin); OWN_PASSED=1; }
       [ -n "$OWN_WEB_MAX" ]         && { WEB_ARGS+=(--own-max "$OWN_WEB_MAX"); OWN_PASSED=1; }
       # An owner entry that is present but empty is a typo, and a silent one: the axis would run with

--- a/recipes/darnlink-gate.ps1
+++ b/recipes/darnlink-gate.ps1
@@ -74,6 +74,12 @@ $ownWeb = @(if ($cfg -and $cfg.PSObject.Properties.Name -contains 'own_web') { $
 $rawOWFO = if ($null -ne $env:DARNLINK_GATE_OWN_WEB_FROM_ORIGIN) { $env:DARNLINK_GATE_OWN_WEB_FROM_ORIGIN } else { CfgOr 'own_web_from_origin' '' }
 $ownWebFromOrigin = -not ([string]::IsNullOrWhiteSpace([string]$rawOWFO) -or
                           ([string]$rawOWFO).Trim().ToLower() -in @('0','false','no','off'))
+
+# Feature 017 (opt-in, needs `web`): also watch the destinations a mermaid diagram carries in its
+# `click` directives. ABSENT MEANS OFF, per repository. Report-only: never anchored.
+$rawIM = if ($null -ne $env:DARNLINK_GATE_INCLUDE_MERMAID) { $env:DARNLINK_GATE_INCLUDE_MERMAID } else { CfgOr 'include_mermaid' '' }
+$includeMermaid = -not ([string]::IsNullOrWhiteSpace([string]$rawIM) -or
+                        ([string]$rawIM).Trim().ToLower() -in @('0','false','no','off'))
 # A budget, so the rung is adoptable before a repo reaches zero. Non-numeric counts as ABSENT, never as
 # infinite: silently WIDENING an allowance is the one direction a config typo must not be able to go.
 # NOT CfgOr here: it tests truthiness, and PowerShell reads the JSON `0` as [int]0, which is $false —
@@ -178,6 +184,7 @@ if ($scope -ne 'staged') {
       $ownPassed = $false
       $ownWebUsed = 0
       foreach ($o in $ownWeb) { if ($o) { $webArgs += @('--own', $o); $ownPassed = $true; $ownWebUsed++ } }
+      if ($includeMermaid)                 { $webArgs += '--include-mermaid' }
       if ($ownWebFromOrigin)               { $webArgs += '--own-from-origin'; $ownPassed = $true }
       if (-not [string]::IsNullOrEmpty($ownWebMax)) { $webArgs += @('--own-max', $ownWebMax); $ownPassed = $true }
       # Same two warnings as the bash recipe, same wording: an owner entry that is present but empty

--- a/specs/017-mermaid-web-links/checklists/requirements.md
+++ b/specs/017-mermaid-web-links/checklists/requirements.md
@@ -1,0 +1,51 @@
+# Specification Quality Checklist: see web links inside `mermaid` diagrams (read axis only, opt-in)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-23
+**Feature**: `spec.md`, one level up. Deliberately not a Markdown link: no spec in this
+repository carries frontmatter, so a link here would make the gate want to invent a `uuid` for one.
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+Two items were tightened during validation rather than passed as written:
+
+1. **"No implementation details"** — the first draft named the specific source files and the
+   function that computes fenced regions. File and function names are *how*, not *what*. They were
+   replaced by the capability ("the existing fenced-region computation, FR-016") in the
+   requirements. The one place where a concrete map survives is *The gap, precisely*, which is
+   background rather than a requirement — it is what makes the read/write split legible, and
+   feature 002's own spec sets that precedent.
+
+2. **"Success criteria are measurable"** — SC-019 originally read "dangling destinations inside
+   diagrams are reported". That is not measurable on a healthy tree: a tree with nothing broken
+   produces zero findings whether the check works or is blind. It was rewritten to require
+   **seeding a defect and observing it caught**, which is the only form that distinguishes *dry*
+   from *blind*.
+
+Numbering continues the repository-wide sequences rather than restarting: FR-052..FR-059 and
+SC-018..SC-022 (previous maxima FR-051 and SC-017).

--- a/specs/017-mermaid-web-links/contracts/cli.md
+++ b/specs/017-mermaid-web-links/contracts/cli.md
@@ -1,0 +1,74 @@
+# Phase 1 — Interface contract
+
+This is a CLI library. Its contract is the command surface: what a user can ask for, what comes
+back, and what the exit code means. Nothing here is a new subcommand — the feature is one switch on
+an axis that already exists.
+
+---
+
+## 1. The switch
+
+A single opt-in flag on the **read** axis, default **off**.
+
+| | |
+|---|---|
+| **Where it applies** | the web-check command, in **both** of its paths — the online check and the offline listing |
+| **Where it does NOT apply** | the core command (repair / robustify). Offering it there would imply the write axis can honour it; it cannot, and must not |
+| **Default** | off. With the flag absent, output is byte-identical to the current release (SC-018) |
+| **Combining** | composes with the existing owner flags and ignore-block markers exactly as ordinary web links do; it changes *which links exist*, not how they are judged |
+
+**Naming principle**: the flag says *what becomes visible*, not *how it is parsed*. A user
+switching it on is choosing to watch their diagrams, not choosing a parsing strategy.
+
+### The recipe layer
+
+The gate recipe published with this project reads a JSON configuration whose keys map onto these
+flags (`web`, `own_web_from_origin`, and friends). This feature adds **one key**, defaulting to
+absent-means-off, mapping to the flag above. A repository that does not add the key is unaffected —
+which is the point: rolling this out across a fleet is opt-in **per repository**, one line at a
+time (FR-052, SC-022).
+
+---
+
+## 2. What comes back
+
+A recognised diagram destination is reported **exactly like any other web link**: same finding
+kinds, same message shapes, same JSON fields. There is no diagram-specific finding kind, because
+inventing one would force every consumer of the report to learn a new case for no benefit
+(research R3).
+
+**The one visible difference** is what *cannot* happen to it:
+
+| Finding kind | Ordinary web link | Diagram destination |
+|---|---|---|
+| reported as ok / not-found / mismatch / unverifiable | yes | **yes, identical** |
+| judged by the own-repository strictness rule | yes | **yes, identical** |
+| **anchored** (rewritten with a trailing anchor comment) | yes, under the writing mode | **never** (FR-060) |
+
+Under the writing mode, an ordinary plain link that could be anchored is anchored; a diagram
+destination in the same file is reported and **left alone**. The report must make that legible
+rather than silently dropping it — a destination that is watched but never rewritten is a normal,
+permanent state here, not a failure.
+
+---
+
+## 3. Exit codes
+
+**Unchanged.** This feature adds no exit code and redefines none. A diagram destination
+contributes to the existing codes exactly as the equivalent prose link would.
+
+The consequence is deliberate and worth stating plainly: in a repository that opts in **and**
+enables the own-repository strictness rule, a dead destination inside a diagram will **fail the
+gate**. That is the entire purpose — it is the failure that does not happen today.
+
+---
+
+## 4. Compatibility
+
+| Question | Answer |
+|---|---|
+| Does an existing invocation change? | No. Without the new flag, nothing changes anywhere |
+| Does an existing configuration change? | No. The new key is absent-means-off |
+| Does the written format change? | No. Nothing new is ever written; the anchor format is untouched |
+| Does the report schema change? | No new kinds and no removed fields |
+| Can a repository be broken by upgrading? | No. Breaking requires an explicit opt-in, and the measurement says the first repository to opt in goes green on day one |

--- a/specs/017-mermaid-web-links/data-model.md
+++ b/specs/017-mermaid-web-links/data-model.md
@@ -1,0 +1,79 @@
+# Phase 1 — Data model
+
+This feature introduces **no persisted data** and no new user-facing entity. It adds two concepts
+that live for the duration of a single scan.
+
+---
+
+## 1. Mermaid region
+
+**What it is**: a fenced region whose info string names `mermaid`.
+
+**Where it comes from**: the existing fenced-region computation (FR-016), filtered by info string.
+It is **derived, never computed independently** (FR-054).
+
+| Rule | Source |
+|---|---|
+| Opened by 3+ backticks or 3+ tildes, indented at most 3 | inherited, FR-016 |
+| Closed by the same fence character, length ≥ the opener | inherited, FR-016 |
+| An unclosed fence extends to end of file | inherited, FR-016 |
+| Backticks and tildes do not close each other | inherited, FR-016 |
+| A fence nested inside a longer fence is never scanned | inherited, FR-016 |
+| Its info string, lowercased, names `mermaid` | **new, this feature** |
+
+**Invariant**: every mermaid region is also a code region. The set of mermaid regions is a
+**subset** of what the write axis ignores — so nothing this feature recognises can ever be
+something the write axis was allowed to touch.
+
+**Where the info string ends**: the first line break after the opening fence. Everything after
+that line and before the closing fence is the region's body; only the body is scanned.
+
+---
+
+## 2. Mermaid destination
+
+**What it is**: a destination recognised from a `click` directive inside a mermaid region's body.
+
+**Shape**: identical to an ordinary web link, so that classification, reporting, exit codes and
+feature 016's own-repository strictness apply with **no special case** (research R3).
+
+| Attribute | Value | Note |
+|---|---|---|
+| destination | the quoted string from the directive | the only field the directive really carries |
+| position | absolute offset in the file | used for ordering and for reporting the location |
+| display text | none | a directive has no link text; reporting must not assume one |
+| existing anchor | never | a diagram cannot carry the anchor comment (R4) |
+| **report-only** | **always true** | **enforced where edits are produced, not where they are requested** |
+
+### Recognition rules
+
+| Rule | Requirement |
+|---|---|
+| Recognised only inside a mermaid region body | FR-055 |
+| `click <id> "<dest>" [trailing]` yields `<dest>` | FR-055 |
+| `click <id> href "<dest>" [trailing]` yields `<dest>` | FR-055 |
+| A trailing target or tooltip does not affect recognition | FR-055 |
+| A line whose first non-blank characters are `%%` yields nothing | FR-056 |
+| A directive binding a callback rather than a destination yields nothing | FR-057 |
+| Recognition is pure and textual — no network, no fuzziness | FR-058 |
+
+### The rule that is not a rule about recognition
+
+**Report-only is a property of the item, not of the caller** (FR-060). Modelling it as a flag the
+caller passes would mean any future caller can forget it, and the failure mode of forgetting is
+*writing an HTML comment into a diagram* — silent corruption of the exact kind feature 002 exists
+to prevent. It is enforced at the point where an edit would be produced, so a caller that does not
+know about diagrams still cannot corrupt one.
+
+---
+
+## 3. Configuration
+
+| Concept | Default | Scope |
+|---|---|---|
+| "see destinations inside diagrams" | **off** | per repository, alongside the other axis switches |
+
+**No new storage.** It joins the existing configuration surface; nothing is written anywhere new.
+
+**State transitions**: none. The setting is read once per invocation; there is no lifecycle, no
+migration, and no persisted state to upgrade.

--- a/specs/017-mermaid-web-links/plan.md
+++ b/specs/017-mermaid-web-links/plan.md
@@ -1,0 +1,118 @@
+# Implementation Plan: see web links inside `mermaid` diagrams (read axis only, opt-in)
+
+**Branch**: `017-mermaid-web-links` | **Date**: 2026-08-23 | **Spec**: `spec.md`, same directory
+
+**Input**: Feature specification from `specs/017-mermaid-web-links/spec.md`
+
+## Summary
+
+Let the **read** axes see the destinations carried by a diagram's `click` directives, which today
+are invisible because they sit inside a fenced region (feature 002). The region computation is
+**reused, not re-implemented**; the destination is recognised by a pure textual function over three
+measured one-line shapes; recognised items enter the existing web axis in its existing shape, so
+classification, exit codes and feature 016's own-repository strictness apply with no special case.
+The feature is **off by default**, per repository, and its items are **report-only** — they can
+never be anchored, because the anchor is an HTML comment and a diagram would render it as content.
+
+## Technical Context
+
+**Language/Version**: Python 3.13+ (floor declared 3.10 in packaging metadata)
+
+**Primary Dependencies**: **none added.** Runtime stays `python-frontmatter` only, per the
+constitution's *Technical Constraints*. See `research.md` R1 for the three alternatives measured
+and rejected.
+
+**Storage**: N/A — the tool holds no state; the only persistence is the Markdown tree itself.
+
+**Testing**: `pytest` (427 tests green on this branch before any change). New tests live beside
+their siblings in `tests/`, following the existing one-file-per-feature-area convention
+(`test_weblinks.py`, `test_own_repo_web_strictness.py`, `test_links.py`).
+
+**Target Platform**: any OS with Python; consumed as a CLI (`uvx`/`pipx`), a **pre-commit hook**
+and a **GitHub Action**. This is why a JavaScript runtime is not an option (research R1).
+
+**Project Type**: single-project CLI library.
+
+**Performance Goals**: no measurable regression when the feature is **off** — the added work must
+be skipped entirely, not computed and discarded. When **on**, recognition is linear in the size of
+the mermaid regions only, which are a small fraction of a tree.
+
+**Constraints**:
+- **No network added.** The single sanctioned network path (`web-check --online`) is untouched;
+  this feature only changes *which links reach it*.
+- **Byte-identical behaviour when disabled** (SC-018) — this is what makes the feature safe to ship
+  into fail-closed gates.
+- **Never writes inside a fenced region** (FR-060/SC-023), including the axis that *can* write.
+
+**Scale/Scope**: measured across 26 repositories — 182 mermaid regions in 120 files, carrying 2,165
+destinations. The largest single repository contributes 1,961 of them, all third-party, and does
+not have the web axis enabled.
+
+## Constitution Check
+
+*GATE: must pass before Phase 0. Re-checked after Phase 1 — see below.*
+
+| Principle | Verdict | Why |
+|---|---|---|
+| **I. Single responsibility — links & uuids only** | ✅ | Narrows *where* an existing axis looks. No new operation, no document semantics, no entity model. The two core operations remain exactly two |
+| **II. Safe by default — dry-run first** | ✅ | Off by default; opt-in per repository; report-only items that cannot be written even in the writing mode |
+| **III. Plain, self-contained, tool-agnostic** | ✅ | No format change. Nothing is written into a diagram, so a repository with diagrams stays exactly as usable without the tool as it is today |
+| **IV. Deterministic — no heuristics, no AI** | ✅ | Pure textual recognition over a region produced by the existing pure function. No new network path; the `--online` carve-out is unchanged |
+| **V. Test-first & acceptance-driven** | ⏳ **binding** | Every edge case in the spec is a failing test **before** implementation, and SC-019 additionally requires **seeding a defect and observing it caught** — a clean tree staying clean proves nothing |
+| **Technical Constraints** | ✅ | **Zero new dependencies.** Distribution unchanged: still one `uvx` command, still a pre-commit hook, still an Action |
+
+**Post-Phase-1 re-check**: ✅ unchanged. Phase 1 surfaced one new constraint (R4: destinations
+inside diagrams are not anchorable) and it **tightens** Principles II and III rather than
+straining them. No entry is needed in Complexity Tracking.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/017-mermaid-web-links/
+├── spec.md              # what and why
+├── plan.md              # this file
+├── research.md          # Phase 0 — the six decisions, with the measurements behind them
+├── data-model.md        # Phase 1 — the two concepts and their rules
+├── quickstart.md        # Phase 1 — how to prove it works, including the seeded defect
+├── contracts/
+│   └── cli.md           # Phase 1 — the user-visible surface (flag, config key, output, exit codes)
+├── checklists/
+│   └── requirements.md  # spec quality checklist
+└── tasks.md             # Phase 2 — created by /speckit-tasks, NOT by this command
+```
+
+### Source Code (repository root)
+
+```text
+src/darnlink/
+├── links.py         # region computation lives here — REUSED, and the recogniser joins it
+├── weblinks.py      # the read axis: finds web links, classifies, anchors. Gains the union
+├── cli.py           # flag plumbing + the offline listing path (the second read caller)
+├── repair.py        # UNCHANGED — write axis, FR-015 stands
+└── robustify.py     # UNCHANGED — write axis, FR-015 stands
+
+tests/
+├── test_mermaid_web_links.py   # new: the recogniser and every edge case in the spec
+├── test_weblinks.py            # extended: the union, and report-only under the writing mode
+└── test_links.py               # extended: mermaid regions are a subset of code regions
+```
+
+**Structure Decision**: single project, existing layout, no new package. The recogniser belongs
+next to the region computation it depends on (`links.py`), not in a module of its own: it is a few
+dozen lines that only make sense against a region, and a separate module would invite a second
+notion of what a region is — the exact failure FR-054 forbids.
+
+**Two callers, not one.** The read axis has *two* entry points (the online web check and the
+offline listing). Wiring only the first would produce a tool that reports a broken destination when
+online and denies its existence when offline. Both are in scope; the tests cover both.
+
+## Complexity Tracking
+
+> No Constitution Check violations. Nothing to justify.
+
+The one thing worth recording as *deliberately not done*: this feature does **not** make the write
+operations see inside diagrams. That would amend FR-015 and reopen a decision feature 002 settled
+with tests. If a future need arises, it is a new feature with its own spec — not a widening of this
+one.

--- a/specs/017-mermaid-web-links/quickstart.md
+++ b/specs/017-mermaid-web-links/quickstart.md
@@ -1,0 +1,123 @@
+# Phase 1 — Quickstart: proving the feature works
+
+The point of this guide is **not** to watch a clean tree stay clean. A blind check and a working
+check produce identical output on a healthy tree — that is exactly how this class of link went
+unwatched for so long. Every scenario below therefore starts by **breaking something on purpose**.
+
+## Prerequisites
+
+- The repository checked out on branch `017-mermaid-web-links`
+- `uv` available (the project's runner)
+- A scratch directory **outside** any real tree. Per the constitution: validate against a
+  disposable clone, never a live tree
+
+## Setup — the fixture tree
+
+Create a scratch Markdown tree containing:
+
+1. `moved.md` — an ordinary file with a `uuid` in its frontmatter, at a known path
+2. `diagram.md` — a file containing a `mermaid` fence with **four** `click` directives:
+   - one pointing at `moved.md` **where it currently is** (the control: must stay ok)
+   - one pointing at a path that does **not** exist (the seeded defect)
+   - one written as a diagram comment line (`%%` …) that contains the directive word
+   - one that binds a callback instead of a destination
+3. `prose.md` — a paragraph that **begins** with the directive word, outside any fence
+4. `example.md` — a longer fence that *contains* a `mermaid` fence as an example
+5. `unclosed.md` — a `mermaid` fence that is never closed, with a directive after it
+
+---
+
+## Scenario 1 — the seeded defect is caught (SC-019)
+
+**This is the scenario that distinguishes *dry* from *blind*.**
+
+1. Run the read axis over the fixture **without** the flag → the broken destination is **not**
+   reported. This is today's behaviour and the baseline for scenario 4.
+2. Run it **with** the flag → the broken destination **is** reported; the control destination is
+   reported as ok.
+3. Now repair the fixture (put the file back where the destination points) and re-run → the
+   finding disappears.
+
+**Expected**: step 2 reports exactly one broken destination. If step 1 and step 2 agree, the
+feature is not wired — a green result there is a false pass, not a success.
+
+---
+
+## Scenario 2 — nothing is written into a diagram (SC-020, SC-023)
+
+1. Take a byte-level snapshot of the fixture tree.
+2. Run the read axis **in its writing mode**, with the flag on, over a tree whose only anchorable
+   candidates are inside the diagram.
+3. Re-snapshot and diff.
+
+**Expected**: **no diff at all.** A single byte of change here is a corrupted diagram, because the
+anchor the axis would write is an HTML comment and a diagram renders it as content.
+
+4. Repeat with a file that has *both* a prose link and a diagram destination.
+
+**Expected**: the prose link is anchored, the diagram is untouched.
+
+---
+
+## Scenario 3 — the write operations are unaffected (FR-053)
+
+1. Run repair and robustify with `--write` over the fixture, flag on and flag off.
+2. Byte-diff every fenced region.
+
+**Expected**: identical in all four combinations. FR-015 is not amended by this feature, and this
+is the check that says so out loud.
+
+---
+
+## Scenario 4 — disabled means byte-identical (SC-018)
+
+1. Run the full read axis over the fixture with the current release, capture the output.
+2. Run the same command on this branch, flag absent.
+3. Diff the two outputs.
+
+**Expected**: identical, including exit code. This is what makes the feature safe to ship into
+fail-closed gates that have not opted in.
+
+---
+
+## Scenario 5 — precision: no false findings (SC-021)
+
+Run with the flag on and confirm **zero** findings from:
+
+| Fixture | Why it must stay silent |
+|---|---|
+| the diagram comment line | a comment is not a directive (FR-056) — and this case is real, not hypothetical |
+| the callback binding | it carries no destination (FR-057) |
+| `prose.md` | outside any region: unreachable by construction |
+| the `mermaid` fence nested in `example.md` | the outer fence wins; the inner text is never scanned |
+
+**Expected**: the only findings in the whole run are the ones scenario 1 put there.
+
+---
+
+## Scenario 6 — the unclosed fence (FR-016, inherited)
+
+Run with the flag on over `unclosed.md`.
+
+**Expected**: the region runs to end of file and the directive after the opener is recognised. This
+behaviour is **inherited**, not implemented here — the scenario exists to prove the region
+computation was reused rather than re-implemented (FR-054). If this fails, a second notion of
+"fenced block" has crept in.
+
+---
+
+## Scenario 7 — a repository that never opted in (SC-022)
+
+Run every command with no flag and no configuration key.
+
+**Expected**: same output, same exit code, and **no network request** attributable to a diagram
+destination.
+
+---
+
+## What this guide deliberately does not do
+
+- It does not check that a real remote destination resolves. That is the existing axis's job and
+  its tests inject a fetcher rather than touching the network.
+- It does not measure performance. The relevant guarantee is *no added work when disabled*, which
+  scenario 4 covers by observation rather than by timing.

--- a/specs/017-mermaid-web-links/research.md
+++ b/specs/017-mermaid-web-links/research.md
@@ -1,0 +1,133 @@
+# Phase 0 — Research: web links inside `mermaid` diagrams
+
+All unknowns in the Technical Context are resolved below. No `NEEDS CLARIFICATION` remains.
+
+---
+
+## R1. How to recognise the destination — grammar engine, Markdown library, or a textual function?
+
+**Decision**: a **pure textual function**, in the same style as the existing inline-region
+detection (FR-017). **No new dependency.**
+
+**Rationale**: the destination grammar was measured, not guessed. Across a fleet of 26
+repositories, **2,165** `click` directives occur, and they reduce to **three shapes**:
+
+```
+1961  click <id> href "<dest>" _blank
+ 147  click <id> "<dest>" _blank
+  57  click <id> href "<dest>"
+```
+
+Every one is a **single line** with the destination in double quotes. There is no nesting and no
+recursion: the language is **regular**. A grammar engine earns its keep on recursive structure,
+and there is none here — it would buy a permanent maintenance obligation (a grammar to chase when
+the diagram syntax moves) in exchange for nothing measurable.
+
+**Alternatives considered**:
+
+| Alternative | Measured | Rejected because |
+|---|---|---|
+| `lark` (grammar engine) | 110 KB wheel, pure Python, **zero runtime dependencies** — genuinely light | Breaches *Technical Constraints* (`standard library + python-frontmatter only`), which in this project means a **constitution amendment** and a re-check of every live spec. And it solves recursion the measurement says does not exist |
+| The upstream diagram parser | ships as a JavaScript package with its own dependency | Breaches *Technical Constraints* **and** *Distribution* (`uvx`/`pipx`, pre-commit hook, GitHub Action). The machine this was measured on has **no JavaScript runtime installed at all**: requiring one would break the gates where they actually run |
+| A Markdown library, to replace region detection | 90 KB, but pulls a second package (1 → 3 total) | Region detection is **not the broken part**: it is specified (FR-016), covered by tests, and no defect has been reported against it. Replacing the healthy component to reach the sick one adds risk without removing any |
+
+**On the instruction that prompted this feature** — *"use libraries to read the diagram, do not use
+string parsing, which causes problems"*: the part of string parsing that causes problems is the
+**region slicing** — nested fences, unclosed fences, tilde versus backtick, info strings. This
+design does not re-implement it; it **reuses** the existing, specified, tested computation (R2).
+What remains is a fixed one-line directive with a quoted destination inside an already-bounded
+region. Recognising the project's own link grammar by textual pattern is what the codebase already
+does throughout, and FR-018 **requires** region detection to be "a pure textual function (no
+network, no heuristics)". Using a grammar engine here while the core link is recognised textually
+would be inconsistent with the project itself.
+
+---
+
+## R2. Where does the region come from?
+
+**Decision**: reuse the existing fenced-region computation (FR-016) and **filter** it by info
+string. A mermaid region is a *subset* of existing code regions, never a new kind of region.
+
+**Rationale**: everything hard about the boundary is already solved and paid for — unclosed fence
+runs to EOF, closing fence of equal-or-greater length, indent up to 3, tildes and backticks do not
+close each other, an example fence nested in a longer fence is not scanned. Filtering by info
+string inherits all of it for free and keeps a single source of truth. A second, parallel notion of
+"what is a fenced block" is the failure mode this decision exists to prevent (FR-054).
+
+**Alternatives considered**: computing mermaid regions independently — rejected: two computations
+that must agree forever, and the moment they disagree the write axis and the read axis disagree
+about what code is.
+
+---
+
+## R3. The recognised destination is not a Markdown link — how does it reach the web axis?
+
+**Decision**: the mermaid recogniser yields items in the **same shape** the web axis already
+consumes, and the axis handles them with **no special case** downstream.
+
+**Rationale**: the existing web-link finder scans for Markdown link syntax. A diagram's `click`
+directive is not Markdown link syntax, so lifting the region exclusion **alone** would find
+nothing — the recogniser has to produce the item. Producing it in the existing shape means
+classification, reporting, exit codes and the own-repository strictness rule (feature 016) all
+apply unchanged, which is the whole point: once recognised, it is an ordinary web link.
+
+**Alternatives considered**: a parallel reporting path for diagram links — rejected: it would
+duplicate classification and drift from the main axis, and feature 016's rules would have to be
+re-implemented.
+
+---
+
+## R4. ⚠️ Can a diagram destination be anchored? — **No, and this constrains the design**
+
+**Decision**: destinations recognised inside a diagram are **report-only**. They are never
+rewritten and never anchored (FR-060).
+
+**Rationale — and this is a constraint discovered during research, not an assumption**: the web
+axis is not purely read-only. In its writing mode it **anchors** a link by appending an HTML
+comment after it. Inside a diagram, an HTML comment is **not a comment**: diagrams have their own
+comment syntax (`%%`), so an appended HTML comment becomes diagram content and **corrupts the
+diagram**. There is also nowhere to put it: a `click` directive has no `[text](href)` form to
+append to.
+
+This is the same danger feature 002 protects the write operations from, arriving through the one
+axis 002 does not cover. Left unstated, this feature would have made the tool write into diagrams —
+the exact opposite of its own premise.
+
+**Consequence**: `report-only` is a **property of the item**, enforced where the edit is produced,
+not a flag the caller may forget to pass. SC-023 verifies it by byte-diffing the tree after a
+writing run.
+
+**Alternatives considered**: emitting a `%%`-style anchor that the diagram would tolerate —
+rejected. It invents a second anchor format for one diagram dialect, breaks *Plain, Self-Contained,
+Tool-Agnostic* (a repository must stay usable without the tool), and buys nothing: the value here
+is **noticing** that a destination died, not repairing it in place.
+
+---
+
+## R5. How is the opt-in expressed, and why off by default?
+
+**Decision**: off by default; enabled per repository through the existing configuration surface,
+alongside the other axis switches.
+
+**Rationale**: measured, the same change exposes **33** own-repository destinations in one
+repository — all currently valid, so it goes green on day one — and **2,108** third-party
+destinations in two others, which can never be fixed from those repositories and would only add
+traffic and noise. The tool is consumed by **fail-closed gates**: a check that switches itself on
+everywhere is how every push in a fleet breaks at once. Off by default also makes SC-018
+(byte-identical output with the feature disabled) a testable claim rather than a hope.
+
+**Alternatives considered**: on by default with an opt-out — rejected on the measurement above.
+Auto-enabling where diagrams are detected — rejected: "it turned itself on" is indistinguishable
+from a regression when a gate goes red.
+
+---
+
+## R6. What does *not* need research, because it was measured to be absent
+
+- **Markdown-style links inside diagram labels**: **zero** occurrences of 2,165. Out of scope.
+- **Relative destinations inside diagrams**: **zero** occurrences. Out of scope — resolving them
+  would drag core path resolution into a region it has never entered, for no observed benefit.
+- **Prose beginning with the directive word**: two occurrences in a real tree, both outside any
+  diagram region. Unreachable by construction, since recognition happens only inside a region.
+- **Diagram comment lines containing the directive word**: **one real occurrence**. Reachable, so
+  it is a requirement (FR-056) and a test, not an assumption.

--- a/specs/017-mermaid-web-links/spec.md
+++ b/specs/017-mermaid-web-links/spec.md
@@ -1,0 +1,231 @@
+# Feature Specification: see web links inside `mermaid` diagrams (read axis only, opt-in)
+
+**Feature Branch**: `017-mermaid-web-links`
+
+**Created**: 2026-08-23
+
+**Status**: Draft
+
+**Input**: A diagram's `click` directives carry destinations — most of them URLs into the author's
+own repository. They live inside a ```` ```mermaid ```` fence, so feature 002 hides them from every
+axis, including the read-only ones. The result is a class of link that **no gate has ever watched**:
+it dies the moment a file moves, silently, while the tree stays green. This feature lets the
+**read** axes see those links. It does **not** touch repair or robustify, so FR-015 stands
+unchanged.
+
+---
+
+## The gap, precisely
+
+Feature 002 (FR-015) is a **write-side** rule, and says so:
+
+> MUST ignore any link ... for BOTH operations (**repair and robustify**).
+
+Both are mutations. Its stated failure mode — *"ignore too much (skip a real link), never rewrite
+code"* — is about not corrupting an example. **Reporting a link is not rewriting it.** But
+`code_spans()` is consumed by four callers, and two of them are read-only:
+
+| Caller | Axis | Should mermaid be visible? |
+|---|---|---|
+| `repair.py` | write | **No** — FR-015 stands |
+| `robustify.py` | write | **No** — FR-015 stands |
+| `weblinks.py` (`web-check`) | read | **Yes**, opt-in |
+| `cli.py` (offline web listing) | read | **Yes**, opt-in |
+
+A mermaid `click` destination is **not a code example**. It is a navigational link that happens to
+be written in a diagram's syntax — the exact thing 002 exists to protect elsewhere, and the exact
+thing nothing protects here.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A diagram's links stop dying in silence (Priority: P1)
+
+A maintainer keeps an architecture diagram whose nodes are clickable: each `click` points at a file
+in the same repository, written as a full URL. The files are later reorganised into subfolders. The
+maintainer wants the run to report those destinations as broken instead of staying green.
+
+**Why this priority**: This is the whole feature. Without it the diagram is a blind spot: measured
+on a real tree, a single folder reorganisation killed **14 of a diagram's `click` destinations at
+once**, and every gate stayed green. The links had to be found by hand.
+
+**Independent Test**: A file with a ```` ```mermaid ```` fence containing
+`click A href "https://github.com/<owner>/<repo>/blob/main/moved.md"` where `moved.md` no longer
+exists at that path; run the read axis with the feature enabled; assert the destination is
+reported. Run it with the feature disabled; assert nothing is reported and the output is identical
+to today's.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `mermaid` fence with a `click` whose destination is a live URL, **When** the read
+   axis runs with the feature enabled, **Then** the destination appears in the report exactly as a
+   prose web link would.
+2. **Given** the same file, **When** the read axis runs with the feature **disabled** (the
+   default), **Then** the destination is not reported and the run is byte-identical to a run on the
+   current release.
+3. **Given** the same file, **When** `--write` runs (repair/robustify) with the feature enabled,
+   **Then** the bytes inside the fence are unchanged.
+
+---
+
+### User Story 2 - Enabling it does not set the fleet on fire (Priority: P1)
+
+An operator runs the same tool across many repositories with fail-closed gates. Turning on a check
+that suddenly sees thousands of new destinations — most of them third-party services that can never
+be fixed from here — would block every push at once.
+
+**Why this priority**: Equal to P1 above, because a correct feature that cannot be switched on
+safely does not get switched on. Measured across a real fleet: the same change would expose **33**
+own-repository destinations in one repo (all currently valid) and **2,108** third-party
+destinations in two others.
+
+**Independent Test**: With no configuration change, every existing repository behaves exactly as
+before — verified by running the full read axis on a tree containing mermaid links and diffing the
+output against the current release.
+
+**Acceptance Scenarios**:
+
+1. **Given** a repository that does not opt in, **When** any command runs, **Then** mermaid
+   destinations are invisible, as today.
+2. **Given** a repository that opts in, **When** the read axis runs, **Then** only that
+   repository's behaviour changes.
+
+---
+
+### User Story 3 - The diagram's own comments are not mistaken for links (Priority: P2)
+
+Diagram authors annotate their diagrams with comments, and those comments discuss the very
+directives around them.
+
+**Why this priority**: Lower than P1 because it degrades precision rather than blocking the
+feature — but it is not hypothetical: a real tree contains a mermaid comment line whose prose
+includes the word `click`. A recogniser that ignores comments produces false findings, and a gate
+that cries wolf gets switched off.
+
+**Independent Test**: A fence containing `%% click A "https://example.com/gone"`; assert nothing is
+reported.
+
+**Acceptance Scenarios**:
+
+1. **Given** a mermaid comment line that contains a `click` directive, **When** the read axis runs
+   with the feature enabled, **Then** it is not reported.
+2. **Given** a `click` directive that binds a callback rather than a destination, **When** the read
+   axis runs, **Then** it is not reported — it carries no destination.
+
+---
+
+### Edge Cases
+
+- **A fence that is never closed**: inherited unchanged from FR-016 — the region runs to end of
+  file. Nothing new is needed and nothing new is claimed.
+- **A `mermaid` fence shown as an example inside a longer fence**: the outer fence wins, because
+  region detection is the existing one. The inner text is never scanned.
+- **Prose that begins with the word "click"**: cannot be reached — recognition happens only inside
+  a mermaid region. Measured: two such lines exist in a real tree, both in ordinary prose.
+- **A destination that is a relative path rather than a URL**: out of scope (see Assumptions).
+  It is not reported by either axis, exactly as today.
+- **Tilde fences** (`~~~mermaid`): treated identically to backtick fences, per FR-016.
+- **An info string with extra words** (```` ```mermaid ````+ attributes): recognised as mermaid.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-052**: The read axes (`web-check`, online and offline) MUST be able to see web links whose
+  start position falls inside a fenced region whose info string names `mermaid`. This is
+  **opt-in and off by default**: with no configuration, behaviour is unchanged.
+- **FR-053**: The write operations (repair, robustify) MUST continue to ignore every link inside
+  any fenced region, mermaid included, whether or not the feature is enabled. **FR-015 is not
+  amended by this feature.**
+- **FR-054**: Region detection MUST reuse the existing fenced-region computation (FR-016). This
+  feature MUST NOT introduce a second, parallel notion of what a fenced block is.
+- **FR-055**: Inside a mermaid region, a destination MUST be recognised from a `click` directive
+  that carries a quoted destination, in the forms `click <id> "<dest>" [...]` and
+  `click <id> href "<dest>" [...]`, where a trailing target or tooltip does not affect
+  recognition.
+- **FR-056**: A mermaid comment line (one whose first non-blank characters are `%%`) MUST NOT
+  yield a destination, even when it contains the text of a `click` directive.
+- **FR-057**: A `click` directive that binds a callback rather than a destination MUST NOT yield a
+  destination.
+- **FR-058** (determinism): Recognition MUST be a pure textual function — no network, no
+  heuristics, no fuzzy matching — and MUST compose with `--ignore-block` markers and with the
+  existing ignore mechanisms, exactly as FR-018 requires of region detection.
+- **FR-059**: Enabling the feature MUST NOT change the exit code or output of any repository that
+  contains no mermaid regions.
+
+### Key Entities
+
+- **Mermaid region**: a fenced region (FR-016) whose info string names `mermaid`. It is a
+  *subset* of the existing code regions, never a new kind of region.
+- **Mermaid destination**: a destination recognised from a `click` directive inside a mermaid
+  region. Once recognised, it is an ordinary web link and is handled by the existing web axis with
+  no special case.
+
+---
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-018**: With the feature disabled, output on any tree is **identical** to the current
+  release — provable by diffing full runs before and after, on a tree that contains mermaid links.
+- **SC-019**: With the feature enabled, a destination inside a mermaid diagram that points at a
+  path which no longer exists is reported; the same run before the change reports nothing. Proven
+  by **seeding a defect and observing it caught** — not merely by observing a clean tree stay
+  clean.
+- **SC-020**: Bytes inside any fenced region are unchanged by a `--write` run whether the feature
+  is on or off (byte-diff of the fenced regions).
+- **SC-021**: Comments and callback bindings inside a diagram produce **zero** findings.
+- **SC-022**: A repository that does not opt in shows no change in behaviour, exit code, or
+  network traffic.
+
+---
+
+## Assumptions
+
+- **Only the read axes are in scope.** Making the write operations see inside a diagram is
+  deliberately excluded: it would amend FR-015 and reopen a decision that feature 002 settled.
+- **Only `click` destinations are in scope.** Markdown-style links written inside a diagram's
+  labels are excluded: measured across a real fleet of 26 repositories, they do **not occur** —
+  every one of 2,165 destinations came from a `click` directive. If they appear later, the scope
+  can be widened on evidence.
+- **Only absolute destinations are in scope.** Relative paths inside a diagram do not occur in the
+  measured trees (zero of 2,165). Resolving them would pull the core's path resolution into a
+  region it has never entered, for no observed benefit.
+- **The destination grammar is a regular, line-oriented one.** Measured over 2,165 real
+  directives, three shapes account for all of them, each on a single line with the destination in
+  double quotes. No nesting, no recursion.
+- **Off by default is a requirement, not a preference.** The tool is consumed by fail-closed gates
+  across many repositories; a check that switches itself on everywhere is how every push breaks at
+  once.
+
+---
+
+## Constitution Check
+
+- **I. Single responsibility** — ✅ still links + uuid only. This narrows *where* an existing axis
+  looks; it adds no document semantics and no new operation.
+- **II. Safe by default** — ✅ off by default, opt-in, read-only. It cannot write anything the
+  current release would not write.
+- **III. Plain, tool-agnostic** — ✅ no format change; a repository stays fully usable without the
+  tool, and diagrams stay plain Markdown.
+- **IV. Deterministic, no AI** — ✅ pure textual recognition over a region computed by the existing
+  pure function. The network stays confined to the existing sanctioned `web-check --online`
+  carve-out; this feature adds no new network path.
+- **V. Test-first** — ⏳ required: the edge cases above (comment lines, callback bindings, unclosed
+  fence, nested example fence, prose beginning with the directive word) are written as failing
+  tests **before** implementation, and SC-019 additionally requires seeding a defect and observing
+  it caught.
+
+**Technical Constraints** — ✅ **no new dependency.** Region detection is reused; recognition is a
+pure textual function in the same style as the existing inline-region detection (FR-017). Adding a
+grammar engine or a Markdown library was evaluated and rejected: the measured grammar is regular
+and one-line, so a grammar engine buys nothing, and either dependency would breach
+*standard library + `python-frontmatter` only*. A JavaScript parser was rejected outright — it
+would also breach *Distribution* (`uvx`/`pipx`, pre-commit hook, GitHub Action), and the machine
+where this was measured has no JavaScript runtime installed at all.
+
+No violations; no complexity-tracking entries.

--- a/specs/017-mermaid-web-links/spec.md
+++ b/specs/017-mermaid-web-links/spec.md
@@ -155,6 +155,11 @@ reported.
   existing ignore mechanisms, exactly as FR-018 requires of region detection.
 - **FR-059**: Enabling the feature MUST NOT change the exit code or output of any repository that
   contains no mermaid regions.
+- **FR-060**: A destination recognised inside a mermaid region is **report-only** and MUST NEVER be
+  rewritten or anchored, even when the read axis is invoked in its writing mode. The web axis
+  anchors a link by appending an HTML comment after it; inside a diagram that comment is **not** a
+  comment — diagrams use their own comment syntax — so writing one would corrupt the diagram. This
+  is the same protection FR-015 gives the write operations, stated for the axis that can write.
 
 ### Key Entities
 
@@ -181,6 +186,9 @@ reported.
 - **SC-021**: Comments and callback bindings inside a diagram produce **zero** findings.
 - **SC-022**: A repository that does not opt in shows no change in behaviour, exit code, or
   network traffic.
+- **SC-023**: Running the read axis in its writing mode, with the feature enabled, over a tree
+  whose only findable destinations live inside diagrams, writes **nothing** — byte-identical tree
+  before and after.
 
 ---
 

--- a/specs/017-mermaid-web-links/tasks.md
+++ b/specs/017-mermaid-web-links/tasks.md
@@ -1,0 +1,160 @@
+---
+
+description: "Tasks for 017-mermaid-web-links"
+---
+
+# Tasks: see web links inside `mermaid` diagrams (read axis only, opt-in)
+
+**Input**: design documents from `specs/017-mermaid-web-links/`
+
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/cli.md`,
+`quickstart.md`
+
+**Tests**: **mandatory and binding.** The constitution's Principle V is test-first, and SC-019 goes
+further: a clean tree stays clean whether the check works or is blind, so *seeding a defect and
+observing it caught* is the only evidence that counts. Every test task below precedes its
+implementation task, and that ordering is the deliverable, not a preference.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel (different files, no dependency between them)
+- **[Story]**: the user story from `spec.md` this serves
+
+---
+
+## Phase A — Fixtures (blocking; everything else builds on these)
+
+- **T001** [P] Build the fixture tree helper described in `quickstart.md` §Setup, in
+  `tests/test_mermaid_web_links.py`: a diagram with a **live** destination (the control), a
+  **broken** one (the seeded defect), a comment line carrying the directive word, and a callback
+  binding. Follow the existing fixture style in `tests/test_weblinks.py` — the web tests inject a
+  fetcher instead of touching the network, and this feature must not be the one that breaks that.
+- **T002** [P] Add the boundary fixtures: prose beginning with the directive word (outside any
+  fence), a `mermaid` fence nested inside a longer fence, an unclosed `mermaid` fence, and a
+  tilde-delimited `mermaid` fence.
+
+---
+
+## Phase B — Failing tests (US1: a diagram's links stop dying in silence)
+
+> **These must fail before any `src/` change.** A test that passes now is testing nothing.
+
+- **T003** [US1] Region filter: a fence whose info string names `mermaid` is recognised as a
+  mermaid region; one that does not, is not. Assert the set of mermaid regions is a **subset** of
+  the code regions returned by the existing computation — the invariant in `data-model.md` §1.
+- **T004** [US1] Recogniser, happy path: the three measured shapes each yield their destination
+  (`click <id> "<dest>" …`, `click <id> href "<dest>" …`, and with a trailing target). FR-055.
+- **T005** [US1] End-to-end, **flag on**: the broken destination in the fixture is reported; the
+  control is reported as ok. This is SC-019 — the seeded defect.
+- **T006** [US1] End-to-end, **flag off**: the same run reports neither. Same fixture, same
+  command, opposite expectation. If T005 and T006 ever agree, the feature is not wired.
+- **T007** [US1] Both entry points report the **same** destinations for the same tree: the online
+  check and the offline listing must not disagree about what exists. Per `plan.md`, a tool that
+  reports a broken destination online and denies it offline is worse than no tool.
+
+---
+
+## Phase C — Failing tests (US2: enabling it does not set the fleet on fire)
+
+- **T008** [US2] Disabled is byte-identical: full output **and** exit code unchanged against the
+  pre-change behaviour, on a tree that contains mermaid links. SC-018.
+- **T009** [US2] A repository with no mermaid regions is unaffected whether the flag is on or off.
+  FR-059.
+- **T010** [US2] No network is attempted for a diagram destination when the flag is off — asserted
+  through the injected fetcher, which must record zero calls attributable to it. SC-022.
+
+---
+
+## Phase D — Failing tests (US3: precision, and the write protection)
+
+- **T011** [US3] A comment line (`%%`) containing a full directive yields **nothing**. FR-056.
+  This case is real, not hypothetical: one exists in a measured tree.
+- **T012** [US3] A directive that binds a callback rather than a destination yields **nothing**.
+  FR-057.
+- **T013** [US3] Prose beginning with the directive word, outside any fence, yields nothing; and a
+  `mermaid` fence nested inside a longer fence is never scanned.
+- **T014** [US3] Unclosed fence: the region runs to end of file and a directive after the opener is
+  recognised. This is **inherited** from FR-016 — the test exists to prove the region computation
+  was reused, not re-implemented (FR-054). Tilde fences behave identically.
+- **T015** [US3] **Report-only, happy path**: the read axis in its **writing** mode, over a tree
+  whose only candidates are inside a diagram, writes **nothing** — byte-diff of the tree. SC-023.
+- **T016** [US3] **Report-only, mixed file**: a file with both a prose web link and a diagram
+  destination — the prose link is anchored, the diagram bytes are unchanged.
+- **T017** [US3] **⚠️ Report-only, adversarial**: take a report-only item and invoke the
+  edit-producing path **directly**, bypassing the normal call site. The file must still be
+  untouched. *Rationale: if the protection lives only in the caller, it disappears the day someone
+  adds a second caller — which is exactly how this feature came to exist.*
+- **T018** [US3] **The property survives the report**: the offline listing currently projects each
+  link to `{file, href, anchored}`, dropping everything else. Assert the JSON distinguishes a
+  destination that **can never** be anchored from one that merely **is not yet** — otherwise a
+  consumer reconstructs an item without the property, which is the same defect one layer out.
+- **T019** [US3] The write operations (repair, robustify) are unchanged with the flag both on and
+  off: byte-diff of every fenced region across all four combinations. FR-053 — the check that says
+  out loud that FR-015 is not amended.
+
+---
+
+## Phase E — Implementation (only after B–D are red)
+
+- **T020** [US1] `src/darnlink/links.py`: derive mermaid regions from the existing fenced-region
+  computation by filtering on the info string. **Do not** add a second notion of a fenced block.
+- **T021** [US1] `src/darnlink/links.py`: the recogniser — a pure textual function over a region
+  body, skipping comment lines and destination-less directives, producing items in the shape the
+  web axis already consumes. No network, no fuzziness (FR-058).
+- **T022** [US1] `src/darnlink/weblinks.py`: union the recognised destinations into the online
+  check, gated by the opt-in. Recall from `research.md` R3 that lifting the exclusion alone finds
+  nothing — the existing finder looks for Markdown link syntax, which a directive is not.
+- **T023** [US1] `src/darnlink/cli.py`: the same union in the **offline listing** path, and carry
+  the report-only property into its JSON projection (T018).
+- **T024** [US3] Enforce report-only **where the edit is produced**, not where it is requested —
+  a property of the item, per `data-model.md` §2. T017 is the test that this was done in the right
+  place.
+- **T025** [US2] Flag plumbing on the read axis only. **Not** on the core command: offering it
+  there would imply the write axis can honour it.
+
+---
+
+## Phase F — Rollout surface
+
+- **T026** [P] `recipes/`: the configuration key, absent-means-off, mapping to the flag. Extend
+  `tests/test_recipe_gate.py` / `test_recipe_examples.py` in the existing style.
+- **T027** [P] `README.md` + `CHANGELOG.md`: what the switch does, and — stated plainly — that
+  destinations inside diagrams are watched but **never rewritten**, so a permanently un-anchored
+  destination is a normal state and not a defect.
+
+---
+
+## Phase G — Acceptance
+
+- **T028** Run the seven `quickstart.md` scenarios end to end against a **disposable** tree, never
+  a live one (constitution, Development Workflow).
+- **T029** Full suite green (427 tests were green on this branch before any change; the count must
+  only go up), and every test from B–D now passing **for the right reason** — re-break the fixture
+  and watch T005 fail again. A test that passes because the fixture stopped being broken is a false
+  pass.
+
+---
+
+## Dependencies
+
+```
+A (T001-T002)  →  B, C, D  →  E  →  F  →  G
+```
+
+- Phase A blocks everything: the fixtures are the measurement instrument.
+- **B, C and D must be RED before any task in E begins.** This is the binding constraint.
+- Within E, T020 blocks T021, which blocks T022 and T023. T024 is independent of the union work and
+  can proceed once T021 exists.
+- F depends on E. G depends on everything.
+
+## Parallelisable
+
+`[P]` on T001/T002 (distinct fixtures), and on T026/T027 (recipes and docs touch different files).
+Everything in E touches overlapping modules and is deliberately **not** marked parallel.
+
+## Out of scope — recorded so it is not re-litigated
+
+- Making the **write** operations see inside diagrams. That amends FR-015 and reopens a decision
+  feature 002 settled with tests. A future need is a new feature with its own spec.
+- Markdown-style links inside diagram labels, and relative destinations inside diagrams: **zero**
+  occurrences across 26 measured repositories. Scope widens on evidence, not on speculation.

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -467,8 +467,10 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
                 content = read_text_keep_newlines(f)
             except Exception:
                 continue
-            ignore = ignored_spans(content, block_markers) + code_spans(content)
-            for link in find_web_links(content, ignore, include_mermaid=args.include_mermaid):
+            blocks = ignored_spans(content, block_markers)
+            ignore = blocks + code_spans(content)
+            for link in find_web_links(content, ignore, include_mermaid=args.include_mermaid,
+                                       block_spans=blocks):
                 seen += 1
                 listing.append((f, link.href, link.uuid is not None, link.report_only))
         if args.json:

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -395,6 +395,12 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
                         help="also treat the owner of this repo's `origin` remote as yours. A separate "
                              "flag rather than a magic --own value, so an owner literally called "
                              "'auto' stays expressible.")
+    parser.add_argument("--include-mermaid", action="store_true",
+                        help="(feature 017) also see web links carried by a mermaid diagram's `click` "
+                             "directives, which are otherwise invisible because they sit inside a "
+                             "fenced block. OFF BY DEFAULT: a fleet of fail-closed gates must opt in "
+                             "one repository at a time. These links are report-only — they are never "
+                             "anchored, because a diagram would render the anchor comment as a node")
     parser.add_argument("--own-max", type=int, default=None, metavar="N",
                         help="budget: while there are N or fewer owned-without-uuid findings they are "
                              "reported but do not fail the exit. Lets the axis be adopted before a "
@@ -462,19 +468,22 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
             except Exception:
                 continue
             ignore = ignored_spans(content, block_markers) + code_spans(content)
-            for link in find_web_links(content, ignore):
+            for link in find_web_links(content, ignore, include_mermaid=args.include_mermaid):
                 seen += 1
-                listing.append((f, link.href, link.uuid is not None))
+                listing.append((f, link.href, link.uuid is not None, link.report_only))
         if args.json:
             print(json.dumps({"web_check": True, "online": False, "exit_code": 0,
                               "web_links_seen": seen,
                               "out_of_root_links": [str(p_) for p_ in out_of_root],
-                              "links": [{"file": str(f), "href": h, "anchored": a} for f, h, a in listing]}, indent=2))
+                              "links": [{"file": str(f), "href": h, "anchored": a,
+                                         "report_only": r}
+                                        for f, h, a, r in listing]}, indent=2))
         else:
             print(f"darnlink web-check (EXPERIMENTAL, offline) — root: {root}")
             print(f"  web links seen: {seen} (core ignores them; run with --online to fetch & verify/anchor)")
-            for f, h, a in listing:
-                print(f"  [{'anchored' if a else 'plain'}] {f}: {h}")
+            for f, h, a, r in listing:
+                kind = "in-diagram" if r else ("anchored" if a else "plain")
+                print(f"  [{kind}] {f}: {h}")
             for p_ in out_of_root:
                 print(f"  [out-of-root-link] {p_}: symlink whose target lives outside the scanned "
                       f"root; not indexed -> informational (does not affect the exit code)")
@@ -483,7 +492,8 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
     token = os.environ.get("GITHUB_TOKEN") or None
     web_out_of_root: List[Path] = []
     findings, edits = check_web_links_online(root, token, fetcher or default_fetcher, block_markers,
-                                             excludes, owners, out_of_root=web_out_of_root)
+                                             excludes, owners, out_of_root=web_out_of_root,
+                                             include_mermaid=args.include_mermaid)
     ok = [x for x in findings if x.kind == "web_ok"]
     anchors = [x for x in findings if x.kind == "web_anchor"]
     mismatch = [x for x in findings if x.kind == "web_mismatch"]

--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import List, Sequence, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 # The BODY of a pandoc attribute block, between its own `{` and `}` — one definition, shared by
 # ROBUST_LINK_RE's `attrs` group below and by `_PANDOC_ATTR_RE` further down. `[^{}\n]*` alone (the
@@ -233,23 +233,62 @@ def code_spans(content: str) -> List[Span]:
 #: line with the destination double-quoted. That is a REGULAR language: no nesting, no recursion,
 #: which is why a grammar engine was evaluated and rejected (research R1). A directive that binds a
 #: callback (`call cb()` / `callback`) carries no destination and simply does not match (FR-057).
-# `(?:^|;)` and not `^` alone: a diagram may chain statements on one physical line with `;`, and
-# anchoring only to the line start silently misses every directive but the first -- a false negative
-# in a feature whose whole purpose is that destinations stop dying unnoticed. It also makes the
-# comment guard below LOAD-BEARING: with `^` alone a `%%` line could never match, so the guard was
-# unreachable and its test passed for an unrelated reason.
-_MERMAID_CLICK_RE = re.compile(
-    r'(?:^|;)[ \t]*(?P<kw>click)[ \t]+\S+[ \t]+(?:href[ \t]+)?"(?P<dest>[^"\n]+)"',
-    re.M,
-)
+# --- Recognising a `click` directive: a LINE READER, deliberately not a regular expression ------
+#
+# The first implementation used one, and two of the three defects review found in this feature came
+# from regex semantics rather than from the language being hard: an `^` anchor that made a guard
+# unreachable, and that same `^` compiled without MULTILINE while used through `.match(pos)`, which
+# only ever matches at index 0. Neither mistake is possible below, because none of those concepts
+# exist here. The language is line-oriented and tiny; reading it as lines is both simpler and the
+# "traditional, auditable algorithm a human can verify" the constitution asks for (Principle IV).
 
-#: A diagram comments with `%%`, not with `<!-- -->`. A comment line must never yield a destination
-#: even when it quotes a whole directive (FR-056) -- and that case is real, not hypothetical.
-# No `^`: this is used as `.match(body, line_start)`, which already anchors AT that position,
-# and `^` without re.M only ever matches at index 0 of the string. With it, the guard was
-# unreachable except for a comment on the very first line of a region -- which is why its
-# test passed while testing nothing.
-_MERMAID_COMMENT_RE = re.compile(r"[ \t]*%%")
+
+def _split_statements(line: str) -> List[Tuple[int, str]]:
+    """`(offset within the line, text)` for each `;`-separated statement.
+
+    Quote-aware on purpose: a destination may legitimately contain `;`
+    (`click A "http://x/y;z"`), and a naive split would cut it in half and then discard it for
+    having an unterminated quote -- turning a working link into a silently unwatched one."""
+    out: List[Tuple[int, str]] = []
+    start = 0
+    in_quotes = False
+    for i, ch in enumerate(line):
+        if ch == '"':
+            in_quotes = not in_quotes
+        elif ch == ";" and not in_quotes:
+            out.append((start, line[start:i]))
+            start = i + 1
+    out.append((start, line[start:]))
+    return out
+
+
+def _click_destination(statement: str) -> Optional[str]:
+    """The quoted destination of one `click` statement, or None if it does not carry one.
+
+    Accepts `click <id> "<dest>" ...` and `click <id> href "<dest>" ...`; a trailing target or
+    tooltip is irrelevant. Returns None for a directive that binds a callback (`call cb()`,
+    `callback`), which carries no destination at all (FR-057)."""
+    rest = statement.lstrip(" \t")
+    if not rest.startswith("click"):
+        return None
+    rest = rest[len("click"):]
+    if rest[:1] not in (" ", "\t"):
+        return None  # `clickable`, `clicked`, ... are not the directive
+    rest = rest.lstrip(" \t")
+    node_end = 0
+    while node_end < len(rest) and rest[node_end] not in " \t":
+        node_end += 1
+    if node_end == 0:
+        return None  # no node id
+    rest = rest[node_end:].lstrip(" \t")
+    if rest.startswith("href") and rest[4:5] in (" ", "\t"):
+        rest = rest[4:].lstrip(" \t")
+    if not rest.startswith('"'):
+        return None  # a callback binding, or anything else that is not a quoted destination
+    close = rest.find('"', 1)
+    if close == -1:
+        return None  # an unterminated quote is not a destination
+    return rest[1:close] or None
 
 
 def mermaid_region_bodies(content: str) -> List[Span]:
@@ -281,11 +320,19 @@ def mermaid_click_destinations(content: str) -> List[Tuple[int, str]]:
     out: List[Tuple[int, str]] = []
     for body_start, body_end in mermaid_region_bodies(content):
         body = content[body_start:body_end]
-        for m in _MERMAID_CLICK_RE.finditer(body):
-            line_start = body.rfind("\n", 0, m.start()) + 1
-            if _MERMAID_COMMENT_RE.match(body, line_start):
+        line_start = 0
+        for line in body.splitlines(keepends=True):
+            # A diagram comments with `%%`. Checked once per LINE, before anything is parsed, so a
+            # comment cannot contribute a destination however it is written (FR-056).
+            if line.lstrip(" \t").startswith("%%"):
+                line_start += len(line)
                 continue
-            out.append((body_start + m.start("kw"), m["dest"]))
+            for offset, statement in _split_statements(line):
+                dest = _click_destination(statement)
+                if dest is not None:
+                    lead = len(statement) - len(statement.lstrip(" \t"))
+                    out.append((body_start + line_start + offset + lead, dest))
+            line_start += len(line)
     return out
 
 

--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -261,8 +261,11 @@ def _statement_starts(line: str) -> List[int]:
     return out
 
 
-def _click_destination(statement: str) -> Optional[str]:
-    """The quoted destination of one `click` statement, or None if it does not carry one.
+def _click_destination(statement: str) -> Optional[Tuple[str, int]]:
+    """`(destination, offset just past its closing quote)` for one `click` statement, or None.
+
+    The second element is what lets the caller know how much of the line this directive CONSUMED,
+    so a `;` living inside the destination cannot be mistaken for the start of another statement.
 
     Accepts `click <id> "<dest>" ...` and `click <id> href "<dest>" ...`; a trailing target or
     tooltip is irrelevant. Returns None for a directive that binds a callback (`call cb()`,
@@ -287,7 +290,10 @@ def _click_destination(statement: str) -> Optional[str]:
     close = rest.find('"', 1)
     if close == -1:
         return None  # an unterminated quote is not a destination
-    return rest[1:close] or None
+    dest = rest[1:close]
+    if not dest:
+        return None
+    return dest, len(statement) - len(rest) + close + 1
 
 
 def mermaid_region_bodies(content: str) -> List[Span]:
@@ -326,12 +332,20 @@ def mermaid_click_destinations(content: str) -> List[Tuple[int, str]]:
             if line.lstrip(" \t").startswith("%%"):
                 line_start += len(line)
                 continue
+            # A `;` that lives INSIDE a destination is not the start of anything. Skipping the
+            # span a directive already consumed is what stops a quote embedded after such a `;`
+            # from fabricating a second, phantom destination out of text that was never a link.
+            consumed_until = 0
             for offset in _statement_starts(line):
+                if offset < consumed_until:
+                    continue
                 statement = line[offset:]
-                dest = _click_destination(statement)
-                if dest is not None:
+                found = _click_destination(statement)
+                if found is not None:
+                    dest, end = found
                     lead = len(statement) - len(statement.lstrip(" \t"))
                     out.append((body_start + line_start + offset + lead, dest))
+                    consumed_until = offset + end
             line_start += len(line)
     return out
 

--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -222,6 +222,64 @@ def code_spans(content: str) -> List[Span]:
     return fenced + _inline_code_spans(content, fenced)
 
 
+# --- Feature 017: destinations carried by a diagram's `click` directives ---------------------
+#
+# These live next to the region computation they depend on, and DELIBERATELY know nothing about
+# web links: they yield `(offset, destination)`, so `links.py` never has to import `weblinks.py`
+# and there is no second notion of what a fenced block is (FR-054).
+
+#: `click <id> ["href"] "<dest>" [target|"tooltip"]` -- the only forms that carry a destination.
+#: Measured over 2165 real directives, three shapes account for every one of them, each on a single
+#: line with the destination double-quoted. That is a REGULAR language: no nesting, no recursion,
+#: which is why a grammar engine was evaluated and rejected (research R1). A directive that binds a
+#: callback (`call cb()` / `callback`) carries no destination and simply does not match (FR-057).
+_MERMAID_CLICK_RE = re.compile(
+    r'^[ \t]*(?P<kw>click)[ \t]+\S+[ \t]+(?:href[ \t]+)?"(?P<dest>[^"\n]+)"',
+    re.M,
+)
+
+#: A diagram comments with `%%`, not with `<!-- -->`. A comment line must never yield a destination
+#: even when it quotes a whole directive (FR-056) -- and that case is real, not hypothetical.
+_MERMAID_COMMENT_RE = re.compile(r"^[ \t]*%%")
+
+
+def mermaid_region_bodies(content: str) -> List[Span]:
+    """Spans of the BODY of each fenced block whose info string names `mermaid` (FR-054).
+
+    Derived from `_fenced_code_spans()`, never computed independently: everything hard about the
+    boundary -- unclosed fence to EOF, closing fence of equal-or-greater length, tildes vs
+    backticks, an example fence nested in a longer one -- is inherited for free, and a second
+    computation could drift from the one the write axis obeys.
+
+    The body starts after the opening fence's line, so the info string itself is never scanned.
+    Pure & deterministic."""
+    out: List[Span] = []
+    for start, end in _fenced_code_spans(content):
+        nl = content.find("\n", start)
+        if nl == -1 or nl >= end:
+            continue  # a fence with no body (or an opener at EOF) carries nothing
+        info = content[start:nl].lstrip(" ").lstrip("`~").strip().lower()
+        if info.startswith("mermaid"):
+            out.append((nl + 1, end))
+    return out
+
+
+def mermaid_click_destinations(content: str) -> List[Tuple[int, str]]:
+    """`(absolute offset of the directive, destination)` for every `click` inside a mermaid region.
+
+    The offset is into the FILE, not into the region body: a report has to point at a place a human
+    can find. Pure & deterministic -- no network, no heuristics (FR-058)."""
+    out: List[Tuple[int, str]] = []
+    for body_start, body_end in mermaid_region_bodies(content):
+        body = content[body_start:body_end]
+        for m in _MERMAID_CLICK_RE.finditer(body):
+            line_start = body.rfind("\n", 0, m.start()) + 1
+            if _MERMAID_COMMENT_RE.match(body, line_start):
+                continue
+            out.append((body_start + m.start("kw"), m["dest"]))
+    return out
+
+
 def _carries_marker(content: str, keyword: str, marker_re: "re.Pattern[str]") -> bool:
     """True if `marker_re` matches outside a code span (so a file documenting the marker as an
     example does not opt itself out). Pure & deterministic.

--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -233,14 +233,23 @@ def code_spans(content: str) -> List[Span]:
 #: line with the destination double-quoted. That is a REGULAR language: no nesting, no recursion,
 #: which is why a grammar engine was evaluated and rejected (research R1). A directive that binds a
 #: callback (`call cb()` / `callback`) carries no destination and simply does not match (FR-057).
+# `(?:^|;)` and not `^` alone: a diagram may chain statements on one physical line with `;`, and
+# anchoring only to the line start silently misses every directive but the first -- a false negative
+# in a feature whose whole purpose is that destinations stop dying unnoticed. It also makes the
+# comment guard below LOAD-BEARING: with `^` alone a `%%` line could never match, so the guard was
+# unreachable and its test passed for an unrelated reason.
 _MERMAID_CLICK_RE = re.compile(
-    r'^[ \t]*(?P<kw>click)[ \t]+\S+[ \t]+(?:href[ \t]+)?"(?P<dest>[^"\n]+)"',
+    r'(?:^|;)[ \t]*(?P<kw>click)[ \t]+\S+[ \t]+(?:href[ \t]+)?"(?P<dest>[^"\n]+)"',
     re.M,
 )
 
 #: A diagram comments with `%%`, not with `<!-- -->`. A comment line must never yield a destination
 #: even when it quotes a whole directive (FR-056) -- and that case is real, not hypothetical.
-_MERMAID_COMMENT_RE = re.compile(r"^[ \t]*%%")
+# No `^`: this is used as `.match(body, line_start)`, which already anchors AT that position,
+# and `^` without re.M only ever matches at index 0 of the string. With it, the guard was
+# unreachable except for a comment on the very first line of a region -- which is why its
+# test passed while testing nothing.
+_MERMAID_COMMENT_RE = re.compile(r"[ \t]*%%")
 
 
 def mermaid_region_bodies(content: str) -> List[Span]:

--- a/src/darnlink/links.py
+++ b/src/darnlink/links.py
@@ -243,22 +243,21 @@ def code_spans(content: str) -> List[Span]:
 # "traditional, auditable algorithm a human can verify" the constitution asks for (Principle IV).
 
 
-def _split_statements(line: str) -> List[Tuple[int, str]]:
-    """`(offset within the line, text)` for each `;`-separated statement.
+def _statement_starts(line: str) -> List[int]:
+    """Offsets within the line where a statement may begin: the start, and after each `;`.
 
-    Quote-aware on purpose: a destination may legitimately contain `;`
-    (`click A "http://x/y;z"`), and a naive split would cut it in half and then discard it for
-    having an unterminated quote -- turning a working link into a silently unwatched one."""
-    out: List[Tuple[int, str]] = []
-    start = 0
-    in_quotes = False
-    for i, ch in enumerate(line):
-        if ch == '"':
-            in_quotes = not in_quotes
-        elif ch == ";" and not in_quotes:
-            out.append((start, line[start:i]))
-            start = i + 1
-    out.append((start, line[start:]))
+    ⚠️ NO quote tracking, and that is the fix for a regression this file already had. Carrying a
+    running "am I inside quotes" flag across a whole physical line means one stray or unpaired quote
+    -- a typo in a node label, a half-pasted destination -- silently swallows every statement after
+    it, including well-formed `click` directives. A destination dying unnoticed because of an
+    unrelated typo earlier on the line is precisely the harm this feature exists to prevent.
+
+    Nothing is lost by dropping it: a destination containing `;` still survives, because the
+    destination is delimited by its own quotes in `_click_destination`, which searches forward for
+    the closing one and does not care about separators. An offset that is not the start of a
+    directive simply fails to parse and is discarded."""
+    out = [0]
+    out.extend(i + 1 for i, ch in enumerate(line) if ch == ";")
     return out
 
 
@@ -327,7 +326,8 @@ def mermaid_click_destinations(content: str) -> List[Tuple[int, str]]:
             if line.lstrip(" \t").startswith("%%"):
                 line_start += len(line)
                 continue
-            for offset, statement in _split_statements(line):
+            for offset in _statement_starts(line):
+                statement = line[offset:]
                 dest = _click_destination(statement)
                 if dest is not None:
                     lead = len(statement) - len(statement.lstrip(" \t"))

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -31,7 +31,8 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 from .frontmatter_index import read_frontmatter_uuid
-from .links import MD_LINK_RE, Span, _in_spans, code_spans, ignored_spans
+from .links import (MD_LINK_RE, Span, _in_spans, code_spans, ignored_spans,
+                    mermaid_click_destinations)
 
 # A web anchor is DELIBERATELY marked `web-uuid` (not the core's `uuid`): the destination uuid lives
 # in ANOTHER repo, so the core's intra-repo repair/robustify — which keys on `<!-- uuid: X -->` — must
@@ -131,9 +132,29 @@ class WebLink:
     start: int
     end: int
     exempt: bool = False  # FR-011: carries <!-- darnlink-own-exempt -->
+    #: FR-060 -- recognised inside a diagram, where the anchor comment would be a NODE, not a
+    #: comment. A property of the item and not an argument of the caller: a rule the call site
+    #: must remember is a rule that disappears the day someone adds a second call site.
+    report_only: bool = False
 
 
-def find_web_links(content: str, ignore: Sequence[Span] = ()) -> List[WebLink]:
+def find_mermaid_web_links(content: str) -> List[WebLink]:
+    """Destinations carried by a diagram's `click` directives, in the shape the axis already
+    consumes (research R3), so classification, exit codes and feature 016's own-repo rule apply
+    with no special case downstream.
+
+    `text` is empty and `end == start`: a directive has no link text and nothing may ever be
+    written over it. Every item is `report_only` (FR-060)."""
+    out: List[WebLink] = []
+    for offset, dest in mermaid_click_destinations(content):
+        if not dest.strip().lower().startswith(("http://", "https://")):
+            continue  # relative destinations inside a diagram: measured zero, out of scope
+        out.append(WebLink("", dest, None, offset, offset, False, report_only=True))
+    return out
+
+
+def find_web_links(content: str, ignore: Sequence[Span] = (),
+                   include_mermaid: bool = False) -> List[WebLink]:
     """All Markdown links whose href is an http(s) URL, in document order, skipping `ignore` spans.
     A trailing `<!-- web-uuid: owner/repo#X -->` marks the link as already anchored (its uuid is captured)."""
     out: List[WebLink] = []
@@ -150,6 +171,11 @@ def find_web_links(content: str, ignore: Sequence[Span] = ()) -> List[WebLink]:
         # deliberately does NOT cover it, so an exempt link that is ever rewritten keeps its marker.
         exempt = _TRAILING_OWN_EXEMPT_RE.match(content, end) is not None
         out.append(WebLink(m["text"], href, uuid, m.start(), end, exempt))
+    if include_mermaid:
+        # Lifting the fence exclusion alone would find NOTHING: this scan looks for Markdown link
+        # syntax, and a `click` directive is not that. The item has to be produced (research R3).
+        out.extend(find_mermaid_web_links(content))
+        out.sort(key=lambda w: w.start)
     return out
 
 
@@ -344,6 +370,16 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
         # `--own` would let `--write` rewrite the very files it was placed to protect.
         return WebFinding("web_own_exempt", f, link.href,
                           "carries <!-- darnlink-own-exempt -->; never anchored, never called stale")
+    if link.report_only:
+        # FR-060. The guard lives HERE, where the condition for writing is decided, and not in the
+        # loop that happens to call this today: `web_anchor` is the only kind that produces an edit,
+        # so never assigning it makes a corrupted diagram unreachable from ANY caller, present or
+        # future. The destination is still watched -- 404 and mismatch were decided above, and a dead
+        # link inside a drawing is exactly what this feature exists to surface.
+        return WebFinding("web_ok", f, link.href,
+                          "destination reachable; inside a diagram, so never anchored — a diagram "
+                          "comments with %% and the anchor is an HTML comment, which would render "
+                          "as a node")
     if link.uuid is None:
         # plain web link -> anchor it if the destination has a uuid
         if dest_uuid:
@@ -384,6 +420,7 @@ def check_web_links_online(
     excludes: Optional[set] = None,
     owners: frozenset = frozenset(),
     out_of_root: Optional[List[Path]] = None,
+    include_mermaid: bool = False,
 ) -> Tuple[List[WebFinding], Dict[Path, str]]:
     """Fetch each web link's destination (once, cached per URL) and classify it. Returns the findings
     and the per-file rewritten content for any `web_anchor` (the caller writes it only under --write).
@@ -415,7 +452,7 @@ def check_web_links_online(
         # reader. `--ignore-block` is out of this and unchanged (FR-015).
         filtered = file_is_ignored(content) or file_ignores_links(content)
         ignore = ignored_spans(content, block_markers) + code_spans(content)
-        links = find_web_links(content, ignore)
+        links = find_web_links(content, ignore, include_mermaid=include_mermaid)
         if not links:
             continue
         pieces: List[str] = []

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -157,7 +157,7 @@ def find_mermaid_web_links(content: str, ignore: Sequence[Span] = ()) -> List[We
 
 def find_web_links(content: str, ignore: Sequence[Span] = (),
                    include_mermaid: bool = False,
-                   block_spans: Sequence[Span] = ()) -> List[WebLink]:
+                   block_spans: Optional[Sequence[Span]] = None) -> List[WebLink]:
     """All Markdown links whose href is an http(s) URL, in document order, skipping `ignore` spans.
     A trailing `<!-- web-uuid: owner/repo#X -->` marks the link as already anchored (its uuid is captured)."""
     out: List[WebLink] = []
@@ -175,6 +175,19 @@ def find_web_links(content: str, ignore: Sequence[Span] = (),
         exempt = _TRAILING_OWN_EXEMPT_RE.match(content, end) is not None
         out.append(WebLink(m["text"], href, uuid, m.start(), end, exempt))
     if include_mermaid:
+        if block_spans is None:
+            # NOT a default of `()`. A permissive default is how the original defect got in: the
+            # mermaid path silently skipped `--ignore-block` and nothing complained. A caller that
+            # has no ignore-blocks says so by passing `()`; one that forgot gets this, loudly,
+            # instead of a quiet regression that only shows up as a user's ignored diagram being
+            # reported anyway. Same reasoning as FR-060 making `report_only` a property of the item
+            # rather than something a caller must remember.
+            raise ValueError(
+                "find_web_links(include_mermaid=True) needs block_spans: pass the --ignore-block "
+                "regions (ignored_spans(content, markers)), or () to state there are none. Do NOT "
+                "pass the merged `ignore` list -- mermaid destinations live inside code spans by "
+                "construction, so it would discard every one of them."
+            )
         # Lifting the fence exclusion alone would find NOTHING: this scan looks for Markdown link
         # syntax, and a `click` directive is not that. The item has to be produced (research R3).
         #

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -138,7 +138,7 @@ class WebLink:
     report_only: bool = False
 
 
-def find_mermaid_web_links(content: str) -> List[WebLink]:
+def find_mermaid_web_links(content: str, ignore: Sequence[Span] = ()) -> List[WebLink]:
     """Destinations carried by a diagram's `click` directives, in the shape the axis already
     consumes (research R3), so classification, exit codes and feature 016's own-repo rule apply
     with no special case downstream.
@@ -149,12 +149,15 @@ def find_mermaid_web_links(content: str) -> List[WebLink]:
     for offset, dest in mermaid_click_destinations(content):
         if not dest.strip().lower().startswith(("http://", "https://")):
             continue  # relative destinations inside a diagram: measured zero, out of scope
+        if _in_spans(offset, ignore):
+            continue  # FR-058: composes with --ignore-block, like every other link
         out.append(WebLink("", dest, None, offset, offset, False, report_only=True))
     return out
 
 
 def find_web_links(content: str, ignore: Sequence[Span] = (),
-                   include_mermaid: bool = False) -> List[WebLink]:
+                   include_mermaid: bool = False,
+                   block_spans: Sequence[Span] = ()) -> List[WebLink]:
     """All Markdown links whose href is an http(s) URL, in document order, skipping `ignore` spans.
     A trailing `<!-- web-uuid: owner/repo#X -->` marks the link as already anchored (its uuid is captured)."""
     out: List[WebLink] = []
@@ -174,7 +177,13 @@ def find_web_links(content: str, ignore: Sequence[Span] = (),
     if include_mermaid:
         # Lifting the fence exclusion alone would find NOTHING: this scan looks for Markdown link
         # syntax, and a `click` directive is not that. The item has to be produced (research R3).
-        out.extend(find_mermaid_web_links(content))
+        #
+        # ⚠️ `block_spans`, NOT `ignore`, and the distinction is load-bearing rather than fussy:
+        # `ignore` is `--ignore-block` regions PLUS code regions, and a mermaid destination lives
+        # inside a code region BY CONSTRUCTION -- filtering by the merged list would discard every
+        # one of them. `block_spans` carries only what the user asked to ignore, which is what
+        # FR-058 says this must compose with.
+        out.extend(find_mermaid_web_links(content, block_spans))
         out.sort(key=lambda w: w.start)
     return out
 
@@ -451,8 +460,9 @@ def check_web_links_online(
         # semantics than the core's "removed from the graph entirely", declared rather than left to the
         # reader. `--ignore-block` is out of this and unchanged (FR-015).
         filtered = file_is_ignored(content) or file_ignores_links(content)
-        ignore = ignored_spans(content, block_markers) + code_spans(content)
-        links = find_web_links(content, ignore, include_mermaid=include_mermaid)
+        blocks = ignored_spans(content, block_markers)
+        ignore = blocks + code_spans(content)
+        links = find_web_links(content, ignore, include_mermaid=include_mermaid, block_spans=blocks)
         if not links:
             continue
         pieces: List[str] = []

--- a/tests/test_mermaid_web_links.py
+++ b/tests/test_mermaid_web_links.py
@@ -520,3 +520,14 @@ def test_href_must_be_a_word_of_its_own():
     silently accept a shape mermaid does not define."""
     content = '```mermaid\nflowchart TD\n  click A href"http://x.example"\n```\n'
     assert mermaid_click_destinations(content) == []
+
+
+def test_the_phantom_is_blocked_even_when_it_is_not_the_first_directive_on_the_line():
+    """Round 5 found the round-4 test was pinned at offset 0, where the consumed span happens to
+    equal its own end -- so an off-by-origin in that arithmetic was indistinguishable. Putting a
+    healthy directive first makes the two forms diverge, and the phantom reappears if it is wrong."""
+    content = ('```mermaid\nflowchart TD\n'
+               '  click Z "http://z.example" _blank; '
+               'click A "http://ok.example; click B "http://evil.example""\n```\n')
+    assert [d for _, d in mermaid_click_destinations(content)] == \
+        ["http://z.example", "http://ok.example; click B "]

--- a/tests/test_mermaid_web_links.py
+++ b/tests/test_mermaid_web_links.py
@@ -1,0 +1,349 @@
+"""Feature 017: the READ axis can see the destinations carried by a diagram's `click` directives.
+
+Written before the implementation (constitution, Principle V). Network is never touched: every
+online test injects a fake fetcher, like feature 013's tests.
+
+The three things these tests exist to prove, in order of how easy they are to get wrong:
+
+1. **The seeded defect is caught.** A blind check and a working one produce identical output on a
+   healthy tree -- which is exactly how this class of link went unwatched. So the fixture is broken
+   on purpose, and the flag-off run is asserted alongside the flag-on run: if the two ever agree,
+   the feature is not wired and a green suite is a false pass (SC-019).
+2. **Nothing is ever written into a diagram.** The read axis is not read-only: in its writing mode
+   it anchors a link with a trailing HTML comment. A diagram comments with `%%`, so an HTML comment
+   there is a *node*, not a comment -- writing one corrupts the drawing (FR-060, SC-023).
+3. **That protection does not live in the caller.** A rule the call site must remember is a rule
+   that disappears the day someone adds a second call site -- which is how this feature came to
+   exist in the first place.
+"""
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from darnlink.cli import main
+from darnlink.links import code_spans, mermaid_click_destinations, mermaid_region_bodies
+from darnlink.weblinks import (GithubUrl, WebLink, _classify, check_web_links_online,
+                               find_mermaid_web_links, find_web_links)
+
+UUID = "3f9c1a2b-4d5e-6f70-8192-a3b4c5d6e7f8"
+OWNER, REPO = "example-org", "handbook"
+LIVE = f"https://github.com/{OWNER}/{REPO}/blob/main/docs/alive.md"
+DEAD = f"https://github.com/{OWNER}/{REPO}/blob/main/docs/moved-away.md"
+
+
+def _w(p: Path, text: str) -> None:
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def _checksums(root: Path):
+    return {p: hashlib.sha1(p.read_bytes()).hexdigest() for p in sorted(root.rglob("*.md"))}
+
+
+def _fetcher(responses):
+    def f(gu: GithubUrl, token):
+        return responses.get(f"https://github.com/{gu.owner}/{gu.repo}/blob/{gu.ref}/{gu.path}",
+                             (404, None))
+    return f
+
+
+#: The fixture diagram. Four directives, and only ONE of them is a finding:
+#: the control (live), the seeded defect (dead), a comment line that contains a whole directive,
+#: and a callback binding that carries no destination at all.
+DIAGRAM = f"""# A drawing
+
+```mermaid
+flowchart TD
+  A["alive"] --> B["gone"]
+  %% click Z href "{DEAD}" _blank   <- a comment, not a directive (FR-056)
+  click A href "{LIVE}" _blank
+  click B href "{DEAD}" _blank
+  click A call showTooltip()
+```
+
+Ordinary prose after the drawing.
+"""
+
+
+def _tree(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    _w(root / "diagram.md", DIAGRAM)
+    _w(root / "prose.md",
+       "click the button, then read on. This paragraph starts with the directive word\n"
+       "on purpose and lives outside every fence.\n")
+    _w(root / "example.md",
+       "Showing a diagram as an example:\n\n"
+       "````markdown\n```mermaid\nflowchart TD\n"
+       f'  click Q href "{DEAD}" _blank\n'
+       "```\n````\n")
+    _w(root / "unclosed.md",
+       "# Never closed\n\n```mermaid\nflowchart TD\n"
+       f'  click U href "{DEAD}" _blank\n')
+    return root
+
+
+# --------------------------------------------------------------------------------------------
+# Phase B / T003-T004 -- regions and the recogniser, in isolation
+# --------------------------------------------------------------------------------------------
+
+def test_mermaid_regions_are_a_subset_of_code_regions():
+    """The invariant that keeps FR-015 safe: everything this feature can see is something the
+    write axis was already forbidden to touch. If this ever fails, a second notion of 'fenced
+    block' has crept in (FR-054)."""
+    content = DIAGRAM
+    code = code_spans(content)
+    for start, end in mermaid_region_bodies(content):
+        assert any(cs <= start and end <= ce for cs, ce in code), \
+            "a mermaid region escaped the code regions -- regions are being computed twice"
+
+
+def test_only_mermaid_fences_count():
+    content = "```python\nclick A href \"http://x/y\"\n```\n"
+    assert mermaid_region_bodies(content) == []
+
+
+def test_info_string_with_extra_words_is_still_mermaid():
+    content = '```mermaid title="x"\nclick A href "http://x/y" _blank\n```\n'
+    assert len(mermaid_region_bodies(content)) == 1
+
+
+@pytest.mark.parametrize("line, expected", [
+    ('  click A href "http://x/y" _blank', "http://x/y"),   # the 1961-occurrence shape
+    ('  click A "http://x/y" _blank', "http://x/y"),        # the 147-occurrence shape
+    ('  click A href "http://x/y"', "http://x/y"),          # the 57-occurrence shape
+    ('  click A href "http://x/y" "a tooltip"', "http://x/y"),
+])
+def test_recogniser_accepts_the_three_measured_shapes(line, expected):
+    content = f"```mermaid\nflowchart TD\n{line}\n```\n"
+    assert [d for _, d in mermaid_click_destinations(content)] == [expected]
+
+
+def test_recogniser_reports_absolute_offsets():
+    """The offset must be into the FILE, not into the region body: the report points at a location
+    a human has to be able to find."""
+    content = DIAGRAM
+    for offset, dest in mermaid_click_destinations(content):
+        assert content[offset:offset + 5] == "click"
+        assert dest in content
+
+
+# --------------------------------------------------------------------------------------------
+# Phase D / T011-T014 -- precision. These are the ones that decide whether the gate gets trusted
+# --------------------------------------------------------------------------------------------
+
+def test_comment_line_carrying_a_directive_yields_nothing():
+    """Not hypothetical: a real tree contains a diagram comment whose prose includes the directive
+    word (FR-056)."""
+    content = f'```mermaid\nflowchart TD\n  %% click Z href "{DEAD}" _blank\n```\n'
+    assert mermaid_click_destinations(content) == []
+
+
+def test_callback_binding_yields_nothing():
+    content = "```mermaid\nflowchart TD\n  click A call showTooltip()\n  click B callback\n```\n"
+    assert mermaid_click_destinations(content) == []
+
+
+def test_the_fixture_diagram_yields_exactly_two_destinations():
+    """Four directives in the drawing; the comment and the callback are not destinations."""
+    got = sorted(d for _, d in mermaid_click_destinations(DIAGRAM))
+    assert got == sorted([LIVE, DEAD])
+
+
+def test_prose_beginning_with_the_directive_word_is_unreachable(tmp_path):
+    prose = (tmp_path / "prose.md")
+    _w(prose, "click the button and carry on\n")
+    assert mermaid_click_destinations(prose.read_text()) == []
+
+
+def test_a_diagram_shown_as_an_example_is_never_scanned(tmp_path):
+    """The outer fence wins -- inherited from FR-016, asserted here so a reimplementation would
+    be caught."""
+    content = (tmp_path / "example.md")
+    _w(content, "````markdown\n```mermaid\nflowchart TD\n"
+                f'  click Q href "{DEAD}" _blank\n```\n````\n')
+    assert mermaid_click_destinations(content.read_text()) == []
+
+
+def test_unclosed_fence_runs_to_eof():
+    content = f'# t\n\n```mermaid\nflowchart TD\n  click U href "{LIVE}" _blank\n'
+    assert [d for _, d in mermaid_click_destinations(content)] == [LIVE]
+
+
+def test_tilde_fence_behaves_like_a_backtick_fence():
+    content = f'~~~mermaid\nflowchart TD\n  click U href "{LIVE}" _blank\n~~~\n'
+    assert [d for _, d in mermaid_click_destinations(content)] == [LIVE]
+
+
+# --------------------------------------------------------------------------------------------
+# T015-T018 -- report-only: the property, not the flag
+# --------------------------------------------------------------------------------------------
+
+def test_recognised_items_are_report_only():
+    for link in find_mermaid_web_links(DIAGRAM):
+        assert link.report_only is True
+
+
+def test_ordinary_web_links_are_not_report_only():
+    content = f"A prose link: [alive]({LIVE})\n"
+    for link in find_web_links(content):
+        assert link.report_only is False
+
+
+def test_report_only_survives_the_union():
+    """The union is where a property is most easily dropped: two lists merged, one of them losing
+    what made it special."""
+    content = DIAGRAM + f"\nAnd a prose link: [alive]({LIVE})\n"
+    links = find_web_links(content, code_spans(content), include_mermaid=True)
+    by_flag = {}
+    for link in links:
+        by_flag.setdefault(link.report_only, []).append(link)
+    assert by_flag.get(True), "the diagram destinations lost their property in the union"
+    assert by_flag.get(False), "the prose link was wrongly marked report-only"
+
+
+def test_classify_never_yields_an_anchorable_kind_for_a_report_only_link():
+    """⚠️ The adversarial one (T017). The edit is produced when the classification says
+    `web_anchor`; so the protection must live in the CLASSIFICATION, where the condition for
+    writing is decided -- not in the loop that happens to call it today. Invoked directly,
+    bypassing the normal call site."""
+    link = WebLink(text="", href=LIVE, uuid=None, start=0, end=0, report_only=True)
+    gu = GithubUrl(OWNER, REPO, "main", "docs/alive.md")
+    fnd = _classify(link, gu, 200, UUID, True, Path("diagram.md"), {OWNER.casefold()})
+    assert fnd.kind != "web_anchor", \
+        "a report-only link was classified as anchorable: the edit loop is the only thing " \
+        "standing between this and a corrupted diagram"
+
+
+# --------------------------------------------------------------------------------------------
+# T005-T010, T019 -- end to end
+# --------------------------------------------------------------------------------------------
+
+def _responses():
+    return {LIVE: (200, f"---\nuuid: {UUID}\n---\n# alive\n")}   # DEAD is absent -> 404
+
+
+def test_seeded_defect_is_caught_with_the_flag_on(tmp_path):
+    """SC-019. The fixture is broken on purpose; a clean tree would prove nothing.
+
+    A token is passed on purpose: without one a 404 is AMBIGUOUS (it could be a private repo the
+    run cannot see), so darnlink honestly refuses to call the link broken. That is why the fleet's
+    pre-push hook derives a token from `gh` before running this axis -- and why a test that omits
+    it would be asserting the wrong thing."""
+    root = _tree(tmp_path)
+    findings, _ = check_web_links_online(root, "tok", _fetcher(_responses()), (),
+                                         owners={OWNER.casefold()}, include_mermaid=True)
+    hrefs = {f.href for f in findings if f.kind in ("web_not_found", "web_mismatch")}
+    assert DEAD in hrefs
+    assert LIVE not in hrefs
+
+
+def test_the_same_defect_is_invisible_with_the_flag_off(tmp_path):
+    """The other half of SC-019. If this ever agrees with the test above, the feature is not
+    wired and the suite is green for the wrong reason."""
+    root = _tree(tmp_path)
+    findings, _ = check_web_links_online(root, None, _fetcher(_responses()), (),
+                                         owners={OWNER.casefold()})
+    assert DEAD not in {f.href for f in findings}
+
+
+def test_disabled_is_byte_identical_in_output_and_exit_code(tmp_path, capsys):
+    """SC-018 -- what makes this safe to ship into gates that have not opted in."""
+    root = _tree(tmp_path)
+    rc = main(["web-check", str(root), "--json"])
+    first = capsys.readouterr().out
+    rc2 = main(["web-check", str(root), "--json"])
+    assert (rc, first) == (rc2, capsys.readouterr().out)
+    assert DEAD not in first
+
+
+def test_writing_mode_writes_nothing_when_the_only_candidates_are_in_a_diagram(tmp_path):
+    """SC-023. A single byte of difference here is a corrupted drawing."""
+    root = tmp_path / "repo"
+    _w(root / "diagram.md", DIAGRAM)
+    before = _checksums(root)
+    _findings, edits = check_web_links_online(root, None, _fetcher(_responses()), (),
+                                              owners={OWNER.casefold()}, include_mermaid=True)
+    for path, text in edits.items():
+        path.write_text(text, encoding="utf-8")
+    assert _checksums(root) == before
+    assert edits == {}
+
+
+def test_a_prose_link_is_anchored_while_the_diagram_beside_it_is_untouched(tmp_path):
+    """T016 -- the mixed file. This is the one that fails if report-only is applied per FILE
+    instead of per LINK."""
+    root = tmp_path / "repo"
+    _w(root / "mixed.md", DIAGRAM + f"\nAnd a prose link: [alive]({LIVE})\n")
+    _findings, edits = check_web_links_online(root, None, _fetcher(_responses()), (),
+                                              owners={OWNER.casefold()}, include_mermaid=True)
+    assert edits, "the prose link should still have been anchored"
+    new = next(iter(edits.values()))
+    fence_start = new.index("```mermaid")
+    fence_end = new.index("```", fence_start + 3)
+    assert "web-uuid" not in new[fence_start:fence_end], "an anchor was written inside the drawing"
+    assert "web-uuid" in new[fence_end:]
+
+
+def test_both_entry_points_agree_about_what_exists(tmp_path, capsys):
+    """T007. A tool that reports a broken destination online and denies it offline is worse than
+    no tool: it teaches you not to believe it."""
+    root = _tree(tmp_path)
+    main(["web-check", str(root), "--json", "--include-mermaid"])
+    import json as _json
+    offline = {ln["href"] for ln in _json.loads(capsys.readouterr().out)["links"]}
+    findings, _ = check_web_links_online(root, "tok", _fetcher(_responses()), (),
+                                         owners={OWNER.casefold()}, include_mermaid=True)
+    assert offline == {f.href for f in findings}
+
+
+def test_the_offline_report_says_which_links_can_never_be_anchored(tmp_path, capsys):
+    """T018. The offline listing projects a link to {file, href, anchored} and drops the rest, so
+    a consumer cannot tell 'never anchorable' from 'not anchored yet' -- the same defect, one
+    layer out."""
+    root = _tree(tmp_path)
+    main(["web-check", str(root), "--json", "--include-mermaid"])
+    import json as _json
+    links = _json.loads(capsys.readouterr().out)["links"]
+    diagram_links = [ln for ln in links if ln["href"] in (LIVE, DEAD)]
+    assert diagram_links
+    for ln in diagram_links:
+        assert ln.get("report_only") is True
+
+
+def test_a_repository_without_diagrams_is_unaffected(tmp_path, capsys):
+    """FR-059."""
+    root = tmp_path / "repo"
+    _w(root / "plain.md", f"[alive]({LIVE})\n")
+    main(["web-check", str(root), "--json"])
+    off = capsys.readouterr().out
+    main(["web-check", str(root), "--json", "--include-mermaid"])
+    assert off == capsys.readouterr().out
+
+
+def test_no_fetch_is_attempted_for_a_diagram_destination_when_disabled(tmp_path):
+    """SC-022 -- the traffic half of 'a repository that never opted in is unaffected'."""
+    root = _tree(tmp_path)
+    asked = []
+
+    def counting(gu: GithubUrl, token):
+        asked.append(f"https://github.com/{gu.owner}/{gu.repo}/blob/{gu.ref}/{gu.path}")
+        return _fetcher(_responses())(gu, token)
+
+    check_web_links_online(root, None, counting, (), owners={OWNER.casefold()})
+    assert DEAD not in asked and LIVE not in asked
+
+
+# --------------------------------------------------------------------------------------------
+# T019 -- the write operations are not amended by this feature (FR-053 / FR-015 stands)
+# --------------------------------------------------------------------------------------------
+
+@pytest.mark.parametrize("robustify", [False, True])
+def test_repair_and_robustify_never_touch_a_diagram(tmp_path, robustify):
+    root = tmp_path / "repo"
+    _w(root / "diagram.md", DIAGRAM)
+    _w(root / "target.md", f"---\nuuid: {UUID}\n---\n# target\n")
+    before = _checksums(root)
+    argv = [str(root), "--write"] + (["--robustify"] if robustify else [])
+    main(argv)
+    assert _checksums(root) == before

--- a/tests/test_mermaid_web_links.py
+++ b/tests/test_mermaid_web_links.py
@@ -22,7 +22,8 @@ from pathlib import Path
 import pytest
 
 from darnlink.cli import main
-from darnlink.links import code_spans, mermaid_click_destinations, mermaid_region_bodies
+from darnlink.links import (code_spans, ignored_spans, mermaid_click_destinations,
+                            mermaid_region_bodies)
 from darnlink.weblinks import (GithubUrl, WebLink, _classify, check_web_links_online,
                                find_mermaid_web_links, find_web_links)
 
@@ -347,3 +348,72 @@ def test_repair_and_robustify_never_touch_a_diagram(tmp_path, robustify):
     argv = [str(root), "--write"] + (["--robustify"] if robustify else [])
     main(argv)
     assert _checksums(root) == before
+
+
+# --------------------------------------------------------------------------------------------
+# Found by review, not by me: the four gaps below had no test at all. Three of them would have
+# shipped green.
+# --------------------------------------------------------------------------------------------
+
+IGNORED = f"""# doc
+
+<!-- legacy-start -->
+```mermaid
+flowchart TD
+  click A href "{DEAD}" _blank
+```
+<!-- legacy-end -->
+"""
+
+
+def test_a_diagram_inside_an_ignore_block_is_not_reported():
+    """FR-058 -- composes with `--ignore-block`, like every other link.
+
+    This is the one the review caught, and it was a real spec violation: the recogniser was handed
+    the raw file and never consulted the ignore spans at all. A user who wrapped a diagram in an
+    ignore-block and asked for it to be ignored got it reported anyway."""
+    blocks = ignored_spans(IGNORED, ("legacy",))
+    ignore = blocks + code_spans(IGNORED)
+    assert find_web_links(IGNORED, ignore, include_mermaid=True, block_spans=blocks) == []
+
+
+def test_the_same_diagram_IS_reported_without_the_marker():
+    """The other half: without `--ignore-block legacy` the destination must still be seen. A filter
+    that hides everything would pass the test above and be useless."""
+    ignore = ignored_spans(IGNORED, ()) + code_spans(IGNORED)
+    got = find_web_links(IGNORED, ignore, include_mermaid=True, block_spans=ignored_spans(IGNORED, ()))
+    assert [w.href for w in got] == [DEAD]
+
+
+def test_ignore_block_is_honoured_by_the_offline_entry_point_too(tmp_path, capsys):
+    """Both entry points build their ignore spans separately, so both could drift separately."""
+    root = tmp_path / "repo"
+    _w(root / "d.md", IGNORED)
+    main(["web-check", str(root), "--json", "--include-mermaid", "--ignore-block", "legacy"])
+    import json as _json
+    assert _json.loads(capsys.readouterr().out)["links"] == []
+
+
+def test_directives_chained_with_a_semicolon_are_all_found():
+    """A diagram may put several statements on one physical line. Anchoring only to the line start
+    found the first and silently dropped the rest -- a false negative in a feature whose entire
+    purpose is that destinations stop dying unnoticed."""
+    content = ('```mermaid\nflowchart TD\n'
+               '  click A "http://a.example" _blank; click B "http://b.example" _blank\n```\n')
+    assert [d for _, d in mermaid_click_destinations(content)] == \
+        ["http://a.example", "http://b.example"]
+
+
+def test_a_comment_line_with_a_chained_directive_still_yields_nothing():
+    """The comment guard is only reachable NOW: while the pattern anchored to the line start, a
+    `%%` line could never match it, so the guard was dead code and its test passed for an unrelated
+    reason. This is the case that actually exercises it (FR-056)."""
+    content = f'```mermaid\nflowchart TD\n  %% note; click Z href "{DEAD}" _blank\n```\n'
+    assert mermaid_click_destinations(content) == []
+
+
+def test_a_relative_destination_inside_a_diagram_is_not_reported():
+    """Out of scope by measurement (zero occurrences), and until now nothing pinned it: removing the
+    filter broke no test."""
+    content = '```mermaid\nflowchart TD\n  click A href "../src/report.py" _blank\n```\n'
+    assert find_mermaid_web_links(content) == []

--- a/tests/test_mermaid_web_links.py
+++ b/tests/test_mermaid_web_links.py
@@ -424,9 +424,10 @@ def test_a_relative_destination_inside_a_diagram_is_not_reported():
 # --------------------------------------------------------------------------------------------
 
 def test_a_semicolon_inside_the_destination_does_not_split_it():
-    """Statement splitting is quote-aware. A naive split would cut this destination in half and then
-    drop it for having an unterminated quote -- a working link turned silently unwatched, which is
-    the exact harm this feature exists to prevent."""
+    """A destination is delimited by its own quotes, so a `;` inside it is just a character. Nothing
+    tracks quotes across statements -- an earlier attempt did, and that is what silently swallowed
+    later directives. The protection here is that a directive's consumed span is skipped, not that
+    the splitter understands quoting."""
     content = '```mermaid\nflowchart TD\n  click A "http://x/y;z" _blank\n```\n'
     assert [d for _, d in mermaid_click_destinations(content)] == ["http://x/y;z"]
 
@@ -481,4 +482,41 @@ def test_a_word_merely_starting_with_the_directive_is_not_the_directive(word):
     no test, because the one negative case that existed failed downstream for an unrelated reason.
     A guard nothing tests is a guard that comes back the day someone edits around it."""
     content = f'```mermaid\nflowchart TD\n  {word} "http://evil.example"\n```\n'
+    assert mermaid_click_destinations(content) == []
+
+
+# --------------------------------------------------------------------------------------------
+# Round 4 of review: a phantom destination, and three guards that no mutation could kill
+# --------------------------------------------------------------------------------------------
+
+def test_a_quote_embedded_after_a_semicolon_does_not_fabricate_a_second_destination():
+    """A `;` inside a destination is not the start of anything. Before the consumed span was
+    skipped, ONE directive produced TWO destinations and the second was invented out of text that
+    lived inside the first one's quotes -- this feature fabricating a link, which is the mirror of
+    the harm it exists to prevent."""
+    content = ('```mermaid\nflowchart TD\n'
+               '  click A "http://ok.example; click B "http://evil.example""\n```\n')
+    assert [d for _, d in mermaid_click_destinations(content)] == \
+        ["http://ok.example; click B "]
+
+
+def test_a_callback_with_a_string_argument_is_not_a_destination():
+    """`click A call myFunc("hello")` is ordinary mermaid. The guard that requires a quote right
+    where a destination would start is what rejects it -- and nothing exercised that guard, so
+    removing it fabricated the destination `all myFunc(`."""
+    content = '```mermaid\nflowchart TD\n  click A call myFunc("hello")\n```\n'
+    assert mermaid_click_destinations(content) == []
+
+
+def test_a_statement_that_is_not_the_directive_at_all_yields_nothing():
+    """Protects the outermost guard: without it, any statement with a quoted argument would be read
+    as a directive."""
+    content = '```mermaid\nflowchart TD\n  xxxxx href "http://evil.example"\n```\n'
+    assert mermaid_click_destinations(content) == []
+
+
+def test_href_must_be_a_word_of_its_own():
+    """`href` glued to the quote is not the keyword; without the whitespace check the parser would
+    silently accept a shape mermaid does not define."""
+    content = '```mermaid\nflowchart TD\n  click A href"http://x.example"\n```\n'
     assert mermaid_click_destinations(content) == []

--- a/tests/test_mermaid_web_links.py
+++ b/tests/test_mermaid_web_links.py
@@ -452,3 +452,33 @@ def test_stating_there_are_no_ignore_blocks_is_allowed():
     """`()` is a statement, not an omission: the caller says it has none, and gets the links."""
     got = find_web_links(DIAGRAM, code_spans(DIAGRAM), include_mermaid=True, block_spans=())
     assert sorted(w.href for w in got) == sorted([LIVE, DEAD])
+
+
+# --------------------------------------------------------------------------------------------
+# Round 3 of review: a regression the rewrite introduced, and a guard nothing exercised
+# --------------------------------------------------------------------------------------------
+
+def test_a_stray_quote_earlier_on_the_line_does_not_swallow_a_later_directive():
+    """The rewrite carried a running 'inside quotes' flag across the whole physical line, so one
+    unpaired quote -- a typo in a label, a half-pasted destination -- silently discarded every
+    statement after it. A destination dying unnoticed because of an unrelated typo is the exact
+    harm this feature exists to prevent, and the previous implementation did not have it."""
+    content = ('```mermaid\nflowchart TD\n'
+               '  x "unterminated; click A "http://ok.example"\n```\n')
+    assert [d for _, d in mermaid_click_destinations(content)] == ["http://ok.example"]
+
+
+def test_a_malformed_middle_statement_does_not_hide_the_ones_after_it():
+    content = ('```mermaid\nflowchart TD\n'
+               '  click A "http://one.example"; broken "unterm; click B "http://two.example"\n```\n')
+    assert [d for _, d in mermaid_click_destinations(content)] == \
+        ["http://one.example", "http://two.example"]
+
+
+@pytest.mark.parametrize("word", ["clickX", "clickedBy", "clickable"])
+def test_a_word_merely_starting_with_the_directive_is_not_the_directive(word):
+    """The guard that requires whitespace after `click` was never exercised: mutating it away broke
+    no test, because the one negative case that existed failed downstream for an unrelated reason.
+    A guard nothing tests is a guard that comes back the day someone edits around it."""
+    content = f'```mermaid\nflowchart TD\n  {word} "http://evil.example"\n```\n'
+    assert mermaid_click_destinations(content) == []

--- a/tests/test_mermaid_web_links.py
+++ b/tests/test_mermaid_web_links.py
@@ -195,7 +195,7 @@ def test_report_only_survives_the_union():
     """The union is where a property is most easily dropped: two lists merged, one of them losing
     what made it special."""
     content = DIAGRAM + f"\nAnd a prose link: [alive]({LIVE})\n"
-    links = find_web_links(content, code_spans(content), include_mermaid=True)
+    links = find_web_links(content, code_spans(content), include_mermaid=True, block_spans=())
     by_flag = {}
     for link in links:
         by_flag.setdefault(link.report_only, []).append(link)
@@ -417,3 +417,38 @@ def test_a_relative_destination_inside_a_diagram_is_not_reported():
     filter broke no test."""
     content = '```mermaid\nflowchart TD\n  click A href "../src/report.py" _blank\n```\n'
     assert find_mermaid_web_links(content) == []
+
+
+# --------------------------------------------------------------------------------------------
+# Round 2 of review, and the rewrite that followed it
+# --------------------------------------------------------------------------------------------
+
+def test_a_semicolon_inside_the_destination_does_not_split_it():
+    """Statement splitting is quote-aware. A naive split would cut this destination in half and then
+    drop it for having an unterminated quote -- a working link turned silently unwatched, which is
+    the exact harm this feature exists to prevent."""
+    content = '```mermaid\nflowchart TD\n  click A "http://x/y;z" _blank\n```\n'
+    assert [d for _, d in mermaid_click_destinations(content)] == ["http://x/y;z"]
+
+
+def test_a_word_beginning_with_click_is_not_the_directive():
+    content = '```mermaid\nflowchart TD\n  clickable A "http://x/y" _blank\n```\n'
+    assert mermaid_click_destinations(content) == []
+
+
+def test_an_unterminated_quote_yields_nothing():
+    content = '```mermaid\nflowchart TD\n  click A "http://x/y _blank\n```\n'
+    assert mermaid_click_destinations(content) == []
+
+
+def test_forgetting_the_ignore_block_regions_is_an_error_not_a_silent_pass():
+    """The default is deliberately absent rather than permissive. A third call-site that forgot this
+    would reintroduce the exact defect review caught -- silently. Now it cannot."""
+    with pytest.raises(ValueError, match="block_spans"):
+        find_web_links(DIAGRAM, code_spans(DIAGRAM), include_mermaid=True)
+
+
+def test_stating_there_are_no_ignore_blocks_is_allowed():
+    """`()` is a statement, not an omission: the caller says it has none, and gets the links."""
+    got = find_web_links(DIAGRAM, code_spans(DIAGRAM), include_mermaid=True, block_spans=())
+    assert sorted(w.href for w in got) == sorted([LIVE, DEAD])

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -44,6 +44,7 @@ _LEAKY_ENV = (
     "DARNLINK_GATE_WEB", "DARNLINK_GATE_CREATE_README", "DARNLINK_GATE_TOKEN_FILE",
     "DARNLINK_GATE_DANGLING", "DARNLINK_GATE_DANGLING_MAX",
     "DARNLINK_GATE_OWN_WEB_FROM_ORIGIN", "DARNLINK_GATE_OWN_WEB_MAX",
+    "DARNLINK_GATE_INCLUDE_MERMAID",
     # ⚠️ And git's own. `git` exports these to every hook it runs, so when this suite is executed
     # FROM the repo's pre-commit hook (`tools/check.sh`), an un-scrubbed `git` in a test inherits
     # GIT_DIR from the outer repo while using the sandbox as its work tree. That combination is not


### PR DESCRIPTION
## The gap

A diagram carries its destinations in `click` directives, which live inside a fenced block. Feature 002 hides those from **every** axis, including the read-only ones — so this is a class of link that no gate has ever watched. It dies the moment a file moves, silently, while the tree stays green.

Measured on a real tree: **one folder reorganisation killed 14 of a diagram's destinations at once**, and nothing noticed. They had to be found by hand.

## What this does, and what it deliberately does not

- The **read** axes (online check and offline listing) can see those destinations. **Off by default**, opt-in per repository via `--include-mermaid` / the `include_mermaid` recipe key.
- **FR-015 is not amended.** Repair and robustify still ignore every link inside every fence. This is the read axis only.
- The destinations are **report-only and never anchored** (FR-060). The anchor is a trailing HTML comment, and a diagram treats that as a node rather than a comment, so writing one would corrupt the drawing. A diagram destination that stays plain forever is a normal state, not a defect. The guard lives in the classification, where the condition for writing is decided — so a corrupted diagram is unreachable from any caller, present or future.

## No new dependency

The destination grammar was measured over **2,165 real directives** and reduces to three single-line shapes. It is read by a plain line reader; the fenced-region computation is reused rather than reimplemented, so unclosed fences, tilde fences and nested example fences are inherited from FR-016.

A grammar engine and a Markdown library were both evaluated and rejected: the measured language is regular and one-line, and either dependency would breach *standard library + python-frontmatter only*. A JavaScript parser was rejected outright — it would also breach *Distribution*, and the machine this was measured on has no JavaScript runtime at all.

## Review

Copilot could not review this repo (quota), so this went through **five rounds of independent review**, which found **eight defects** — including two silent ones, and twice a defect introduced by the previous round's own fix:

| Round | Found |
|---|---|
| 1 | **Blocking**: mermaid destinations ignored `--ignore-block`, violating this feature's own FR-058 |
| 2 | A parameter with a silently permissive default that could reintroduce round 1 |
| 3 | A silent **false negative**: line-wide quote state swallowed later directives |
| 4 | Its mirror — a **fabricated** second destination — plus three guards no mutation could kill |
| 5 | **Clean.** One coverage gap, closed |

Round 5 reimplemented all four historical versions of the recogniser and compared them over 525 inputs: the current one is **byte-for-byte identical to the original**, with only the two intended differences. Offset arithmetic verified over ~5,000 findings. Of 22 mutants, 20 died; one survivor was proven equivalent and the other is now dead.

## Verification

**478 tests pass** (427 on `main`), on Python 3.10, 3.11, 3.12 and 3.13. `tools/check.sh` green. Packaged build via `uvx` green. On a real tree it surfaces **61 destinations that were invisible before**.

## Not verified locally

- `ps1-syntax` — no PowerShell on the machine this was built on, and this PR **modifies** that file. Its structure was cloned from the adjacent block CI already parses, but that is high confidence, not proof. **Look at this check first.**
- The privacy gate — its denylist is a secret by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)