### PR TITLE
Windows: config LIST values arrive with a stray CR, and only the ones in the middle

### DIFF
--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -150,6 +150,14 @@ fi
 # --- read config (JSON, all optional) via python; env wins over file ---
 read_cfg() { python3 - "$cfg" "$1" "$2" <<'PY' 2>/dev/null || printf '%s' "$2"
 import json, sys
+# ⚠️ En Windows, `print()` traduce cada \n a \r\n, y esta salida la consume el SHELL. Con UN valor
+# no se nota: `$(...)` se come el salto final junto con su \r. Con una LISTA si: el separador queda
+# como \r\n, bash parte por \n (IFS no incluye \r) y **todos los elementos menos el ultimo** llegan
+# con un \r pegado -> `--exclude worktrees\r`, que no casa con nada y el excluido deja de excluirse.
+#
+# Esa forma -- N-1 de N -- es lo que lo hacia invisible: con un solo `exclude` funciona, y el ULTIMO
+# siempre funciona, asi que la comprobacion casual pasa y el fallo solo aparece al anadir el segundo.
+sys.stdout.reconfigure(newline="\n")
 cfg, key, default = sys.argv[1], sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else ""
 try:
     d = json.load(open(cfg, encoding="utf-8-sig"))   # -sig: reads plain UTF-8 identically, but
@@ -167,6 +175,7 @@ PY
 # the length separately instead of trying to infer it from the flattened value.
 read_cfg_len() { python3 - "$cfg" "$1" <<'PY' 2>/dev/null || printf '0'
 import json, sys
+sys.stdout.reconfigure(newline="\n")   # mismo motivo que read_cfg: aqui el \r rompe la ARITMETICA
 try:
     d = json.load(open(sys.argv[1], encoding="utf-8-sig"))   # -sig: same reason as read_cfg above
 except Exception:


### PR DESCRIPTION
On Windows, `print()` translates every `\n` to `\r\n`. `recipes/darnlink-gate` reads its JSON config
through a `python3 -` heredoc whose output is consumed **by the shell** — so every config value that
crosses that boundary can arrive with a stray `\r`.

## The real shape is worse than "a `\r` on every value"

Measured on a Windows machine over ssh, not reasoned:

```
$ v=$(python3 -c "print('worktrees')")
  w o r k t r e e s                      <- CLEAN: $(...) eats the trailing newline with its \r

$ v=$(python3 -c "print('\n'.join(['worktrees','clones','.venv']))")
  w o r k t r e e s \r \n c l o n e s \r \n . v e n v
$ while IFS= read -r x; do ...; done <<< "$v"
  worktrees \r        <- carries it
  clones    \r        <- carries it
  .venv               <- clean
```

**Single values are fine. In a list, the first N-1 carry a `\r` and the last one does not.**

For `--exclude` that yields `--exclude worktrees\r`, which matches nothing — the excluded path
silently stops being excluded. Reported from a Windows box: **275 dangling links and a blocked
push**, against **0** with the fix.

### Why it stayed invisible

That N-1-of-N shape is exactly what defeats a casual check:

- with a **single** `exclude`, it works;
- the **last** entry always works;

so the bug only appears when you add the second entry, and the obvious "does exclude work?" test
passes. It fails green.

## `read_cfg_len` has the same cause and a worse effect

It prints a **number**. A trailing `\r` there does not produce a strange value — it makes bash's
arithmetic comparison **error out**.

## Scope

- `recipes/darnlink-gate` only, two heredocs, one line each: `sys.stdout.reconfigure(newline="\n")`.
- `recipes/darnlink-gate.ps1` is **not** affected: it reads the JSON with `ConvertFrom-Json` and
  never round-trips through the shell.
- But git hooks on Windows run under `sh`, so the recipe a hook actually invokes is the bash one —
  which is why this path matters even though a PowerShell variant exists.

## What this does NOT cover

- **No regression test.** The failure only reproduces under a Windows text-mode stdout; asserting it
  on Linux would require faking the translation, which would test the fake and not the mechanism.
  The measurement above is from a real Windows machine and is quoted in the commit message.
- The other two `python3 -` heredocs in the file (the report-formatting ones around lines 330/371)
  are untouched: their output is parsed as JSON, where a stray `\r` is insignificant whitespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
