### PR TITLE
An inert rung must say so: three red builds could not tell me it had switched itself off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to darnlink are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## 0.26.0
+
+**An inert rung now says so.** When the pending-on-default-branch rung cannot identify the repo or
+its default branch it disables itself — correct — but it did so SILENTLY, and a disabled rung looks
+exactly like one that ran and found a real break: same `web_not_found`, same exit 4. Three
+attempted fixes each looked like they had never arrived, when they had arrived and were switching
+themselves off. One line on stderr turns that mystery into a datum.
+
+**New `--default-branch NAME`**, which wins over both automatic sources. It is the only one that
+cannot fail, and in CI it is often the only one that CAN answer: the checkout has no `origin/HEAD`
+(only the PR ref is fetched) and the credentials for `ls-remote` are usually scoped to the checkout
+step rather than to what it spawns.
+
 ## 0.25.1
 
 The 0.25.0 rung was **inert in CI**, which is the only place it mattered. It read the default branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "darnlink"
-version = "0.25.1"
+version = "0.26.0"
 description = "auto-healing Markdown links — anchor links to a UUID: repair moved links, robustify plain ones"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -66,6 +66,7 @@ is that orchestration in one place; a consumer carries only a tiny config + a 3-
   |---|---|---|
   | `own_web` | list of GitHub owners | the owners you control |
   | `own_web_from_origin` | bool | also count this repo's `origin` owner. A **separate key, not a sentinel** in the list, so an owner literally called `origin` stays expressible |
+  | `default_branch` | string | the repo's default branch, e.g. `main`. **Declare it in CI**: a multibranch PR job fetches only the pull ref, so there is no `origin/HEAD`, and `ls-remote` usually has no credentials there — without this the pending-vs-broken rung goes INERT exactly where it is needed. It says so on stderr when it does |
   | `own_web_max` | int | a budget, so the rung is adoptable before the repo reaches zero. **Non-numeric counts as ABSENT, never as infinite** — widening an allowance is the one direction a config typo must not be able to go |
 
 - `include_mermaid` (opt-in, **needs `web`**) → feature 017. A `mermaid` diagram carries its

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -212,6 +212,14 @@ case "${WEB,,}" in ""|0|false|no|off) WEB="" ;; *) WEB=1 ;; esac
 mapfile -t OWN_WEB < <(read_cfg own_web "")
 OWN_WEB_N="$(read_cfg_len own_web)"; [[ "$OWN_WEB_N" =~ ^[0-9]+$ ]] || OWN_WEB_N=0
 OWN_WEB_FROM_ORIGIN="${DARNLINK_GATE_OWN_WEB_FROM_ORIGIN:-$(read_cfg own_web_from_origin "")}"
+
+# The repo's DEFAULT BRANCH, for telling a link that is PENDING on it from one that is broken.
+# ⚠️ Normally derived from `origin`, and in CI that derivation FAILS: a multibranch PR job fetches
+# only `+refs/pull/<n>/head:...`, so there is no `origin/HEAD`, and the credentials for `ls-remote`
+# are usually scoped to the checkout step rather than to what it spawns. The rung then goes INERT
+# exactly where it is needed -- three red builds before anyone could see that. Declaring it here
+# cannot fail and cannot be guessed wrong.
+DEFAULT_BRANCH="${DARNLINK_GATE_DEFAULT_BRANCH:-$(read_cfg default_branch "")}"
 # Feature 017 (opt-in, needs `web`): also watch the destinations a mermaid diagram carries in
 # its `click` directives. ABSENT MEANS OFF, per repository: a fleet of fail-closed gates has to
 # be able to switch this on one repo at a time. These links are report-only and never anchored.
@@ -483,6 +491,10 @@ if [ "$SCOPE" != "staged" ]; then
         echo "darnlink-gate: own_web has $((OWN_WEB_N - OWN_WEB_USED)) empty entry/entries out of" >&2
         echo "  $OWN_WEB_N — they were ignored, so fewer owners are enforced than the config lists." >&2
       fi
+      # ⚠️ Only added when declared: an empty `--default-branch ""` would be worse than absent --
+      # it would look like an answer. Absent means the rung falls back to deriving it, and says so
+      # on stderr if it cannot.
+      [ -n "$DEFAULT_BRANCH" ] && WEB_ARGS+=(--default-branch "$DEFAULT_BRANCH")
       run web-check . --online "${WEB_ARGS[@]}"; rc=$?
       set -e
       # Exit 1 CAN be a usage error — feature 016 makes it reachable from CONFIGURATION: own_web_max

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -391,6 +391,11 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
                         help="feature 016: a GitHub owner you control (repeatable). A destination "
                              "owned by one of these whose .md has no uuid becomes a FAILURE — it is "
                              "not an external limitation, it is a missing edit in a repo you control.")
+    parser.add_argument("--default-branch", metavar="NAME", default=None,
+                        help="the repo's default branch, for telling a link that is PENDING on it "
+                             "from one that is broken. Normally derived from `origin`; pass it when "
+                             "the checkout cannot answer (CI fetches only the PR ref, so there is "
+                             "no origin/HEAD, and a credential-less `ls-remote` cannot ask either)")
     parser.add_argument("--own-from-origin", action="store_true",
                         help="also treat the owner of this repo's `origin` remote as yours. A separate "
                              "flag rather than a magic --own value, so an owner literally called "
@@ -496,7 +501,18 @@ def _run_web_check_cli(argv: List[str], fetcher=None) -> int:
     # This is what lets us tell "pending on the default branch" from "broken" WITHOUT opening the
     # door to downgrading someone else's real break: only the repo we are actually in can have its
     # own working tree consulted about where a `blob/<default-branch>/...` URL points after a merge.
-    own = _own_repo(root)
+    own = _own_repo(root, getattr(args, "default_branch", None))
+    # ⚠️ A RUNG THAT DISABLES ITSELF IN SILENCE IS INDISTINGUISHABLE FROM ONE THAT WORKS, and it
+    # took THREE red builds to find that out: the rung was inert in CI and all anyone could see was
+    # the same `not-found` as always -- exactly what you would see if it had never been written.
+    # Each attempted fix looked like it had never arrived, when it had arrived and was switching
+    # itself off. Saying so costs one line on stderr and turns a mystery into a datum.
+    if own is None or not own.default_ref:
+        motivo = ("could not identify this repo from `origin`" if own is None
+                  else "could not determine the default branch (no origin/HEAD, and `ls-remote` "
+                       "could not be asked — pass --default-branch)")
+        print(f"  note: the pending-on-default-branch rung is INERT — {motivo}. A 404 to a file that "
+              "exists here will be reported as broken.", file=sys.stderr)
     findings, edits = check_web_links_online(root, token, fetcher or default_fetcher, block_markers,
                                              excludes, owners, out_of_root=web_out_of_root,
                                              include_mermaid=args.include_mermaid, own=own)
@@ -645,7 +661,7 @@ def _github_owner_from_origin(root: Path) -> Optional[str]:
     return m["owner"] if m else None
 
 
-def _own_repo(root: Path) -> Optional["OwnRepo"]:
+def _own_repo(root: Path, default_branch: Optional[str] = None) -> Optional["OwnRepo"]:
     """The repo we are running in: `owner/repo`, its REAL ROOT and its default branch. Or None.
 
     All three from the same reading of git, deliberately. Measured in adversarial review: the gate
@@ -701,8 +717,13 @@ def _own_repo(root: Path) -> Optional["OwnRepo"]:
     #
     # Guessing "main" would be worse than not knowing: it would forgive links in every repo whose
     # default is something else. Unknown still means inert.
-    head = _git("symbolic-ref", "--short", "refs/remotes/origin/HEAD") or ""
-    default_ref = head.split("/", 1)[1] if "/" in head else ""
+    # An explicit value wins over both automatic sources: it is the only one that cannot fail, and
+    # in CI it is often the only one that CAN answer -- the checkout has no origin/HEAD and the
+    # credentials for `ls-remote` are usually scoped to the checkout step, not to what it spawns.
+    default_ref = (default_branch or "").strip()
+    if not default_ref:
+        head = _git("symbolic-ref", "--short", "refs/remotes/origin/HEAD") or ""
+        default_ref = head.split("/", 1)[1] if "/" in head else ""
     if not default_ref:
         # `ref: refs/heads/master\tHEAD` on the first line, or nothing at all.
         salida = _git("ls-remote", "--symref", "origin", "HEAD") or ""

--- a/tests/test_own_repo_web_strictness.py
+++ b/tests/test_own_repo_web_strictness.py
@@ -18,6 +18,9 @@ from pathlib import Path
 import pytest
 
 from darnlink.cli import _run_web_check_cli
+URL = "https://github.com/example-org/handbook/blob/main/docs/living/service-topology.md"
+UUID = "3f9c1a2b-4d5e-6f70-8192-a3b4c5d6e7f8"
+
 from darnlink.weblinks import GithubUrl, check_web_links_online
 
 UUID = "3f9c1a2b-4d5e-6f70-8192-a3b4c5d6e7f8"
@@ -759,3 +762,29 @@ def test_default_branch_falls_back_to_the_remote_when_origin_HEAD_is_absent(tmp_
     assert own.default_ref == "master", (
         "origin/HEAD is absent, so this can only have come from the remote fallback; an empty "
         "value here means the rung is inert exactly where it is needed")
+
+
+def test_default_branch_flag_wins_over_the_automatic_sources(tmp_path):
+    """The explicit value is the only source that cannot fail, and in CI it is often the only one
+    that CAN answer: the checkout has no `origin/HEAD`, and the credentials for `ls-remote` are
+    usually scoped to the checkout step rather than to what it spawns."""
+    import subprocess
+    from darnlink.cli import _own_repo
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "remote", "add", "origin",
+                    "https://github.com/example-org/handbook.git"], check=True)
+    own = _own_repo(tmp_path, "trunk")
+    assert own is not None and own.default_ref == "trunk"
+
+
+def test_an_INERT_rung_says_so_instead_of_looking_like_a_working_one(tmp_path, capsys, monkeypatch):
+    """⚠️ THE LESSON THAT COST THREE RED BUILDS. When the rung cannot identify the repo it disables
+    itself — correct — but it did so SILENTLY, and a disabled rung looks exactly like one that ran
+    and found a real break: the same `web_not_found`, the same exit 4. Three attempted fixes each
+    looked like they had never arrived, when in fact they had arrived and were switching themselves
+    off. Saying it costs one line on stderr and turns a mystery into a datum."""
+    _w(tmp_path / "docs" / "living" / "service-topology.md", "# present\n")
+    _w(tmp_path / "conta.md", f"see [t]({URL}) <!-- web-uuid: {UUID} -->\n")   # no git repo at all
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
+    _run_web_check_cli([str(tmp_path), "--online"], fetcher=_fetcher({}))
+    assert "rung is INERT" in capsys.readouterr().err


### PR DESCRIPTION
I stopped guessing.

Three attempts at fixing the same red build. **Every one looked like it had never arrived** — same
two links, same `not-found 6`, same `exit 4`. It had arrived. The rung was switching itself off, and
there was nothing to read: **a rung that disables itself in silence is indistinguishable from one
that ran and found a real break.** The failure and the no-op print the same thing.

## This is one failure class, not one bug

| | was silent about | read as |
|---|---|---|
| a gate nobody ever ran | not running | covered |
| a bench green with six defects seeded in it | not measuring | passing |
| a watcher that read the previous build | not waiting | finished |
| **this rung** | **being disabled** | **finding a real break** |

Silence reads exactly like success. Every one of those was found by accident, days or hours late.

## What changes

**One line on stderr** when the rung cannot identify the repo or its default branch — which of the
two failed, and what it costs:

```
note: the pending-on-default-branch rung is INERT — could not determine the default branch
(no origin/HEAD, and `ls-remote` could not be asked — pass --default-branch). A 404 to a file
that exists here will be reported as broken.
```

**`--default-branch NAME`**, which wins over both automatic sources. It is the only one that cannot
fail, and in CI it is often the only one that *can* answer: the checkout has no `origin/HEAD` (only
the PR ref is fetched), and the credentials for `ls-remote` are usually scoped to the checkout step
rather than to what it spawns — which is where this runs.

## Verified by seeding, not by reading

Remove the note → one test fails. Remove the flag → another does. **491 pass** with both.

## What this does NOT do

- It does **not** yet prove which of the two conditions was failing in the build that started this.
  That is the point: until now there was no way to ask. The next build says it in its own log.
- It does **not** make the rung fire anywhere it did not before. Nothing is forgiven that was not
  forgiven yesterday; the only new behaviour is that a disabled rung admits it.
- The note goes to **stderr on every run where the rung is inert**, including ordinary local runs in
  a tree with no `origin`. That is deliberate — a warning that only appears in CI is one nobody
  reads — but it is a new line in everyone's output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
