### PR TITLE
A link pending on the default branch is not a broken link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@ All notable changes to darnlink are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## 0.25.0
+
+### A link pending on the default branch is not a broken link
+
+A `blob/<default-branch>/<path>` URL to a file that exists in the working tree but has not reached
+the default branch yet was classified `web_not_found` -> `exit 4`. In a blocking gate that is a
+**deadlock**: the red blocks the merge that would make the link resolve. Measured in the field as
+`not-found 6` on a branch that could not go green before merging and could not merge while red.
+
+It now becomes `web_unverifiable` — the kind that already existed for "cannot tell from here" —
+under **five** conditions, every one of which closes a way a permanently-dead link walked through
+an earlier draft of this rung, green:
+
+| condition | what it stops forgiving |
+|---|---|
+| the ref IS the default branch | `blob/<sha>/…`, a tag, a deleted branch — none of which any merge resolves |
+| the slug is ASCII and matches `origin` | lookalike hosts; `casefold()` collapses U+212A to `k` |
+| the path is confined to the tree | `blob/main//etc/hostname` escaped it entirely |
+| the destination is a FILE | a directory is served under `/tree/`, so `/blob/<dir>` 404s forever |
+| the destination is TRACKED | a gitignored artefact never reaches the default branch |
+
+The base of the path join is `rev-parse --show-toplevel`, not the scanned directory: scanning a
+subdirectory is supported, and there `<path>` (repo-relative) compared against the wrong tree.
+Percent-encoded paths are decoded, so the rung is not silently inert on `%2B` and `%20`.
+
+Unknown origin, non-GitHub remote or unknown default branch -> the rung is **inert** and behaviour
+is exactly as before. A rung that changed behaviour when it could not identify the repo would be
+worse than no rung.
+
+⚠️ **Consumers pin by SHA**, so merging this changes nothing for them until each `darnlink-gate.json`
+`ref` is bumped.
+
 ## [Unreleased]
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.24.0"
+version = "0.25.0"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -493,9 +493,13 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
 
     token = os.environ.get("GITHUB_TOKEN") or None
     web_out_of_root: List[Path] = []
+    # `own_slug` is what lets us tell "pending on the default branch" from "broken" WITHOUT opening
+    # the door to downgrading someone else's real break: only the repo we are actually in can have
+    # its own working tree consulted about where a `blob/<branch>/...` URL points after a merge.
+    own_slug = _github_slug_from_origin(root)
     findings, edits = check_web_links_online(root, token, fetcher or default_fetcher, block_markers,
                                              excludes, owners, out_of_root=web_out_of_root,
-                                             include_mermaid=args.include_mermaid)
+                                             include_mermaid=args.include_mermaid, own_slug=own_slug)
     ok = [x for x in findings if x.kind == "web_ok"]
     anchors = [x for x in findings if x.kind == "web_anchor"]
     mismatch = [x for x in findings if x.kind == "web_mismatch"]
@@ -639,6 +643,34 @@ def _github_owner_from_origin(root: Path) -> Optional[str]:
                   r"|(?:[^/@]*@)?github\.com:)(?P<owner>[^/]+)/",
                   out.stdout.strip(), _re.IGNORECASE | _re.ASCII)
     return m["owner"] if m else None
+
+
+def _github_slug_from_origin(root: Path) -> Optional[str]:
+    """`owner/repo` of `origin`, or None. Same hardening as its sibling above -- scrubbed git env,
+    ASCII-anchored regex -- because the same two traps apply: a hook's inherited GIT_DIR would answer
+    about the WRONG repository, and IGNORECASE without _re.ASCII folds U+0131 so `gıthub.com/evil`
+    would resolve as GitHub.
+
+    Used to tell "pending on the default branch" from "broken" (see `weblinks._classify`): only the
+    repo we are actually IN can have its own working tree consulted about where a `blob/<branch>/...`
+    URL will point after a merge. For any other repo, a path that happens to exist here says nothing.
+    """
+    import os as _os
+    import re as _re
+    import subprocess
+    env = {k: v for k, v in _os.environ.items()
+           if k not in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR")}
+    try:
+        out = subprocess.run(["git", "-C", str(root), "config", "--get", "remote.origin.url"],
+                             capture_output=True, text=True, timeout=10, env=env)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if out.returncode != 0:
+        return None
+    m = _re.match(r"(?:(?:https?|ssh)://(?:[^/@]*@)?(?:www\.|ssh\.)?github\.com(?::\d+)?/"
+                  r"|(?:[^/@]*@)?github\.com:)(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$",
+                  out.stdout.strip(), _re.IGNORECASE | _re.ASCII)
+    return f"{m['owner']}/{m['repo']}" if m else None
 
 
 def _make_stdio_encoding_safe() -> None:

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -493,13 +493,13 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
 
     token = os.environ.get("GITHUB_TOKEN") or None
     web_out_of_root: List[Path] = []
-    # `own_slug` is what lets us tell "pending on the default branch" from "broken" WITHOUT opening
-    # the door to downgrading someone else's real break: only the repo we are actually in can have
-    # its own working tree consulted about where a `blob/<branch>/...` URL points after a merge.
-    own_slug = _github_slug_from_origin(root)
+    # This is what lets us tell "pending on the default branch" from "broken" WITHOUT opening the
+    # door to downgrading someone else's real break: only the repo we are actually in can have its
+    # own working tree consulted about where a `blob/<default-branch>/...` URL points after a merge.
+    own = _own_repo(root)
     findings, edits = check_web_links_online(root, token, fetcher or default_fetcher, block_markers,
                                              excludes, owners, out_of_root=web_out_of_root,
-                                             include_mermaid=args.include_mermaid, own_slug=own_slug)
+                                             include_mermaid=args.include_mermaid, own=own)
     ok = [x for x in findings if x.kind == "web_ok"]
     anchors = [x for x in findings if x.kind == "web_anchor"]
     mismatch = [x for x in findings if x.kind == "web_mismatch"]
@@ -645,32 +645,53 @@ def _github_owner_from_origin(root: Path) -> Optional[str]:
     return m["owner"] if m else None
 
 
-def _github_slug_from_origin(root: Path) -> Optional[str]:
-    """`owner/repo` of `origin`, or None. Same hardening as its sibling above -- scrubbed git env,
-    ASCII-anchored regex -- because the same two traps apply: a hook's inherited GIT_DIR would answer
-    about the WRONG repository, and IGNORECASE without _re.ASCII folds U+0131 so `gıthub.com/evil`
-    would resolve as GitHub.
+def _own_repo(root: Path) -> Optional["OwnRepo"]:
+    """The repo we are running in: `owner/repo`, its REAL ROOT and its default branch. Or None.
 
-    Used to tell "pending on the default branch" from "broken" (see `weblinks._classify`): only the
-    repo we are actually IN can have its own working tree consulted about where a `blob/<branch>/...`
-    URL will point after a merge. For any other repo, a path that happens to exist here says nothing.
+    All three from the same reading of git, deliberately. Measured in adversarial review: the gate
+    supports scanning a SUBDIRECTORY (a fleet gate takes it as an argument), and there `root` stops
+    being the repo root while `<path>` stays relative to it — so a broken link was compared against
+    the wrong tree and came out green. Hence the root comes from `rev-parse --show-toplevel` and not
+    from the scanned directory.
+
+    Same hardening as `_github_owner_from_origin`: scrubbed git environment (a hook exports GIT_DIR
+    and would answer about ANOTHER repository, silently and with a plausible answer) and an
+    ASCII-anchored regex (without `re.ASCII`, IGNORECASE folds U+0131 so a lookalike host resolves
+    as GitHub). Any failure returns None and the rung is INERT, which is the safe side.
     """
     import os as _os
     import re as _re
     import subprocess
+    from darnlink.weblinks import OwnRepo
     env = {k: v for k, v in _os.environ.items()
            if k not in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR")}
-    try:
-        out = subprocess.run(["git", "-C", str(root), "config", "--get", "remote.origin.url"],
-                             capture_output=True, text=True, timeout=10, env=env)
-    except (OSError, subprocess.SubprocessError):
-        return None
-    if out.returncode != 0:
+
+    def _git(*args: str) -> Optional[str]:
+        try:
+            out = subprocess.run(["git", "-C", str(root), *args],
+                                 capture_output=True, text=True, timeout=10, env=env)
+        except (OSError, subprocess.SubprocessError):
+            return None
+        return out.stdout.strip() if out.returncode == 0 else None
+
+    url = _git("config", "--get", "remote.origin.url")
+    if not url:
         return None
     m = _re.match(r"(?:(?:https?|ssh)://(?:[^/@]*@)?(?:www\.|ssh\.)?github\.com(?::\d+)?/"
                   r"|(?:[^/@]*@)?github\.com:)(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$",
-                  out.stdout.strip(), _re.IGNORECASE | _re.ASCII)
-    return f"{m['owner']}/{m['repo']}" if m else None
+                  url, _re.IGNORECASE | _re.ASCII)
+    if not m:
+        return None
+    top = _git("rev-parse", "--show-toplevel")
+    if not top:
+        return None
+    # `origin`'s default branch. `origin/HEAD` is a LOCAL symref that can be MISSING (a clone made
+    # with `--no-tags`, a remote added by hand), and when it is, this returns the empty string and
+    # the rung stays inert. Guessing "main" would be worse than not knowing: it would forgive links
+    # in every repo whose default is something else.
+    head = _git("symbolic-ref", "--short", "refs/remotes/origin/HEAD") or ""
+    default_ref = head.split("/", 1)[1] if "/" in head else ""
+    return OwnRepo(slug=f"{m['owner']}/{m['repo']}", root=Path(top), default_ref=default_ref)
 
 
 def _make_stdio_encoding_safe() -> None:

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -27,7 +27,8 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from functools import lru_cache
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from urllib.parse import unquote
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 from .frontmatter_index import read_frontmatter_uuid
@@ -332,10 +333,86 @@ class WebFinding:
     token_would_help: bool = False
 
 
+@dataclass(frozen=True)
+class OwnRepo:
+    """What we must know about the repo WE ARE IN to be able to say "pending, not broken".
+
+    The three facts travel together rather than loose because all three must come from the SAME
+    reading of git: mixing one repo's slug with another's toplevel IS one of the leaks an
+    adversarial review walked through — the gate supports scanning a SUBDIRECTORY, and there `root`
+    stops being the repo root while `<path>` stays relative to it.
+    """
+    slug: str          # owner/repo of `origin`
+    root: Path         # `git rev-parse --show-toplevel`, NOT the scanned directory
+    default_ref: str   # the default branch of `origin`, e.g. `main` or `master`
+
+
+def _pendiente_en_la_rama_por_defecto(gu: "GithubUrl", own: Optional["OwnRepo"]) -> bool:
+    """Is this 404 "not published yet" rather than "broken"? Only if ALL of the following hold.
+
+    Each condition closes a leak MEASURED in adversarial review. An earlier draft checked only two
+    — own repo, and `.exists()` — and every case below walked through it GREEN while being a link
+    that no merge will ever resolve. A gate that lets a real break past is worse than one that cuts
+    too much: green reads the same whether it is right or blind.
+    """
+    if own is None:
+        return False
+    # (1) ASCII SLUG, and `.lower()` rather than `.casefold()`. GitHub slugs are ASCII, so any URL
+    #     carrying anything else is a permanently dead link — and `casefold()` COLLAPSES exactly
+    #     those lookalikes: U+212A (KELVIN) folds to `k`, U+00DF to `ss`. The sibling helper
+    #     `_github_owner_from_origin` carries an explicit comment about `re.ASCII` and U+0131 for
+    #     this same reason; this comparison did not inherit that hardening.
+    if not (gu.owner.isascii() and gu.repo.isascii()):
+        return False
+    if f"{gu.owner}/{gu.repo}".lower() != own.slug.lower():
+        return False
+    # (2) THE REF MUST BE THE DEFAULT BRANCH. It is what the message claims ("resolves when this
+    #     branch merges") and what went unchecked: a `blob/<sha>/x` or `blob/v1.0.0/x` is IMMUTABLE
+    #     — it will never resolve — and was forgiven all the same. This file already ships the
+    #     detector (`_IMMUTABLE_REF_RE`, used for exactly this in FR-006); requiring the default
+    #     branch is stronger still and does not depend on guessing what an immutable ref looks like.
+    if not own.default_ref or gu.ref != own.default_ref:
+        return False
+    # (3) THE PATH, CONFINED TO THE TREE. URL paths are PERCENT-ENCODED, and this matters daily
+    #     here: folder names carry a timezone offset (`…T104500+0200_…`), which in a URL is `%2B`.
+    #     Undecoded, the rung sat silently inert on the commonest shape in the repo — it did not
+    #     fail, it did nothing. And `Path(root) / "/etc/hostname"` IS `/etc/hostname` on POSIX, so
+    #     an absolute path left the repo entirely and `.exists()` happily agreed.
+    ruta = unquote(gu.path)
+    if ruta.startswith("/") or ".." in PurePosixPath(ruta).parts:
+        return False
+    destino = own.root / ruta
+    try:
+        if not destino.resolve().is_relative_to(own.root.resolve()):
+            return False
+    except (OSError, ValueError):
+        return False
+    # (4) AND IT MUST BE A TRACKED FILE. `.exists()` accepts a DIRECTORY (which GitHub serves under
+    #     `/tree/`, so `/blob/<dir>` 404s forever) and a GITIGNORED file, which no merge puts on the
+    #     default branch. Neither of them is fixed by merging.
+    if not destino.is_file():
+        return False
+    return _esta_versionado(own.root, ruta)
+
+
+def _esta_versionado(root: "Path", ruta: str) -> bool:
+    """`git ls-files --error-unmatch`. Fail-closed: on any doubt, do NOT forgive."""
+    import os as _os
+    import subprocess
+    env = {k: v for k, v in _os.environ.items()
+           if k not in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR")}
+    try:
+        r = subprocess.run(["git", "-C", str(root), "ls-files", "--error-unmatch", "--", ruta],
+                           capture_output=True, text=True, timeout=10, env=env)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return r.returncode == 0
+
+
 def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Optional[str],
               have_token: bool, f: Path, owners: frozenset = frozenset(),
               dest_fm_status: Optional[str] = None, filtered: bool = False,
-              local_root: Optional[Path] = None, own_slug: Optional[str] = None) -> WebFinding:
+              own: Optional["OwnRepo"] = None) -> WebFinding:
     """Feature 016 adds two kinds on top of 013's five. Two axes (§Precedence): visibility first —
     `--ignore-block` and code fences never reach here, and a file carrying `darnlink-ignore-file` /
     `darnlink-ignore-links` arrives with `filtered=True`, which suppresses ONLY the new finding
@@ -392,13 +469,12 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
         # downgrade a REAL break whenever an unrelated repo happens to share a filename (`README.md`
         # is the obvious one). So it must also be OUR OWN repo — the only one whose working tree says
         # anything about where that URL will point after a merge.
-        if (own_slug and local_root is not None
-                and f"{gu.owner}/{gu.repo}".casefold() == own_slug.casefold()
-                and (local_root / gu.path).exists()):
+        if _pendiente_en_la_rama_por_defecto(gu, own):
             return WebFinding("web_unverifiable", f, link.href,
-                              f"destination 404s on `{gu.ref}` but `{gu.path}` EXISTS in this working "
-                              "tree — pending on the default branch, not broken; it resolves when this "
-                              "branch merges. Blocking here would block the merge that fixes it")
+                              f"destination 404s on the default branch `{gu.ref}` but `{gu.path}` is a "
+                              "TRACKED FILE in this working tree — pending on the default branch, not "
+                              "broken. It resolves when this branch merges (or stays pending if the "
+                              "branch is abandoned); blocking here would block that merge")
         return WebFinding("web_not_found", f, link.href,
                           "destination URL 404s; darnlink does not search where it moved (LLM layer's job)")
     if status == -3:
@@ -467,7 +543,7 @@ def check_web_links_online(
     owners: frozenset = frozenset(),
     out_of_root: Optional[List[Path]] = None,
     include_mermaid: bool = False,
-    own_slug: Optional[str] = None,
+    own: Optional["OwnRepo"] = None,
 ) -> Tuple[List[WebFinding], Dict[Path, str]]:
     """Fetch each web link's destination (once, cached per URL) and classify it. Returns the findings
     and the per-file rewritten content for any `web_anchor` (the caller writes it only under --write).
@@ -510,7 +586,7 @@ def check_web_links_online(
             gu = parse_github_url(link.href)
             if gu is None:
                 findings.append(_classify(link, None, 0, None, have_token, f, owners,
-                                          local_root=root, own_slug=own_slug))
+                                          own=own))
                 continue
             if link.href not in cache:
                 cache[link.href] = fetcher(gu, token)
@@ -522,7 +598,7 @@ def check_web_links_online(
             dest_fm_status, dest_uuid = (read_frontmatter_uuid(text.lstrip("\ufeff"))
                                          if (status == 200 and text is not None) else (None, None))
             fnd = _classify(link, gu, status, dest_uuid, have_token, f, owners, dest_fm_status, filtered,
-                            local_root=root, own_slug=own_slug)
+                            own=own)
             findings.append(fnd)
             if fnd.kind == "web_anchor" and fnd.anchored_uuid:
                 pieces.append(content[cursor:link.start])

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -334,7 +334,8 @@ class WebFinding:
 
 def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Optional[str],
               have_token: bool, f: Path, owners: frozenset = frozenset(),
-              dest_fm_status: Optional[str] = None, filtered: bool = False) -> WebFinding:
+              dest_fm_status: Optional[str] = None, filtered: bool = False,
+              local_root: Optional[Path] = None, own_slug: Optional[str] = None) -> WebFinding:
     """Feature 016 adds two kinds on top of 013's five. Two axes (§Precedence): visibility first —
     `--ignore-block` and code fences never reach here, and a file carrying `darnlink-ignore-file` /
     `darnlink-ignore-links` arrives with `filtered=True`, which suppresses ONLY the new finding
@@ -375,6 +376,29 @@ def _classify(link: WebLink, gu: Optional[GithubUrl], status: int, dest_uuid: Op
                               "destination 404s but no token — ambiguous (could be a private repo we "
                               "cannot see, not necessarily moved); a token is needed to call it broken",
                               token_would_help=True)
+        # PENDING-ON-DEFAULT-BRANCH, not broken. A `blob/<default-branch>/…` URL to a path that
+        # EXISTS in the working tree is not a dead link: it is a link that the merge will make
+        # resolve. Calling it `web_not_found` in a blocking gate creates a DEADLOCK — the red
+        # blocks the merge that would fix it — and the two states are genuinely different:
+        #
+        #     will never resolve   -> a real break, must cut
+        #     not there YET        -> resolves on merge, and cutting blocks the merge
+        #
+        # This repo's own doctrine already argues for it thirteen lines up in this file: *"a false
+        # `web_not_found` in a blocking gate is worse than the crash this replaces"*. And it needs no
+        # new kind: `web_unverifiable` is exactly the honest "cannot tell from here" bucket.
+        #
+        # ⚠️ TWO conditions, and the second is what makes it safe. Path-exists alone would silently
+        # downgrade a REAL break whenever an unrelated repo happens to share a filename (`README.md`
+        # is the obvious one). So it must also be OUR OWN repo — the only one whose working tree says
+        # anything about where that URL will point after a merge.
+        if (own_slug and local_root is not None
+                and f"{gu.owner}/{gu.repo}".casefold() == own_slug.casefold()
+                and (local_root / gu.path).exists()):
+            return WebFinding("web_unverifiable", f, link.href,
+                              f"destination 404s on `{gu.ref}` but `{gu.path}` EXISTS in this working "
+                              "tree — pending on the default branch, not broken; it resolves when this "
+                              "branch merges. Blocking here would block the merge that fixes it")
         return WebFinding("web_not_found", f, link.href,
                           "destination URL 404s; darnlink does not search where it moved (LLM layer's job)")
     if status == -3:
@@ -443,6 +467,7 @@ def check_web_links_online(
     owners: frozenset = frozenset(),
     out_of_root: Optional[List[Path]] = None,
     include_mermaid: bool = False,
+    own_slug: Optional[str] = None,
 ) -> Tuple[List[WebFinding], Dict[Path, str]]:
     """Fetch each web link's destination (once, cached per URL) and classify it. Returns the findings
     and the per-file rewritten content for any `web_anchor` (the caller writes it only under --write).
@@ -484,7 +509,8 @@ def check_web_links_online(
         for link in links:
             gu = parse_github_url(link.href)
             if gu is None:
-                findings.append(_classify(link, None, 0, None, have_token, f, owners))
+                findings.append(_classify(link, None, 0, None, have_token, f, owners,
+                                          local_root=root, own_slug=own_slug))
                 continue
             if link.href not in cache:
                 cache[link.href] = fetcher(gu, token)
@@ -495,7 +521,8 @@ def check_web_links_online(
             # `web_unverifiable` into an exit 4 telling you to add a uuid the file already has.
             dest_fm_status, dest_uuid = (read_frontmatter_uuid(text.lstrip("\ufeff"))
                                          if (status == 200 and text is not None) else (None, None))
-            fnd = _classify(link, gu, status, dest_uuid, have_token, f, owners, dest_fm_status, filtered)
+            fnd = _classify(link, gu, status, dest_uuid, have_token, f, owners, dest_fm_status, filtered,
+                            local_root=root, own_slug=own_slug)
             findings.append(fnd)
             if fnd.kind == "web_anchor" and fnd.anchored_uuid:
                 pieces.append(content[cursor:link.start])

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -507,26 +507,44 @@ def test_verdict_line_offers_the_token_when_it_WOULD_help(tmp_path, capsys, monk
     assert "1 of them would resolve with GITHUB_TOKEN" in out
 
 
-# --- "pending on the default branch" vs "broken": the deadlock, and the guard that makes it safe ---
+# --- "pending on the default branch" vs "broken": the deadlock, and the five guards ---
 #
-# Measured 2026-08-25 on a real repo: a branch added `systems/jenkins/informes.md`, whose sibling
-# docs link to it as `blob/master/systems/jenkins/informes.md`. That URL 404s until the branch
-# merges -> 6 `web_not_found` -> exit 4 -> red build -> **the red blocks the merge that would make
-# the links resolve**. The two states are genuinely different and one kind was covering both:
+# Measured on a real repo: a branch added `systems/jenkins/informes.md`, whose sibling docs link to
+# it as `blob/master/systems/jenkins/informes.md`. That URL 404s until the branch merges -> 6
+# `web_not_found` -> exit 4 -> red build -> **the red blocks the merge that makes the links
+# resolve**. Two genuinely different states shared one kind:
 #
 #     will never resolve  -> a real break, must cut
 #     not there YET       -> resolves on merge, and cutting blocks the merge
 #
-# `web_unverifiable` already existed as the honest "cannot tell from here" bucket, so no new kind.
+# ⚠️ THE FIRST VERSION OF THIS RUNG CHECKED ONLY TWO THINGS -- own repo, and `.exists()` -- and an
+# adversarial review found FIVE ways to walk a permanently-dead link straight through it, all of
+# them green. Every test below is one of those five. They are not padding: the four tests that
+# shipped first (own/other/absent/no-slug) pass in ALL five leaking cases.
+
+def _own(tmp_path, slug="example-org/handbook", ref="main"):
+    from darnlink.weblinks import OwnRepo
+    return OwnRepo(slug=slug, root=tmp_path, default_ref=ref)
+
+
+def _git_init(tmp_path):
+    """A real repo: the rung requires the destination to be a TRACKED file, so a bare tmpdir is not
+    enough. `git ls-files` is what tells a file that will reach the default branch from one that
+    never will (a gitignored build artefact looks identical to `.exists()`)."""
+    import subprocess
+    subprocess.run(["git", "-C", str(tmp_path), "init", "-q"], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "add", "-A"], check=True)
+
 
 def test_404_on_OWN_repo_with_the_path_present_locally_is_pending_not_broken(tmp_path):
     """The deadlock case. Own repo + the path exists in the working tree -> unverifiable, gate green."""
     _w(tmp_path / "docs" / "living" / "service-topology.md", "# lives here already\n")
     _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
+    _git_init(tmp_path)
     findings, _ = check_web_links_online(tmp_path, token="tok", fetcher=_fetcher({}),
-                                         own_slug="example-org/handbook")
+                                         own=_own(tmp_path))
     assert findings[0].kind == "web_unverifiable"
-    assert "EXISTS in this working tree" in findings[0].detail
+    assert "TRACKED FILE in this working tree" in findings[0].detail
 
 
 def test_404_on_OWN_repo_with_the_path_ABSENT_is_still_a_real_break(tmp_path):
@@ -534,8 +552,9 @@ def test_404_on_OWN_repo_with_the_path_ABSENT_is_still_a_real_break(tmp_path):
     stays exactly as broken as before. Without this test the change could silently downgrade
     everything and still look correct."""
     _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
+    _git_init(tmp_path)
     findings, _ = check_web_links_online(tmp_path, token="tok", fetcher=_fetcher({}),
-                                         own_slug="example-org/handbook")
+                                         own=_own(tmp_path))
     assert findings[0].kind == "web_not_found"
 
 
@@ -547,8 +566,9 @@ def test_404_on_ANOTHER_repo_is_NOT_downgraded_by_a_same_named_local_file(tmp_pa
     Here the file exists locally and the link points elsewhere: it must stay `web_not_found`."""
     _w(tmp_path / "docs" / "living" / "service-topology.md", "# same path, different repo\n")
     _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
+    _git_init(tmp_path)
     findings, _ = check_web_links_online(tmp_path, token="tok", fetcher=_fetcher({}),
-                                         own_slug="someone-else/other-repo")
+                                         own=_own(tmp_path, slug="someone-else/other-repo"))
     assert findings[0].kind == "web_not_found"
 
 
@@ -557,5 +577,114 @@ def test_pending_rung_is_INERT_when_the_origin_slug_is_unknown(tmp_path):
     A rung that changed behaviour when it could not identify the repo would be worse than no rung."""
     _w(tmp_path / "docs" / "living" / "service-topology.md", "# present\n")
     _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
+    _git_init(tmp_path)
     findings, _ = check_web_links_online(tmp_path, token="tok", fetcher=_fetcher({}))
     assert findings[0].kind == "web_not_found"
+
+
+# --- the five leaks an adversarial review walked straight through the FIRST version of this rung ---
+#
+# All five were permanently-dead links that came out GREEN. None of the four tests above catches any
+# of them: they all pass in every leaking case, which is why they are not enough on their own.
+
+def test_leak1_an_immutable_ref_is_never_pending(tmp_path):
+    """A `blob/<sha>/…` or `blob/<tag>/…` is IMMUTABLE: no merge makes it resolve, so calling it
+    "pending on the default branch" is a lie the operator acts on. This file already carried
+    `_IMMUTABLE_REF_RE` for exactly this distinction (FR-006) and the rung did not consult it. The
+    fix is stronger than that regex: the ref must BE the default branch, which is what the message
+    claims. A deleted long-lived branch is dead the same way and no regex would have caught it."""
+    _w(tmp_path / "docs" / "living" / "service-topology.md", "# present\n")
+    for ref in ("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "v1.0.0", "branch-deleted-years-ago"):
+        url = f"https://github.com/example-org/handbook/blob/{ref}/docs/living/service-topology.md"
+        _w(tmp_path / "conta.md", f"see [topo]({url}) <!-- web-uuid: {UUID} -->\n")
+        _git_init(tmp_path)
+        findings, _ = check_web_links_online(tmp_path, token="tok", fetcher=_fetcher({}),
+                                             own=_own(tmp_path, ref="main"))
+        assert findings[0].kind == "web_not_found", f"ref {ref!r} was forgiven"
+
+
+def test_leak2_the_join_base_is_the_repo_ROOT_not_the_scanned_dir(tmp_path):
+    """`gu.path` is relative to the REPO ROOT, so joining it to the SCANNED directory compares
+    against the wrong tree. Not hypothetical: a fleet gate takes the scan root as an argument
+    (`SCAN_ROOT="${1:-.}"`). Here the file exists under `docs/` and the URL says root-level: with the
+    scanned dir as base it would "exist" and be forgiven; with the repo root it correctly stays broken."""
+    url = "https://github.com/example-org/handbook/blob/main/notes.md"
+    _w(tmp_path / "docs" / "notes.md", "# only under docs/\n")
+    _w(tmp_path / "docs" / "conta.md", f"see [n]({url}) <!-- web-uuid: {UUID} -->\n")
+    _git_init(tmp_path)
+    findings, _ = check_web_links_online(tmp_path / "docs", token="tok", fetcher=_fetcher({}),
+                                         own=_own(tmp_path, ref="main"))
+    assert findings[0].kind == "web_not_found"
+
+
+def test_leak3_a_directory_or_an_untracked_file_is_not_pending(tmp_path):
+    """`.exists()` says yes to two things that NO merge can put on the default branch as a `/blob/`
+    URL: a DIRECTORY (GitHub serves those under `/tree/`, so `/blob/<dir>` 404s forever) and a file
+    that is not tracked (a build artefact, a gitignored report). Both looked identical to a pending
+    file, and both were forgiven."""
+    _w(tmp_path / ".gitignore", "dist/\n")
+    _w(tmp_path / "docs" / "living" / "keep.md", "# tracked sibling so the dir exists\n")
+    _w(tmp_path / "dist" / "report.html", "<p>generated</p>\n")
+    _git_init(tmp_path)
+    for path in ("docs/living", "dist/report.html"):
+        url = f"https://github.com/example-org/handbook/blob/main/{path}"
+        _w(tmp_path / "conta.md", f"see [x]({url}) <!-- web-uuid: {UUID} -->\n")
+        findings, _ = check_web_links_online(tmp_path, token="tok", fetcher=_fetcher({}),
+                                             own=_own(tmp_path, ref="main"))
+        assert findings[0].kind == "web_not_found", f"{path!r} was forgiven"
+
+
+def test_leak4_the_path_cannot_escape_the_working_tree(tmp_path):
+    """`Path(root) / "/etc/hostname"` IS `/etc/hostname` in POSIX, so an absolute path in the URL
+    escaped the tree entirely and `.exists()` said yes — the rung then printed that a file OUTSIDE
+    the repo "EXISTS in this working tree".
+
+    ⚠️ WHAT THIS TEST DOES AND DOES NOT PIN DOWN, because it was measured and not assumed. Seeding
+    says it: remove the containment check and this test STILL PASSES. The escape is already blocked
+    one guard later, by `git ls-files --error-unmatch` — nothing outside the tree is ever tracked.
+    So this pins the BEHAVIOUR (an escaping path is never forgiven) and NOT which guard does it.
+
+    The containment check stays anyway, and deliberately: it is two comparisons, it fails closed,
+    and unlike the tracked check it does not depend on `git` being runnable — a subprocess that
+    cannot start is exactly when you want the cheap guard to still be there. But calling it
+    "the fix for this leak" would claim more than the measurement supports."""
+    repo = tmp_path / "repo"
+    _w(tmp_path / "vecino.md", "# outside the repo\n")
+    _w(repo / "docs" / "keep.md", "# something tracked\n")
+    _git_init(repo)
+    for path in ("/etc/hostname", "../vecino.md"):
+        url = f"https://github.com/example-org/handbook/blob/main/{path}"
+        _w(repo / "conta.md", f"see [x]({url}) <!-- web-uuid: {UUID} -->\n")
+        findings, _ = check_web_links_online(repo, token="tok", fetcher=_fetcher({}),
+                                             own=_own(repo, ref="main"))
+        assert all(f.kind != "web_unverifiable" or "TRACKED FILE" not in f.detail
+                   for f in findings), f"{path!r} escaped the tree and was forgiven"
+
+
+def test_leak5_a_non_ascii_slug_never_matches(tmp_path):
+    """GitHub slugs are ASCII, so a lookalike is a permanently dead link — and `casefold()` COLLAPSES
+    exactly those lookalikes (U+212A KELVIN folds to `k`, U+00DF to `ss`). Its sibling helper carries
+    an explicit comment about `re.ASCII` and U+0131 for this same reason; the comparison did not
+    inherit that hardening."""
+    url = "https://github.com/example-org/handbooK/blob/main/docs/living/service-topology.md"
+    _w(tmp_path / "docs" / "living" / "service-topology.md", "# present\n")
+    _w(tmp_path / "conta.md", f"see [x]({url}) <!-- web-uuid: {UUID} -->\n")
+    _git_init(tmp_path)
+    findings, _ = check_web_links_online(tmp_path, token="tok", fetcher=_fetcher({}),
+                                         own=_own(tmp_path, slug="example-org/handbook", ref="main"))
+    assert findings[0].kind != "web_unverifiable" or "TRACKED FILE" not in findings[0].detail
+
+
+def test_a_percent_encoded_path_still_resolves(tmp_path):
+    """⚠️ NOT a leak — the opposite: the rung was INERT here. URL paths are percent-encoded, and this
+    account's dominant convention puts a timezone offset in folder names (`…T104500+0200_…`), which
+    in a URL is `%2B`. Undecoded, the rung silently did nothing on precisely the most common shape."""
+    _w(tmp_path / "log" / "2026-08-11T104500+0200_x" / "README.md", "# pending\n")
+    url = ("https://github.com/example-org/handbook/blob/main/"
+           "log/2026-08-11T104500%2B0200_x/README.md")
+    _w(tmp_path / "conta.md", f"see [x]({url}) <!-- web-uuid: {UUID} -->\n")
+    _git_init(tmp_path)
+    findings, _ = check_web_links_online(tmp_path, token="tok", fetcher=_fetcher({}),
+                                         own=_own(tmp_path, ref="main"))
+    assert findings[0].kind == "web_unverifiable"
+    assert "TRACKED FILE" in findings[0].detail

--- a/tests/test_weblinks.py
+++ b/tests/test_weblinks.py
@@ -505,3 +505,57 @@ def test_verdict_line_offers_the_token_when_it_WOULD_help(tmp_path, capsys, monk
     assert _run_web_check_cli([str(tmp_path), "--online"], fetcher=_fetcher({URL: (403, None)})) == 0
     out = capsys.readouterr().out
     assert "1 of them would resolve with GITHUB_TOKEN" in out
+
+
+# --- "pending on the default branch" vs "broken": the deadlock, and the guard that makes it safe ---
+#
+# Measured 2026-08-25 on a real repo: a branch added `systems/jenkins/informes.md`, whose sibling
+# docs link to it as `blob/master/systems/jenkins/informes.md`. That URL 404s until the branch
+# merges -> 6 `web_not_found` -> exit 4 -> red build -> **the red blocks the merge that would make
+# the links resolve**. The two states are genuinely different and one kind was covering both:
+#
+#     will never resolve  -> a real break, must cut
+#     not there YET       -> resolves on merge, and cutting blocks the merge
+#
+# `web_unverifiable` already existed as the honest "cannot tell from here" bucket, so no new kind.
+
+def test_404_on_OWN_repo_with_the_path_present_locally_is_pending_not_broken(tmp_path):
+    """The deadlock case. Own repo + the path exists in the working tree -> unverifiable, gate green."""
+    _w(tmp_path / "docs" / "living" / "service-topology.md", "# lives here already\n")
+    _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
+    findings, _ = check_web_links_online(tmp_path, token="tok", fetcher=_fetcher({}),
+                                         own_slug="example-org/handbook")
+    assert findings[0].kind == "web_unverifiable"
+    assert "EXISTS in this working tree" in findings[0].detail
+
+
+def test_404_on_OWN_repo_with_the_path_ABSENT_is_still_a_real_break(tmp_path):
+    """The control that keeps the rung useful: without the file there is nothing pending, so a 404
+    stays exactly as broken as before. Without this test the change could silently downgrade
+    everything and still look correct."""
+    _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
+    findings, _ = check_web_links_online(tmp_path, token="tok", fetcher=_fetcher({}),
+                                         own_slug="example-org/handbook")
+    assert findings[0].kind == "web_not_found"
+
+
+def test_404_on_ANOTHER_repo_is_NOT_downgraded_by_a_same_named_local_file(tmp_path):
+    """⚠️ THE ONE THAT MATTERS. Path-exists ALONE would silently downgrade a real break whenever an
+    unrelated repo happens to share a filename -- and shared filenames are the norm, not the
+    exception (`README.md`, `docs/index.md`). Only OUR OWN repo's working tree says anything about
+    where a `blob/<branch>/...` URL will point after a merge; for any other repo it says nothing.
+    Here the file exists locally and the link points elsewhere: it must stay `web_not_found`."""
+    _w(tmp_path / "docs" / "living" / "service-topology.md", "# same path, different repo\n")
+    _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
+    findings, _ = check_web_links_online(tmp_path, token="tok", fetcher=_fetcher({}),
+                                         own_slug="someone-else/other-repo")
+    assert findings[0].kind == "web_not_found"
+
+
+def test_pending_rung_is_INERT_when_the_origin_slug_is_unknown(tmp_path):
+    """No `own_slug` (no origin, a non-GitHub remote, a bare tree) -> behaves exactly as before.
+    A rung that changed behaviour when it could not identify the repo would be worse than no rung."""
+    _w(tmp_path / "docs" / "living" / "service-topology.md", "# present\n")
+    _w(tmp_path / "conta.md", f"see [topo]({URL}) <!-- web-uuid: {UUID} -->\n")
+    findings, _ = check_web_links_online(tmp_path, token="tok", fetcher=_fetcher({}))
+    assert findings[0].kind == "web_not_found"


### PR DESCRIPTION
A blocking link gate had one finding kind covering **two genuinely different states**, and the
consequence is a deadlock: the red blocks the merge that would clear it.

## The measurement

Today, on a private repo of a fleet that uses this gate. A branch added two files; sibling docs link
to them as `blob/master/<path>`. Those URLs 404 until the branch merges:

```
ok 109 | anchor 0 | mismatch 0 | not-found 6 | unverifiable 2454   ->  exit 4  ->  build red
```

**The branch cannot go green before merging, and cannot merge while red.**

| state | what it means | what the gate should do |
|---|---|---|
| will never resolve | a real break | **cut** |
| not there *yet* | resolves on merge | cutting blocks the fix |

`web_not_found` was answering both. No new kind is needed: **`web_unverifiable` already exists** as
the honest "cannot tell from here" bucket, which is exactly what this is.

And `weblinks.py` already argued for the change, thirteen lines above the site it changes:

> *"A false `web_not_found` in a blocking gate is worse than the crash this replaces"*

A link pending on the default branch, called broken, **is** that false positive.

## Two conditions, and the second is the one that makes it safe

1. the path **exists** in the working tree, and
2. the URL points at **our own repo** (`owner/repo` from `origin`)

Path-exists alone would silently downgrade a real break whenever an unrelated repo happens to share
a filename — and shared filenames are the norm, not the exception (`README.md`, `docs/index.md`).
Only the repo we are actually *in* can have its working tree consulted about where a
`blob/<branch>/…` URL will point after a merge. For any other repo it says nothing.

`_github_slug_from_origin` **reuses the hardening** of its owner-only sibling rather than re-deriving
it — the scrubbed git env (a hook exports `GIT_DIR` and would answer about the *wrong* repository,
silently and with a plausible answer) and the ASCII-anchored regex (without `re.ASCII`, `IGNORECASE`
folds U+0131, so a lookalike host resolves as GitHub).

## Tests: the two that matter are the negative ones

| test | what it protects |
|---|---|
| own repo + path present | the deadlock case → `web_unverifiable` |
| own repo + path **absent** | a real 404 is still a real break |
| **another repo + same-named local file** | **must NOT be downgraded** |
| **no origin slug** | the rung is **inert**, behaves exactly as before |

Verified by seeding, not by reading: dropping the own-repo guard makes **exactly those two negative
tests go red**. 482 tests pass with it in place.

> A rung that changed behaviour when it could not identify the repo would be worse than no rung.

## What this does NOT cover

- **It does not find where a file moved to.** That is unchanged and deliberate ("the LLM layer's
  job"); this only stops calling *not yet published* the same thing as *gone*.
- **It says nothing about the tokenless path.** A 404 without a token was already `web_unverifiable`
  for a different reason and is untouched.
- **It cannot help a detached or bare tree** with no `origin` — there the rung is inert by design,
  which is the fourth test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
