### PR TITLE
The pending-on-default-branch rung was inert in CI, the only place it mattered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to darnlink are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## 0.25.1
+
+The 0.25.0 rung was **inert in CI**, which is the only place it mattered. It read the default branch
+from  — a LOCAL symref that a CI checkout does not create: a multibranch PR job fetches
+only `+refs/pull/<n>/head:refs/remotes/origin/PR-<n>`, so there is no `refs/remotes/origin/master`
+and `symbolic-ref` fails. Every ordinary clone HAS that symref, which is why it looked correct.
+
+The local read stays first (free); the remote is asked with `ls-remote --symref` only when it
+fails. Unknown default branch still means inert — guessing `main` would forgive links in every repo
+whose default is something else.
+
 ## 0.25.0
 
 ### A link pending on the default branch is not a broken link

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.25.0"
+version = "0.25.1"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -685,12 +685,31 @@ def _own_repo(root: Path) -> Optional["OwnRepo"]:
     top = _git("rev-parse", "--show-toplevel")
     if not top:
         return None
-    # `origin`'s default branch. `origin/HEAD` is a LOCAL symref that can be MISSING (a clone made
-    # with `--no-tags`, a remote added by hand), and when it is, this returns the empty string and
-    # the rung stays inert. Guessing "main" would be worse than not knowing: it would forgive links
-    # in every repo whose default is something else.
+    # `origin`'s default branch, and it takes TWO tries for a reason that cost a red build.
+    #
+    # ⚠️ `origin/HEAD` IS A LOCAL SYMREF, AND CI DOES NOT CREATE IT. Measured on the very build this
+    # rung exists for: a Jenkins multibranch PR job fetches ONLY the pull ref
+    #     +refs/pull/<n>/head:refs/remotes/origin/PR-<n>
+    # so there is no `refs/remotes/origin/master` and no `origin/HEAD` -- `symbolic-ref` fails and
+    # the rung went INERT in exactly the environment it was written for. It worked perfectly in
+    # every local clone, which is why it looked correct: the local clone has the symref, CI does not.
+    #
+    # So the local read stays first (free, no network) and the REMOTE is asked only when it fails.
+    # `ls-remote --symref` is authoritative and works with no local refs at all. It costs one round
+    # trip, which is why it is not the first choice -- but this only ever runs on the `--online` web
+    # axis, which is already making one request per link, so one more is not what makes it slow.
+    #
+    # Guessing "main" would be worse than not knowing: it would forgive links in every repo whose
+    # default is something else. Unknown still means inert.
     head = _git("symbolic-ref", "--short", "refs/remotes/origin/HEAD") or ""
     default_ref = head.split("/", 1)[1] if "/" in head else ""
+    if not default_ref:
+        # `ref: refs/heads/master\tHEAD` on the first line, or nothing at all.
+        salida = _git("ls-remote", "--symref", "origin", "HEAD") or ""
+        for linea in salida.splitlines():
+            if linea.startswith("ref:") and "refs/heads/" in linea:
+                default_ref = linea.split("refs/heads/", 1)[1].split()[0]
+                break
     return OwnRepo(slug=f"{m['owner']}/{m['repo']}", root=Path(top), default_ref=default_ref)
 
 

--- a/tests/test_own_repo_web_strictness.py
+++ b/tests/test_own_repo_web_strictness.py
@@ -716,3 +716,46 @@ def test_the_marker_is_honoured_with_no_owner_set_at_all(tmp_path):
     assert _run_web_check_cli([str(tmp_path), "--online", "--write"],
                               fetcher=_fetcher({OWNED: _with_uuid()})) == 0
     assert (tmp_path / "src.md").read_text(encoding="utf-8") == before
+
+
+# --- the default branch must survive a CI checkout, where `origin/HEAD` does not exist ---
+
+def test_default_branch_falls_back_to_the_remote_when_origin_HEAD_is_absent(tmp_path, monkeypatch):
+    """⚠️ THE FAILURE THAT SHIPPED. `origin/HEAD` is a LOCAL symref and CI does not create it: a
+    Jenkins multibranch PR job fetches only `+refs/pull/<n>/head:refs/remotes/origin/PR-<n>`, so
+    there is no `refs/remotes/origin/master` and `symbolic-ref` fails. The rung went INERT in
+    exactly the environment it was written for — and it looked correct everywhere else, because
+    every ordinary clone HAS the symref.
+
+    This pins the shape of the bug without touching the network: a repo whose `origin/HEAD` is
+    missing must still resolve a default branch (here, from the remote), not silently give up."""
+    import subprocess
+    from darnlink.cli import _own_repo
+
+    origen = tmp_path / "origen"
+    subprocess.run(["git", "init", "-q", "-b", "master", str(origen)], check=True)
+    (origen / "a.md").write_text("x\n", encoding="utf-8")
+    for args in (["add", "-A"], ["-c", "user.email=b@b", "-c", "user.name=b", "commit", "-qm", "i"]):
+        subprocess.run(["git", "-C", str(origen), *args], check=True)
+
+    clon = tmp_path / "clon"          # a CI-shaped checkout: a remote, and no origin/HEAD
+    subprocess.run(["git", "init", "-q", str(clon)], check=True)
+    subprocess.run(["git", "-C", str(clon), "remote", "add", "origin",
+                    "https://github.com/example-org/handbook.git"], check=True)
+    assert subprocess.run(["git", "-C", str(clon), "symbolic-ref", "--short",
+                           "refs/remotes/origin/HEAD"], capture_output=True).returncode != 0, \
+        "the fixture must NOT have origin/HEAD, or it pins nothing"
+
+    # ⚠️ `insteadOf` is what makes this a REAL test instead of a skip. `_own_repo` needs the origin
+    # URL to READ as a GitHub URL (that is where the slug comes from) and to be REACHABLE (that is
+    # what `ls-remote` needs). A local path satisfies the second and fails the first. `insteadOf`
+    # rewrites the URL only at transport time, so the config still reads as GitHub while the fetch
+    # goes to a directory: no network, and the same code path the CI failure took.
+    subprocess.run(["git", "-C", str(clon), "config",
+                    f"url.{origen}.insteadOf", "https://github.com/example-org/handbook.git"],
+                   check=True)
+    own = _own_repo(clon)
+    assert own is not None and own.slug == "example-org/handbook"
+    assert own.default_ref == "master", (
+        "origin/HEAD is absent, so this can only have come from the remote fallback; an empty "
+        "value here means the rung is inert exactly where it is needed")


### PR DESCRIPTION
The build this rung exists for stayed **red with the fix merged and pinned** — same two links, same `exit 4`. Found by the real environment, not by a review.

## One line, and it disabled the whole rung

The default branch came from `origin/HEAD`, which is a **local symref that a CI checkout does not create**. A multibranch PR job fetches only the pull ref:

```
+refs/pull/<n>/head:refs/remotes/origin/PR-<n>
```

No `refs/remotes/origin/master` → `symbolic-ref` fails → `default_ref` empty → **the rung disables itself**, exactly as documented, in exactly the environment it was written for.

```
$ git init c && git -C c remote add origin https://github.com/o/r.git
$ git -C c symbolic-ref --short refs/remotes/origin/HEAD
fatal: ref refs/remotes/origin/HEAD is not a symbolic ref
```

## Why nothing local caught it

**Every ordinary clone HAS that symref.** Local runs, the test suite, and a hand-verification against the two real files all passed. The rung failed only in the shape of checkout that nothing local reproduces — the same class of bug as a gate that only runs in CI.

## The fix

Local read first (free). `ls-remote --symref` only when it fails — one round trip, on an axis already making a request per link. **Unknown default branch still means inert**: guessing `main` would forgive links in every repo whose default is something else.

## The test is real, not a skip

It builds a CI-shaped checkout — a remote, no fetched branches, no `origin/HEAD` — and uses `insteadOf` so the URL still **reads** as GitHub (where the slug comes from) while the fetch goes to a local directory. No network, same code path.

Verified by seeding: remove the fallback and it fails. **489 pass** with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)