### PR TITLE
Verify the recipe before running it, and three more defects the gate was handing out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to darnlink are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+⚠️ **The recipe is consumed AT A TAG, so the two behaviour fixes below reach nobody until this is
+released.** Anyone following the new README today seals a digest of a recipe that does not yet
+contain them.
+
+**The shipped CI templates downloaded the recipe and executed it without verifying a byte** — both
+of them, at every released version. `recipes/examples/github-actions-darnlink-gate.yml` and
+`recipes/examples/Jenkinsfile-stage.groovy` now compare `recipe_sha256` **before** `chmod +x`, warn
+loudly (instead of silently) when the key is absent, reject a value that is not a 64-hex digest with
+a message about placeholders rather than crying tampering, and fall back to `shasum -a 256` where
+`sha256sum` does not exist.
+
+**New config key `recipe_sha256`** — and "new" understates it: consumers had been using the key for
+months while it appeared nowhere in this repo, so every surface that verified had invented it
+locally. It is now documented in the recipe's CONFIG header and in `recipes/README.md`, including
+the rule that prevents the failure it is most likely to produce: **`ref` and `recipe_sha256` move in
+the same commit.** It is the one key the recipe never reads — whoever fetches the script consumes
+it, because a downloaded script cannot vouch for its own download. It does **not** cover
+`darnlink-gate.ps1`, which is a different file with a different digest.
+
+### Fixed
+
+- **A JSON `false` turned `include_mermaid` ON**, and `default_branch: false` reached the tool as
+  `--default-branch False`, a branch that exists nowhere. `read_cfg` renders a JSON boolean as the
+  string `"False"`, and `[ -n "$X" ]` is true for any non-empty string. Five other keys were already
+  normalised; the two that were not sat directly above a `case` belonging to a key assigned thirteen
+  lines earlier, which is how both were missed. Normalisers now live beside their own assignment.
+- **A docstring in `frontmatter_index.py` claimed a leading BOM survives the read.** `utf-8-sig`
+  consumes it. Documentation only — and the same reader's other docstring already said the opposite,
+  correctly.
+- **`tools/check.sh` run as a git hook redirected the suite's git calls at this repository.** git
+  exports `GIT_DIR` to hooks; tests that build their own repo in a temp dir were silently pointed
+  here, and one ordinary `git commit` produced a commit that deleted the entire tree. It also made
+  four tests fail *only* when the suite was acting as the gate.
+
 ## 0.26.0
 
 **An inert rung now says so.** When the pending-on-default-branch rung cannot identify the repo or

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -124,12 +124,19 @@ whole-repo where it's the wall.
 ```json
 {
   "ref": "git+https://github.com/txemi/darnlink@vX.Y.Z",
+  "recipe_sha256": "<sha256 of recipes/darnlink-gate at that ref>",
   "excludes": ["secrets", "external_repos"],
   "ignore_blocks": ["txmd-autogrid"],
   "mode": "check",
   "scope": "repo"
 }
 ```
+
+⚠️ **`recipe_sha256` is the only key here the recipe never reads.** Every other key is consumed by
+`darnlink-gate` once it is already running; this one is consumed by whatever **fetches** it, *before*
+it runs. That asymmetry is the whole point, and it is why the key was easy to overlook: a CI surface
+that downloads this script and executes it cannot ask the script whether the download was genuine.
+See **"Verify what you download"** below for how to compute and re-seal it.
 
 ⚠️ **`vX.Y.Z` is a placeholder, and it is the one thing here you must not copy verbatim.** Resolve it
 when you paste — `gh release view -R txemi/darnlink --json tagName -q .tagName` — because this is the
@@ -202,6 +209,9 @@ any CI can fetch it **without a token** (no private checkout, no cred):
 # Derive the version from the `ref` you already declared — do NOT write a second copy of it here.
 VER=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json"))["ref"].rsplit("@",1)[1])')
 curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate" -o darnlink-gate
+# VERIFY BEFORE YOU MAKE IT EXECUTABLE — see "Verify what you download" below.
+WANT=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json")).get("recipe_sha256",""))')
+[ -n "$WANT" ] && { echo "$WANT  darnlink-gate" | sha256sum -c - || exit 1; }
 chmod +x darnlink-gate
 ```
 
@@ -212,6 +222,47 @@ fails when two copies of a version number drift, so the second copy has to go ra
 sync. `-f` so a moved or typo'd version is a 404 instead of a file containing the words
 "404: Not Found". Windows agents fetch `darnlink-gate.ps1` the same way. Locally, drop it on your
 `PATH` (e.g. `~/.local/bin`).
+
+## Verify what you download
+
+Every CI surface in this page ends with the same three lines: **fetch a script over the network, mark
+it executable, run it.** A pin does not make that safe. A tag is a mutable pointer — and this recipe
+deliberately accepts a branch or a SHA too — so the pin says *which name* you asked for, never *which
+bytes* you got. `recipe_sha256` is the only statement about the bytes.
+
+Compute it once, at the ref you pinned:
+
+```bash
+VER=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json"))["ref"].rsplit("@",1)[1])')
+curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate" | sha256sum
+```
+
+and put the digest in `darnlink-gate.json` next to `ref`. The shipped examples then compare it
+**before** `chmod +x`, and — just as importantly — **say so when the key is absent** rather than
+staying quiet, because silence at that spot is indistinguishable from "verified".
+
+> ### ⚠️ The rule that actually bites: `ref` and `recipe_sha256` move TOGETHER
+>
+> They are two halves of one statement. Bump the pin and leave the digest behind, and the next build
+> fails with a checksum mismatch that *looks* like tampering. Keep them adjacent in the file, and
+> re-seal in the same commit that bumps the ref.
+>
+> This is why the examples' error message names **three** causes and puts the mundane one first. An
+> earlier wording offered only "the tag moved, or the fetch was tampered with" — both catastrophic,
+> neither of them what happens in practice. A message that only offers alarming explanations turns a
+> maintenance slip into a suspected supply-chain attack, and someone pays for that in wasted alarm.
+
+**Adopting this into an existing gate?** The two lines are additive and the key is optional, so a
+repo that has not sealed a digest yet keeps working exactly as before — it just starts warning that
+its download is unverified. That is deliberate: a hard failure on arrival would get the gate deleted
+rather than sealed.
+
+⚠️ **Fixing this file does not fix the copies.** These are copy-paste templates: every surface that
+already pasted the older version still runs unverified, and nothing here reaches them. Measured once
+across a private fleet: the wall was standing on the self-hosted-CI and local-script surfaces and
+**absent from every hosted-CI one**, in every repo — so it was not a stray bad copy, it was one whole
+axis that never had the check. When you take this update, grep your own surfaces rather than trusting
+a list.
 
 ## Notes
 

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -218,7 +218,9 @@ VER=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json"))["ref"]
 curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate" -o darnlink-gate
 # VERIFY BEFORE YOU MAKE IT EXECUTABLE — see "Verify what you download" below.
 WANT=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json")).get("recipe_sha256",""))')
+WANT=$(printf '%s' "$WANT" | tr 'A-F' 'a-f')   # PowerShell's Get-FileHash returns uppercase
 if [ -n "$WANT" ]; then
+  case "$WANT" in *[!0-9a-f]*|"") echo "recipe_sha256 is not a digest — did you paste the placeholder?" >&2; exit 1 ;; esac
   echo "$WANT  darnlink-gate" | sha256sum -c - || { rm -f darnlink-gate; exit 1; }
 else
   echo "darnlink-gate.json declares no recipe_sha256 — THIS DOWNLOAD IS NOT VERIFIED." >&2
@@ -241,8 +243,8 @@ templates print. Locally, drop it on your
 
 ## Verify what you download
 
-Two of the four pieces above end with the same three lines: **fetch a script over the network, mark
-it executable, run it** — piece 4 in both its forms, plus the manual snippet below. (Pieces 2 and 3
+Only piece 4 fetches anything, in both its forms — plus the manual snippet below. All three end
+with the same three lines: **fetch a script over the network, mark it executable, run it**. (Pieces 2 and 3
 `exec darnlink-gate` off your `PATH` and download nothing, so none of this applies to them.) A pin
 does not make the fetching ones safe. A tag is a mutable pointer — and this recipe
 deliberately accepts a branch or a SHA too — so the pin says *which name* you asked for, never *which

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -124,13 +124,20 @@ whole-repo where it's the wall.
 ```json
 {
   "ref": "git+https://github.com/txemi/darnlink@vX.Y.Z",
-  "recipe_sha256": "<sha256 of recipes/darnlink-gate at that ref>",
+  "recipe_sha256": "<64 hex chars — RESOLVE THIS, see below; do not paste it as-is>",
   "excludes": ["secrets", "external_repos"],
   "ignore_blocks": ["txmd-autogrid"],
   "mode": "check",
   "scope": "repo"
 }
 ```
+
+⚠️ **`recipe_sha256` is a placeholder too, and unlike `ref` it does not fail cleanly.** A wrong
+`ref` is a 404 and `curl -f` says so; a wrong digest is a *checksum mismatch*, and the first cause
+that message names is "someone bumped `ref` without re-sealing" — which is not what happened. The
+templates therefore check the SHAPE first (64 lowercase hex) and say "you pasted the placeholder"
+rather than crying tampering. Resolve it with the command in **"Verify what you download"** below,
+or drop the key while you adopt: absent is honest, wrong is misleading.
 
 ⚠️ **`recipe_sha256` is the only key here the recipe never reads.** Every other key is consumed by
 `darnlink-gate` once it is already running; this one is consumed by whatever **fetches** it, *before*
@@ -211,7 +218,11 @@ VER=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json"))["ref"]
 curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate" -o darnlink-gate
 # VERIFY BEFORE YOU MAKE IT EXECUTABLE — see "Verify what you download" below.
 WANT=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json")).get("recipe_sha256",""))')
-[ -n "$WANT" ] && { echo "$WANT  darnlink-gate" | sha256sum -c - || exit 1; }
+if [ -n "$WANT" ]; then
+  echo "$WANT  darnlink-gate" | sha256sum -c - || { rm -f darnlink-gate; exit 1; }
+else
+  echo "darnlink-gate.json declares no recipe_sha256 — THIS DOWNLOAD IS NOT VERIFIED." >&2
+fi
 chmod +x darnlink-gate
 ```
 
@@ -220,13 +231,20 @@ keep it pinned — and that instruction is what rotted: it sat at `v0.7.0` for *
 telling every new adopter to install a gate far behind the one documented right above it. Nothing
 fails when two copies of a version number drift, so the second copy has to go rather than be kept in
 sync. `-f` so a moved or typo'd version is a 404 instead of a file containing the words
-"404: Not Found". Windows agents fetch `darnlink-gate.ps1` the same way. Locally, drop it on your
+"404: Not Found". Windows agents fetch `darnlink-gate.ps1` the same way — ⚠️ **but `recipe_sha256` does NOT cover it.**
+The key is defined as the digest of `recipes/darnlink-gate`; the `.ps1` is a different file with a
+different digest, and there is no second key for it today. Sealing `recipe_sha256` on a Windows agent
+that fetches the `.ps1` gives a permanent mismatch. Until a `recipe_sha256_ps1` exists, verify that
+download by other means or leave it unsealed — knowingly, which is the whole point of the warning the
+templates print. Locally, drop it on your
 `PATH` (e.g. `~/.local/bin`).
 
 ## Verify what you download
 
-Every CI surface in this page ends with the same three lines: **fetch a script over the network, mark
-it executable, run it.** A pin does not make that safe. A tag is a mutable pointer — and this recipe
+Two of the four pieces above end with the same three lines: **fetch a script over the network, mark
+it executable, run it** — piece 4 in both its forms, plus the manual snippet below. (Pieces 2 and 3
+`exec darnlink-gate` off your `PATH` and download nothing, so none of this applies to them.) A pin
+does not make the fetching ones safe. A tag is a mutable pointer — and this recipe
 deliberately accepts a branch or a SHA too — so the pin says *which name* you asked for, never *which
 bytes* you got. `recipe_sha256` is the only statement about the bytes.
 
@@ -234,10 +252,15 @@ Compute it once, at the ref you pinned:
 
 ```bash
 VER=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json"))["ref"].rsplit("@",1)[1])')
-curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate" | sha256sum
+curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate" \
+  | sha256sum | cut -d' ' -f1
 ```
 
-and put the digest in `darnlink-gate.json` next to `ref`. The shipped examples then compare it
+⚠️ **The `cut` is not decoration.** `sha256sum` prints `<digest>  <name>` — two spaces and a name —
+and the templates compare against `cut -d" " -f1`. Paste the full line and you seal a value that can
+never match, reported as a mismatch. (On macOS: `shasum -a 256`, which the templates also accept.)
+
+Put the digest in `darnlink-gate.json` next to `ref`. The shipped examples then compare it
 **before** `chmod +x`, and — just as importantly — **say so when the key is absent** rather than
 staying quiet, because silence at that spot is indistinguishable from "verified".
 

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -243,7 +243,10 @@ DEFAULT_BRANCH="${DARNLINK_GATE_DEFAULT_BRANCH:-$(read_cfg default_branch "")}"
 # Same direction as `own_web_max` just below: a config typo may narrow what runs, never widen it.
 case "$DEFAULT_BRANCH" in
   True|False)
-    echo "darnlink-gate: default_branch=$DEFAULT_BRANCH is a JSON boolean, not a branch name -- ignoring it." >&2
+    # "looks like", not "is": a QUOTED "True" lands here too, and the shell cannot tell the two
+    # apart. Claiming it was a JSON boolean would be a false statement in that case, and a branch
+    # genuinely named True is not worth passing an unusable value through for.
+    echo "darnlink-gate: default_branch=$DEFAULT_BRANCH looks like a JSON boolean, not a branch name -- ignoring it." >&2
     echo "  Quote it (\"main\") if you meant a branch; remove the key to derive it from origin." >&2
     DEFAULT_BRANCH="" ;;
 esac

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -223,6 +223,10 @@ case "${WEB,,}" in ""|0|false|no|off) WEB="" ;; *) WEB=1 ;; esac
 mapfile -t OWN_WEB < <(read_cfg own_web "")
 OWN_WEB_N="$(read_cfg_len own_web)"; [[ "$OWN_WEB_N" =~ ^[0-9]+$ ]] || OWN_WEB_N=0
 OWN_WEB_FROM_ORIGIN="${DARNLINK_GATE_OWN_WEB_FROM_ORIGIN:-$(read_cfg own_web_from_origin "")}"
+# ⚠️ NORMALISE ON THE LINE AFTER THE ASSIGNMENT. This `case` used to sit thirteen lines below, past
+# two unrelated assignments -- and that is not a style point, it is how the bug below happened: the
+# next person to add a key landed right above a `case` that looked like theirs and was not.
+case "${OWN_WEB_FROM_ORIGIN,,}" in ""|0|false|no|off) OWN_WEB_FROM_ORIGIN="" ;; *) OWN_WEB_FROM_ORIGIN=1 ;; esac
 
 # The repo's DEFAULT BRANCH, for telling a link that is PENDING on it from one that is broken.
 # ⚠️ Normally derived from `origin`, and in CI that derivation FAILS: a multibranch PR job fetches
@@ -231,11 +235,26 @@ OWN_WEB_FROM_ORIGIN="${DARNLINK_GATE_OWN_WEB_FROM_ORIGIN:-$(read_cfg own_web_fro
 # exactly where it is needed -- three red builds before anyone could see that. Declaring it here
 # cannot fail and cannot be guessed wrong.
 DEFAULT_BRANCH="${DARNLINK_GATE_DEFAULT_BRANCH:-$(read_cfg default_branch "")}"
+# ⚠️ This one is a STRING, not a flag, so the fix is not a `case` -- a branch may legitimately be
+# called `off` or `no`, and silently blanking those would be a worse bug than the one being fixed.
+# What cannot be legitimate is a JSON boolean: `read_cfg` renders it "True"/"False", and the gate
+# would then run with `--default-branch False` -- a branch name that exists nowhere, making every
+# link look pending against a branch that does not exist. Refuse the type, keep every real name.
+# Same direction as `own_web_max` just below: a config typo may narrow what runs, never widen it.
+case "$DEFAULT_BRANCH" in
+  True|False)
+    echo "darnlink-gate: default_branch=$DEFAULT_BRANCH is a JSON boolean, not a branch name -- ignoring it." >&2
+    echo "  Quote it (\"main\") if you meant a branch; remove the key to derive it from origin." >&2
+    DEFAULT_BRANCH="" ;;
+esac
 # Feature 017 (opt-in, needs `web`): also watch the destinations a mermaid diagram carries in
 # its `click` directives. ABSENT MEANS OFF, per repository: a fleet of fail-closed gates has to
 # be able to switch this on one repo at a time. These links are report-only and never anchored.
 INCLUDE_MERMAID="${DARNLINK_GATE_INCLUDE_MERMAID:-$(read_cfg include_mermaid "")}"
-case "${OWN_WEB_FROM_ORIGIN,,}" in ""|0|false|no|off) OWN_WEB_FROM_ORIGIN="" ;; *) OWN_WEB_FROM_ORIGIN=1 ;; esac
+# `read_cfg` prints the raw Python value, so a JSON `false` arrives as the STRING "False" -- and the
+# `[ -n "$X" ]` this feeds is TRUE for any non-empty string. Without this line, `include_mermaid:
+# false` TURNED THE AXIS ON: the config said off, the gate read on, and nothing said a word.
+case "${INCLUDE_MERMAID,,}" in ""|0|false|no|off) INCLUDE_MERMAID="" ;; *) INCLUDE_MERMAID=1 ;; esac
 # A budget, so the rung is adoptable before a repo reaches zero. Non-numeric counts as ABSENT, never as
 # infinite: silently WIDENING an allowance is the one direction a config typo must not be able to go —
 # the same rule `dangling_max` follows, and for the same reason.
@@ -273,19 +292,24 @@ case "${CREATE_README,,}" in ""|0|false|no|off) CREATE_README="" ;; *) CREATE_RE
 # budget — an unlowered budget is the failure mode, and nothing else would catch it.
 # Only `repo` has a wall, so the budget only applies there. A non-numeric value is treated as 0
 # (strictest) on purpose: a typo must never silently WIDEN an allowance.
+# ⚠️ Each of these two is normalised on the lines directly after its own assignment. They used to be
+# interleaved (both assigned, then both normalised, in the other order) and BOTH were correct -- this
+# is prophylactic, not a bug fix. It is here because that interleaving is the exact shape that let two
+# other keys ship unguarded: an author adding a key lands above a `case` that belongs to someone else
+# and reasonably reads it as theirs. The pattern is what was dangerous, so the pattern is what goes.
 DANGLING="${DARNLINK_GATE_DANGLING:-$(read_cfg dangling off)}"
-DANGLING_MAX="${DARNLINK_GATE_DANGLING_MAX:-$(read_cfg dangling_max 0)}"
-case "$DANGLING_MAX" in
-  ''|*[!0-9]*)
-    echo "darnlink-gate: dangling_max='$DANGLING_MAX' is not a non-negative integer — using 0." >&2
-    DANGLING_MAX=0 ;;
-esac
 case "${DANGLING,,}" in
   off|""|0|false|no) DANGLING=off ;;
   warn) DANGLING=warn ;;
   added-lines|added_lines) DANGLING=added-lines ;;
   repo|all|on|1|true|yes) DANGLING=repo ;;
   *) echo "darnlink-gate: unknown dangling=$DANGLING (use off|warn|added-lines|repo) — treating as off." >&2; DANGLING=off ;;
+esac
+DANGLING_MAX="${DARNLINK_GATE_DANGLING_MAX:-$(read_cfg dangling_max 0)}"
+case "$DANGLING_MAX" in
+  ''|*[!0-9]*)
+    echo "darnlink-gate: dangling_max='$DANGLING_MAX' is not a non-negative integer — using 0." >&2
+    DANGLING_MAX=0 ;;
 esac
 mapfile -t EXCLUDES < <(read_cfg excludes "")
 mapfile -t IGNORE_BLOCKS < <(read_cfg ignore_blocks "")

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -34,12 +34,23 @@
 #
 # CONFIG. Reads `darnlink-gate.json` at the repo root (all keys optional):
 #   { "ref": "git+https://github.com/txemi/darnlink@vX.Y.Z",
+#     "recipe_sha256": "<sha256 of THIS file at that ref>",
 #     "excludes": ["secrets","node_modules",".venv"], "ignore_blocks": ["txmd-autogrid"],
 #     "mode": "max", "scope": "repo", "fail_closed": true,
 #     "web": true, "dangling": "repo", "create_readme": true,
 #     "create_readme_excludes": ["mirrors"] }
 #
 #   ^ That is the TARGET, not a starting point: every axis at its strictest.
+#
+#   ⚠️ `recipe_sha256` IS THE ONE KEY THIS SCRIPT NEVER READS, and that is not an oversight. Every
+#   other key is consumed here, at runtime, by a script that is already executing. That one is
+#   consumed by whoever FETCHES this file, before it runs -- because a downloaded script cannot
+#   vouch for its own download. It is listed here anyway: this header is where adopters look for
+#   the contract, and a key that exists only in the examples is a key nobody knows to set. The
+#   shipped CI examples compare it before `chmod +x`, and warn loudly when it is absent rather than
+#   passing silently. Compute and re-seal it as described in recipes/README.md
+#   ("Verify what you download") -- and re-seal it IN THE SAME COMMIT that bumps `ref`: the two are
+#   halves of one statement, and separating them produces a mismatch that reads like tampering.
 #
 #   `vX.Y.Z` is a PLACEHOLDER ON PURPOSE, and it is the one thing here you must not copy verbatim.
 #   Resolve it when you paste:

--- a/recipes/examples/Jenkinsfile-stage.groovy
+++ b/recipes/examples/Jenkinsfile-stage.groovy
@@ -37,14 +37,20 @@ stage('darnlink gate (links)') {
       # escape sequences inside a triple-quoted string, so a backslash that is not a valid escape is a
       # COMPILE error in the adopter's whole Jenkinsfile -- not a runtime one, and not confined to
       # this stage. The first draft of this block wrote a shell backtick as a backslash-backtick and
-      # did exactly that. Second: with no backslashes the raw text of this block is byte-identical to
-      # what Groovy hands to the shell, which is the only reason a test can extract it and run it.
+      # did exactly that. Second: the ONLY transformation either side applies is joining a backslash-
+      # newline, and BOTH apply it, so bash reading this raw text and Groovy handing it to sh are
+      # behaviourally identical -- NOT byte-identical: Groovy has already joined the continuations,
+      # so the two differ by a few bytes. That equivalence is why a test can extract this and run it.
       # Use single quotes where the shell needs a quote. There is a test that fails on a backslash.
       WANT=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json")).get("recipe_sha256",""))')
       if [ -n "$WANT" ]; then
         # A digest is 64 lowercase hex. Anything else is a copied placeholder or a truncated paste,
         # and without this it would be reported as a checksum MISMATCH -- sending the reader to hunt
         # a tampered download when they simply pasted the wrong thing.
+        # Uppercase is a REAL digest, not a typo: PowerShell's Get-FileHash returns A-F, and this
+        # page tells Windows agents to fetch the recipe. Rejecting it would call a correct value
+        # "not a digest" and tell the reader to replace it -- false, and it breaks a real adopter.
+        WANT=$(printf '%s' "$WANT" | tr 'A-F' 'a-f')
         case "$WANT" in
           *[!0-9a-f]* | "" ) BAD=1 ;;
           * ) [ ${#WANT} -eq 64 ] && BAD= || BAD=1 ;;

--- a/recipes/examples/Jenkinsfile-stage.groovy
+++ b/recipes/examples/Jenkinsfile-stage.groovy
@@ -28,6 +28,26 @@ stage('darnlink gate (links)') {
       # -f: fail on a 404 (moved/typo'd tag) instead of writing "404: Not Found" and running garbage.
       curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate" \
         -o "$WORKSPACE/.darnlink-gate"
+      # ⚠️ VERIFY BEFORE `chmod +x` -- byte-identical in intent to the GitHub Actions example, and for
+      # the same reason: this fetches a script over the network and runs it. `recipe_sha256` is the
+      # only statement about the BYTES; the pin is a mutable pointer (and may be a branch or a SHA).
+      WANT=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json")).get("recipe_sha256",""))')
+      if [ -n "$WANT" ]; then
+        GOT=$(sha256sum "$WORKSPACE/.darnlink-gate" | cut -d" " -f1)
+        if [ "$GOT" != "$WANT" ]; then
+          # THREE causes, most probable FIRST -- the mundane one is the one that actually happens.
+          echo "recipe checksum mismatch for $VER -- most likely someone bumped \`ref\` without re-sealing \`recipe_sha256\` next to it; otherwise the tag moved, or the download was tampered with" >&2
+          echo "  expected $WANT" >&2
+          echo "  got      $GOT" >&2
+          echo "  re-seal with: curl -fsSL \"https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate\" | sha256sum" >&2
+          rm -f "$WORKSPACE/.darnlink-gate"   # never leave an unverified script on disk
+          exit 1
+        fi
+        echo "recipe checksum OK: $GOT"
+      else
+        # Say so. Silence reads as "verified", which is the failure this step exists to prevent.
+        echo "darnlink-gate.json declares no recipe_sha256 -- THIS DOWNLOAD IS NOT VERIFIED. See recipes/README.md." >&2
+      fi
       chmod +x "$WORKSPACE/.darnlink-gate"
       "$WORKSPACE/.darnlink-gate"          # scope=repo from darnlink-gate.json
       rm -f "$WORKSPACE/.darnlink-gate"

--- a/recipes/examples/Jenkinsfile-stage.groovy
+++ b/recipes/examples/Jenkinsfile-stage.groovy
@@ -31,15 +31,43 @@ stage('darnlink gate (links)') {
       # ⚠️ VERIFY BEFORE `chmod +x` -- byte-identical in intent to the GitHub Actions example, and for
       # the same reason: this fetches a script over the network and runs it. `recipe_sha256` is the
       # only statement about the BYTES; the pin is a mutable pointer (and may be a branch or a SHA).
+      # ⚠️ NO BACKSLASH IN THIS BLOCK EXCEPT A LINE CONTINUATION (a backslash immediately before a
+      # newline, as on the curl above -- Groovy and the shell both just remove it, so they agree).
+      # That rule is load-bearing twice over. Groovy processes
+      # escape sequences inside a triple-quoted string, so a backslash that is not a valid escape is a
+      # COMPILE error in the adopter's whole Jenkinsfile -- not a runtime one, and not confined to
+      # this stage. The first draft of this block wrote a shell backtick as a backslash-backtick and
+      # did exactly that. Second: with no backslashes the raw text of this block is byte-identical to
+      # what Groovy hands to the shell, which is the only reason a test can extract it and run it.
+      # Use single quotes where the shell needs a quote. There is a test that fails on a backslash.
       WANT=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json")).get("recipe_sha256",""))')
       if [ -n "$WANT" ]; then
-        GOT=$(sha256sum "$WORKSPACE/.darnlink-gate" | cut -d" " -f1)
+        # A digest is 64 lowercase hex. Anything else is a copied placeholder or a truncated paste,
+        # and without this it would be reported as a checksum MISMATCH -- sending the reader to hunt
+        # a tampered download when they simply pasted the wrong thing.
+        case "$WANT" in
+          *[!0-9a-f]* | "" ) BAD=1 ;;
+          * ) [ ${#WANT} -eq 64 ] && BAD= || BAD=1 ;;
+        esac
+        if [ -n "$BAD" ]; then
+          echo "recipe_sha256 is not a sha256 digest (expected 64 lowercase hex): $WANT" >&2
+          echo "  if that looks like the placeholder from recipes/README.md, replace it with a real digest." >&2
+          rm -f "$WORKSPACE/.darnlink-gate"
+          exit 1
+        fi
+        # macOS ships shasum, not sha256sum. Without this the step dies with command-not-found on a
+        # mac agent -- fail-closed, so no false green, but it breaks a consumer who works today.
+        if command -v sha256sum >/dev/null 2>&1; then
+          GOT=$(sha256sum "$WORKSPACE/.darnlink-gate" | cut -d" " -f1)
+        else
+          GOT=$(shasum -a 256 "$WORKSPACE/.darnlink-gate" | cut -d" " -f1)
+        fi
         if [ "$GOT" != "$WANT" ]; then
           # THREE causes, most probable FIRST -- the mundane one is the one that actually happens.
-          echo "recipe checksum mismatch for $VER -- most likely someone bumped \`ref\` without re-sealing \`recipe_sha256\` next to it; otherwise the tag moved, or the download was tampered with" >&2
+          echo "recipe checksum mismatch for $VER -- most likely someone bumped 'ref' without re-sealing 'recipe_sha256' next to it; otherwise the tag moved, or the download was tampered with" >&2
           echo "  expected $WANT" >&2
           echo "  got      $GOT" >&2
-          echo "  re-seal with: curl -fsSL \"https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate\" | sha256sum" >&2
+          echo "  re-seal: curl -fsSL 'https://raw.githubusercontent.com/txemi/darnlink/$VER/recipes/darnlink-gate' | sha256sum | cut -d' ' -f1" >&2
           rm -f "$WORKSPACE/.darnlink-gate"   # never leave an unverified script on disk
           exit 1
         fi

--- a/recipes/examples/github-actions-darnlink-gate.yml
+++ b/recipes/examples/github-actions-darnlink-gate.yml
@@ -51,7 +51,28 @@ jobs:
           # a SHA too. Only the checksum is a statement about the BYTES.
           WANT=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json")).get("recipe_sha256",""))')
           if [ -n "$WANT" ]; then
-            GOT=$(sha256sum "$RUNNER_TEMP/darnlink-gate" | cut -d" " -f1)
+            # A digest is 64 lowercase hex. Anything else is a copied placeholder or a truncated
+            # paste — and without this check it is reported as a checksum MISMATCH, sending the
+            # reader to hunt a tampered download when they simply pasted the wrong thing. That is
+            # the most likely FIRST-CONTACT failure of this whole file, so it gets its own message.
+            case "$WANT" in
+              *[!0-9a-f]* | "" ) BAD=1 ;;
+              * ) [ ${#WANT} -eq 64 ] && BAD= || BAD=1 ;;
+            esac
+            if [ -n "$BAD" ]; then
+              echo "::error::recipe_sha256 is not a sha256 digest (expected 64 lowercase hex): $WANT"
+              echo "::error::  if that looks like the placeholder from recipes/README.md, replace it with a real digest."
+              rm -f "$RUNNER_TEMP/darnlink-gate"
+              exit 1
+            fi
+            # macOS ships shasum, not sha256sum: a macos-latest runner or a self-hosted mac agent
+            # would die with command-not-found. It fails closed, so no false green — but it breaks a
+            # consumer who works today, the moment they seal a digest.
+            if command -v sha256sum >/dev/null 2>&1; then
+              GOT=$(sha256sum "$RUNNER_TEMP/darnlink-gate" | cut -d" " -f1)
+            else
+              GOT=$(shasum -a 256 "$RUNNER_TEMP/darnlink-gate" | cut -d" " -f1)
+            fi
             if [ "$GOT" != "$WANT" ]; then
               # THREE causes, most probable FIRST. An earlier version of this message named only the
               # two alarming ones ("the tag moved, or the fetch was tampered with") and the cause that
@@ -61,7 +82,7 @@ jobs:
               echo "::error::recipe checksum mismatch for ${DARNLINK_GATE_VERSION} — most likely someone bumped \`ref\` without re-sealing \`recipe_sha256\` next to it; otherwise the tag moved, or the download was tampered with"
               echo "::error::  expected $WANT"
               echo "::error::  got      $GOT"
-              echo "::error::  re-seal with: curl -fsSL \"https://raw.githubusercontent.com/txemi/darnlink/${DARNLINK_GATE_VERSION}/recipes/darnlink-gate\" | sha256sum"
+              echo "::error::  re-seal: curl -fsSL 'https://raw.githubusercontent.com/txemi/darnlink/${DARNLINK_GATE_VERSION}/recipes/darnlink-gate' | sha256sum | cut -d' ' -f1"
               rm -f "$RUNNER_TEMP/darnlink-gate"   # never leave an unverified script on disk
               exit 1
             fi

--- a/recipes/examples/github-actions-darnlink-gate.yml
+++ b/recipes/examples/github-actions-darnlink-gate.yml
@@ -55,6 +55,10 @@ jobs:
             # paste — and without this check it is reported as a checksum MISMATCH, sending the
             # reader to hunt a tampered download when they simply pasted the wrong thing. That is
             # the most likely FIRST-CONTACT failure of this whole file, so it gets its own message.
+            # Uppercase is a REAL digest, not a typo: PowerShell's Get-FileHash returns A-F, and this
+            # page tells Windows agents to fetch the recipe. Rejecting it would call a correct value
+            # "not a digest" and tell the reader to replace it -- false, and it breaks a real adopter.
+            WANT=$(printf '%s' "$WANT" | tr 'A-F' 'a-f')
             case "$WANT" in
               *[!0-9a-f]* | "" ) BAD=1 ;;
               * ) [ ${#WANT} -eq 64 ] && BAD= || BAD=1 ;;
@@ -79,7 +83,7 @@ jobs:
               # actually occurs is the mundane third: a `ref` bumped without re-sealing the checksum
               # beside it. Offering only catastrophic branches makes a maintenance slip look like
               # sabotage; measured cost of that omission, once: about an hour of the wrong suspicion.
-              echo "::error::recipe checksum mismatch for ${DARNLINK_GATE_VERSION} — most likely someone bumped \`ref\` without re-sealing \`recipe_sha256\` next to it; otherwise the tag moved, or the download was tampered with"
+              echo "::error::recipe checksum mismatch for ${DARNLINK_GATE_VERSION} — most likely someone bumped 'ref' without re-sealing 'recipe_sha256' next to it; otherwise the tag moved, or the download was tampered with"
               echo "::error::  expected $WANT"
               echo "::error::  got      $GOT"
               echo "::error::  re-seal: curl -fsSL 'https://raw.githubusercontent.com/txemi/darnlink/${DARNLINK_GATE_VERSION}/recipes/darnlink-gate' | sha256sum | cut -d' ' -f1"

--- a/recipes/examples/github-actions-darnlink-gate.yml
+++ b/recipes/examples/github-actions-darnlink-gate.yml
@@ -37,11 +37,40 @@ jobs:
           VER=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json"))["ref"].rsplit("@",1)[1])') \
             || { echo "::error::cannot derive the pin: darnlink-gate.json has no ref key, or its ref has no @version"; exit 1; }
           echo "DARNLINK_GATE_VERSION=$VER" >> "$GITHUB_ENV"
-      - name: Fetch the pinned recipe (public repo → no token)
+      - name: Fetch the pinned recipe and VERIFY it before running it
         run: |
           # -f: fail on a 404 (a moved/typo'd tag), instead of silently writing "404: Not Found".
           curl -fsSL "https://raw.githubusercontent.com/txemi/darnlink/${DARNLINK_GATE_VERSION}/recipes/darnlink-gate" \
             -o "$RUNNER_TEMP/darnlink-gate"
+          # ⚠️ VERIFY BEFORE `chmod +x`, not after. This step downloads a script from the network and
+          # executes it on every push and every PR — the single most consequential thing this file
+          # does. `recipe_sha256` is what turns "someone moved the recipe under you" into a red build
+          # with a name on it; without it, curl|chmod|run trusts whatever the URL served that day.
+          #
+          # A pin is not a substitute. A tag is a mutable pointer, and this file accepts a branch or
+          # a SHA too. Only the checksum is a statement about the BYTES.
+          WANT=$(python3 -c 'import json;print(json.load(open("darnlink-gate.json")).get("recipe_sha256",""))')
+          if [ -n "$WANT" ]; then
+            GOT=$(sha256sum "$RUNNER_TEMP/darnlink-gate" | cut -d" " -f1)
+            if [ "$GOT" != "$WANT" ]; then
+              # THREE causes, most probable FIRST. An earlier version of this message named only the
+              # two alarming ones ("the tag moved, or the fetch was tampered with") and the cause that
+              # actually occurs is the mundane third: a `ref` bumped without re-sealing the checksum
+              # beside it. Offering only catastrophic branches makes a maintenance slip look like
+              # sabotage; measured cost of that omission, once: about an hour of the wrong suspicion.
+              echo "::error::recipe checksum mismatch for ${DARNLINK_GATE_VERSION} — most likely someone bumped \`ref\` without re-sealing \`recipe_sha256\` next to it; otherwise the tag moved, or the download was tampered with"
+              echo "::error::  expected $WANT"
+              echo "::error::  got      $GOT"
+              echo "::error::  re-seal with: curl -fsSL \"https://raw.githubusercontent.com/txemi/darnlink/${DARNLINK_GATE_VERSION}/recipes/darnlink-gate\" | sha256sum"
+              rm -f "$RUNNER_TEMP/darnlink-gate"   # never leave an unverified script on disk
+              exit 1
+            fi
+            echo "recipe checksum OK: $GOT"
+          else
+            # SAY SO. Silence here is indistinguishable from "verified", which is the failure this
+            # whole step exists to prevent — one layer up.
+            echo "::warning::darnlink-gate.json declares no recipe_sha256 — THIS DOWNLOAD IS NOT VERIFIED. See recipes/README.md."
+          fi
           chmod +x "$RUNNER_TEMP/darnlink-gate"
       - name: darnlink gate (whole repo)
         # Only needed with `"web": true`, and the reason is QUOTA, not permission: anonymous GitHub

--- a/src/darnlink/frontmatter_index.py
+++ b/src/darnlink/frontmatter_index.py
@@ -139,8 +139,9 @@ def scan_tree(
     Measured on a large repo in the fleet: ~25-30s per pass, so a plain `check` paid for two full
     tree reads to produce two verdicts neither of which alone needed the other's walk to also happen.
 
-    This is the ONE walk both axes now share. `read_text_keep_newlines` (byte-preserving: CRLF and
-    a leading BOM survive verbatim) is used rather than `read_text()`'s universal-newline read that
+    This is the ONE walk both axes now share. `read_text_keep_newlines` (no universal-newline
+    translation, so CRLF survives verbatim; a leading BOM is STRIPPED, since it reads `utf-8-sig`)
+    is used rather than `read_text()`'s universal-newline read that
     `build_index` used before this — parsing YAML frontmatter for a `uuid` does not care about the
     line-ending style, so this is a safe unification, not a behaviour change for the index; it is
     the mode the WRITE-side callers (repair, robustify) always needed, so unifying on it (rather

--- a/tests/test_hook_env_does_not_leak_into_the_suite.py
+++ b/tests/test_hook_env_does_not_leak_into_the_suite.py
@@ -39,14 +39,25 @@ requires_bash = pytest.mark.skipif(
     reason="the guard is POSIX shell; on Windows agents `bash` is the WSL launcher",
 )
 CHECK_SH = Path(__file__).resolve().parent.parent / "tools" / "check.sh"
-LEAKY = ("GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE", "GIT_PREFIX")
+# ⚠️ THIS LIST MUST NAME EVERY VARIABLE THE GUARD CLEARS. It listed four of seven, and a review
+# seeded the gap: shrinking the `unset` to just those four left this file GREEN. A test whose
+# docstring promises "dropping one is a failure with the variable's name on it" while silently
+# ignoring three of them is worse than no test, because it is quoted as coverage.
+LEAKY = ("GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE", "GIT_PREFIX", "GIT_COMMON_DIR",
+         "GIT_OBJECT_DIRECTORY", "GIT_NAMESPACE", "GIT_CONFIG_PARAMETERS")
 
 
 def _guard_line() -> str:
-    line = next((l for l in CHECK_SH.read_text(encoding="utf-8").splitlines()
-                 if l.startswith("unset ") and "GIT_DIR" in l), None)
-    assert line, "tools/check.sh no longer unsets git's per-invocation environment"
-    return line
+    """The whole `unset` statement, continuations included — it spans two lines now, and reading only
+    the first would silently stop checking the variables on the second."""
+    text = CHECK_SH.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    start = next((i for i, l in enumerate(lines) if l.startswith("unset ") and "GIT_DIR" in l), None)
+    assert start is not None, "tools/check.sh no longer unsets git's per-invocation environment"
+    out = [lines[start]]
+    while out[-1].rstrip().endswith("\\") and start + len(out) < len(lines):
+        out.append(lines[start + len(out)])
+    return " ".join(l.rstrip("\\").strip() for l in out)
 
 
 def _where_does_a_child_git_point(tmp_path: Path, env_extra: dict, prelude: str = "") -> str:
@@ -94,7 +105,7 @@ def test_the_guard_runs_before_anything_that_shells_out():
     already run against the inherited environment."""
     lines = CHECK_SH.read_text(encoding="utf-8").splitlines()
     code = [(i, l) for i, l in enumerate(lines) if not l.strip().startswith("#")]
-    unset = min(i for i, l in code if l.startswith("unset ") and "GIT_DIR" in l)
+    unset = min(i for i, l in code if l.startswith("unset ") and "GIT_DIR" in l)  # noqa: A001
     runs = [i for i, l in code if "uvx " in l or "uv run" in l or "python3 tools/" in l]
     assert runs, "check.sh no longer runs anything — this test is measuring the wrong file"
     assert unset < min(runs), (

--- a/tests/test_hook_env_does_not_leak_into_the_suite.py
+++ b/tests/test_hook_env_does_not_leak_into_the_suite.py
@@ -23,7 +23,21 @@ from pathlib import Path
 
 import pytest
 
-requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="needs git")
+# ⚠️ The platform test comes FIRST and `shutil.which` is only a fallback: on a GitHub windows-latest
+# runner `bash` IS on PATH -- it is the WSL launcher -- so `which` finds it and then every invocation
+# exits 1 with "Windows Subsystem for Linux has no installed distributions", in UTF-16. A
+# `which("bash") is None` guard alone does not skip; it turns the whole Windows matrix red. Measured
+# on this very PR: these two tests failed on all four Windows jobs, in exactly that way, and the
+# sibling file `test_recipe_examples.py` already carried this same guard for the same reason.
+#
+# Only the two EXECUTING tests are skipped. The text checks below stay live on Windows: they are the
+# ones most likely to rot and they cost nothing to run anywhere, and skipping the module wholesale
+# would leave the Windows matrix validating none of this.
+requires_bash = pytest.mark.skipif(
+    sys.platform.startswith("win") or os.name == "nt" or shutil.which("bash") is None
+    or shutil.which("git") is None,
+    reason="the guard is POSIX shell; on Windows agents `bash` is the WSL launcher",
+)
 CHECK_SH = Path(__file__).resolve().parent.parent / "tools" / "check.sh"
 LEAKY = ("GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE", "GIT_PREFIX")
 
@@ -44,7 +58,7 @@ def _where_does_a_child_git_point(tmp_path: Path, env_extra: dict, prelude: str 
     return r.stdout.strip()
 
 
-@requires_git
+@requires_bash
 def test_the_leak_is_REAL_hooks_redirect_a_child_git_at_this_repo(tmp_path):
     """The control. Without it the test below passes on a suite that was never vulnerable, and this
     file asserts nothing. My first attempt at this control FAILED -- I had guessed GIT_INDEX_FILE
@@ -58,7 +72,7 @@ def test_the_leak_is_REAL_hooks_redirect_a_child_git_at_this_repo(tmp_path):
         "and the guard in tools/check.sh needs re-measuring rather than trusting")
 
 
-@requires_git
+@requires_bash
 def test_the_guard_in_check_sh_stops_it(tmp_path):
     """Treatment: the SAME hijack, behind the exact `unset` line check.sh ships."""
     here = subprocess.run(["git", "rev-parse", "--absolute-git-dir"], cwd=CHECK_SH.parent,

--- a/tests/test_hook_env_does_not_leak_into_the_suite.py
+++ b/tests/test_hook_env_does_not_leak_into_the_suite.py
@@ -1,0 +1,87 @@
+"""`tools/check.sh` IS the pre-commit and pre-push hook, and a hook inherits git's environment.
+
+Measured here, once: an ordinary `git commit` produced a commit that DELETED THE ENTIRE TREE, and
+its message was `i` -- a string that appears nowhere in this project except a test fixture. Nothing
+was wrong with the change being committed. git exports GIT_DIR to its hooks; the hook runs this
+suite; four tests across two files legitimately build their own repo in a temp dir and shell out to
+git; those child `git` calls were redirected at THIS repository, so a fixture's `git add -A` and
+`git commit` landed on the real branch, mid-commit.
+
+The working files survive -- the commit just stops describing them -- so the damage reads as a
+catastrophic mistake by whoever committed, and `git status` afterwards calls the whole repo
+untracked.
+
+The same leak has a quieter second effect that is arguably worse: run by hand the suite is green,
+run as the hook those same four tests fail. A gate that is red only when it is acting as the gate
+teaches people to bypass it.
+"""
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+requires_git = pytest.mark.skipif(shutil.which("git") is None, reason="needs git")
+CHECK_SH = Path(__file__).resolve().parent.parent / "tools" / "check.sh"
+LEAKY = ("GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE", "GIT_PREFIX")
+
+
+def _guard_line() -> str:
+    line = next((l for l in CHECK_SH.read_text(encoding="utf-8").splitlines()
+                 if l.startswith("unset ") and "GIT_DIR" in l), None)
+    assert line, "tools/check.sh no longer unsets git's per-invocation environment"
+    return line
+
+
+def _where_does_a_child_git_point(tmp_path: Path, env_extra: dict, prelude: str = "") -> str:
+    """Build a repo in a temp dir and ask the child git which repo it is actually talking to."""
+    target = tmp_path / "elsewhere"
+    script = f'{prelude}\ngit init -q "{target}"\ngit -C "{target}" rev-parse --absolute-git-dir\n'
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True,
+                       env={**os.environ, **env_extra})
+    return r.stdout.strip()
+
+
+@requires_git
+def test_the_leak_is_REAL_hooks_redirect_a_child_git_at_this_repo(tmp_path):
+    """The control. Without it the test below passes on a suite that was never vulnerable, and this
+    file asserts nothing. My first attempt at this control FAILED -- I had guessed GIT_INDEX_FILE
+    alone and could not reproduce the damage, so the fix was withheld until the variable was pinned.
+    Keeping the control is what turned a plausible story into a measured one."""
+    here = subprocess.run(["git", "rev-parse", "--absolute-git-dir"], cwd=CHECK_SH.parent,
+                          capture_output=True, text=True, check=True).stdout.strip()
+    got = _where_does_a_child_git_point(tmp_path, {"GIT_DIR": here})
+    assert got == here, (
+        "expected GIT_DIR to hijack a child git; if this no longer holds, git changed its behaviour "
+        "and the guard in tools/check.sh needs re-measuring rather than trusting")
+
+
+@requires_git
+def test_the_guard_in_check_sh_stops_it(tmp_path):
+    """Treatment: the SAME hijack, behind the exact `unset` line check.sh ships."""
+    here = subprocess.run(["git", "rev-parse", "--absolute-git-dir"], cwd=CHECK_SH.parent,
+                          capture_output=True, text=True, check=True).stdout.strip()
+    got = _where_does_a_child_git_point(tmp_path, {"GIT_DIR": here}, prelude=_guard_line())
+    assert got != here, "the guard did not stop the redirect"
+    assert got.startswith(str(tmp_path)), f"child git landed somewhere unexpected: {got}"
+
+
+@pytest.mark.parametrize("var", LEAKY)
+def test_every_variable_git_exports_to_hooks_is_cleared(var):
+    """Named individually so dropping one from the list is a failure with the variable's name on it,
+    rather than a silently narrower guard."""
+    assert var in _guard_line(), f"{var} is no longer cleared before the suite runs"
+
+
+def test_the_guard_runs_before_anything_that_shells_out():
+    """Order is the property. An `unset` after `uv run pytest` is decoration: by then the tests have
+    already run against the inherited environment."""
+    lines = CHECK_SH.read_text(encoding="utf-8").splitlines()
+    code = [(i, l) for i, l in enumerate(lines) if not l.strip().startswith("#")]
+    unset = min(i for i, l in code if l.startswith("unset ") and "GIT_DIR" in l)
+    runs = [i for i, l in code if "uvx " in l or "uv run" in l or "python3 tools/" in l]
+    assert runs, "check.sh no longer runs anything — this test is measuring the wrong file"
+    assert unset < min(runs), (
+        f"the guard is at line {unset+1}, after the first child process at line {min(runs)+1}")

--- a/tests/test_hook_env_does_not_leak_into_the_suite.py
+++ b/tests/test_hook_env_does_not_leak_into_the_suite.py
@@ -94,9 +94,15 @@ def test_the_guard_in_check_sh_stops_it(tmp_path):
 
 
 @pytest.mark.parametrize("var", LEAKY)
-def test_every_variable_git_exports_to_hooks_is_cleared(var):
-    """Named individually so dropping one from the list is a failure with the variable's name on it,
-    rather than a silently narrower guard."""
+def test_every_variable_the_guard_CLEARS_is_named_here(var):
+    """Named individually so dropping one from the guard is a failure with the variable's name on it,
+    rather than a silently narrower guard.
+
+    ⚠️ The name says "the guard clears", not "git exports", and the difference is deliberate. git also
+    exports GIT_AUTHOR_NAME/EMAIL/DATE, GIT_EDITOR and GIT_EXEC_PATH to hooks, and those are left
+    alone on purpose: the author/editor set only affects commits a test makes in its OWN repo, which
+    is harmless, and clearing GIT_EXEC_PATH could break git itself on an unusual install. The list
+    here is the contract of the guard, and an earlier name overclaimed it as the contract of git."""
     assert var in _guard_line(), f"{var} is no longer cleared before the suite runs"
 
 

--- a/tests/test_recipe_examples.py
+++ b/tests/test_recipe_examples.py
@@ -340,3 +340,60 @@ def test_the_checksum_key_is_DOCUMENTED_not_only_used(doc):
     is a key nobody knows to set, and one no reader can look up."""
     assert RECIPE_SHA_KEY in doc.read_text(encoding="utf-8"), (
         f"{doc.name} does not document {RECIPE_SHA_KEY}")
+
+
+# ─────────────────────────────────────────────────────────────────────────────────────────────────
+# THE JENKINS EXAMPLE IS GROOVY, AND GROOVY EATS BACKSLASHES BEFORE THE SHELL EVER SEES THEM.
+#
+# Escape sequences ARE processed inside a Groovy ''' … ''' string. A backslash that is not a valid
+# Groovy escape is a COMPILE error — and it takes down the adopter's entire Jenkinsfile at CPS
+# compile time, before any stage runs, not just this stage.
+#
+# ⚠️ Measured on this PR: `\`ref\`` (backslash-backtick, meant as a shell backtick) shipped here and
+# `main` parsed while this branch did not, on Groovy 2.4.21 and 4.0.22 alike. The whole suite stayed
+# GREEN on it, because `_fetch_shell` reads the RAW FILE TEXT and hands it to bash — bash is happy
+# with `\``, Groovy is not. The repo had already written this failure down twice (the `ps1-syntax`
+# CI job exists for the identical reason on the PowerShell side, and this file's own header records
+# an adversarial round where "a `\.` that is a Groovy compile error" survived the suite) and it
+# happened anyway.
+#
+# There is no Groovy parser in this test environment, so this asserts the INVARIANT THAT MAKES THE
+# CLASS IMPOSSIBLE instead of parsing: no backslash at all, except a line continuation. That is
+# strictly stronger than "it happens to parse today", and it is checkable everywhere.
+#
+# It is also what makes `_fetch_shell` honest: with no escapes, the raw text IS what Groovy hands to
+# the shell, so running the raw text tests the real thing. Without this, those tests measure a string
+# Jenkins never sees.
+
+def test_the_jenkins_example_contains_no_groovy_escape_the_shell_would_not_see():
+    text = JENKINS.read_text(encoding="utf-8")
+    m = re.search(r"sh\s+'''(.*?)'''", text, re.DOTALL)
+    assert m, "no sh ''' … ''' block in the Jenkins example"
+    body = m.group(1)
+    offenders = []
+    for n, line in enumerate(body.splitlines(), 1):
+        # A trailing backslash is a line continuation: Groovy drops backslash+newline, and so does
+        # the shell, so both agree. Every other backslash is an escape only ONE of them resolves.
+        stripped = line[:-1] if line.endswith("\\") else line
+        if "\\" in stripped:
+            offenders.append(f"line {n}: {line.strip()[:90]}")
+    assert not offenders, (
+        "backslash escapes in the Jenkins sh block — Groovy resolves these before the shell sees "
+        "them, so at best the shell gets different text and at worst the adopter's whole Jenkinsfile "
+        "fails to compile:\n  " + "\n  ".join(offenders))
+
+
+def test_both_examples_carry_the_same_verification_contract():
+    """The two templates drifted once already (the Jenkins one shipped without the fetch-version
+    check the Actions one had, and the suite was green). The checksum wall must not drift the same
+    way: whatever one verifies, the other verifies."""
+    a = ACTIONS.read_text(encoding="utf-8")
+    j = JENKINS.read_text(encoding="utf-8")
+    for token, what in [("recipe_sha256", "reads the digest key"),
+                        ("sha256sum", "computes a digest"),
+                        ("shasum -a 256", "has the macOS fallback"),
+                        ("NOT VERIFIED", "warns when the key is absent"),
+                        ("re-sealing", "names the mundane cause first"),
+                        ("64 lowercase hex", "rejects a non-digest before crying mismatch")]:
+        assert token in a, f"the Actions example no longer {what}"
+        assert token in j, f"the Jenkins example no longer {what}"

--- a/tests/test_recipe_examples.py
+++ b/tests/test_recipe_examples.py
@@ -214,3 +214,129 @@ def test_version_is_derived_and_lazy():
          "import sys, darnlink; print('importlib.metadata' in sys.modules)"],
         capture_output=True, text=True)
     assert probe.stdout.strip() == "False", "importing darnlink must not pull importlib.metadata"
+
+
+# ─────────────────────────────────────────────────────────────────────────────────────────────────
+# The examples download a script and RUN it. Until this block existed, nothing checked that they
+# verified what they downloaded — and they did not, in either file, at any released version. The
+# defect shipped by copy-paste: every surface that pasted these templates inherited it, and the
+# copies are not reachable from here, which is exactly why the templates must be gated.
+#
+# ⚠️ These tests EXECUTE the shipped shell with a stubbed `curl`, rather than grepping it. A text
+# assertion ("the file mentions sha256sum") is satisfied by a comment, by a disabled branch, or by a
+# comparison placed AFTER `chmod +x` — all three of which look fine on inspection and verify nothing.
+# The mutation that motivated this: moving the comparison below the `chmod +x` kept every text check
+# green.
+RECIPE_SHA_KEY = "recipe_sha256"
+
+
+def _fetch_shell(path: Path) -> str:
+    """The shipped fetch-and-verify shell, with `curl` stubbed to write known bytes."""
+    if path is ACTIONS:
+        yaml = pytest.importorskip("yaml")
+        doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        body = next(s["run"] for s in doc["jobs"]["gate"]["steps"]
+                    if "curl" in s.get("run", "") and "sha256sum" in s.get("run", ""))
+    else:
+        m = re.search(r"sh\s+'''(.*?)'''", path.read_text(encoding="utf-8"), re.DOTALL)
+        assert m, "no sh ''' … ''' block in the Jenkins example"
+        body = m.group(1)
+    stub = ('curl() { while [ $# -gt 0 ]; do if [ "$1" = "-o" ]; then shift; '
+            'printf "%s" "$PAYLOAD" > "$1"; return 0; fi; shift; done; }\n')
+    return stub + body
+
+
+def _run_fetch(path: Path, cwd: Path, payload: str, sealed):
+    cfg = {"ref": "git+https://github.com/txemi/darnlink@main"}
+    if sealed is not None:
+        cfg[RECIPE_SHA_KEY] = sealed
+    (cwd / "darnlink-gate.json").write_text(json.dumps(cfg), encoding="utf-8")
+    env = {**os.environ, "PAYLOAD": payload, "RUNNER_TEMP": str(cwd),
+           "WORKSPACE": str(cwd), "DARNLINK_GATE_VERSION": "main"}
+    return subprocess.run(["bash", "-c", _fetch_shell(path)],
+                          cwd=cwd, capture_output=True, text=True, env=env)
+
+
+def _sha(s: str) -> str:
+    import hashlib
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+@pytest.mark.parametrize("example", EXECUTED, ids=lambda p: p.name)
+@requires_bash
+def test_a_tampered_recipe_is_REFUSED_not_executed(tmp_path, example):
+    """The one that matters. A sealed digest plus different bytes must stop the build."""
+    r = _run_fetch(example, tmp_path, "#!/bin/sh\necho pwned\n", sealed=_sha("the original bytes"))
+    assert r.returncode != 0, f"a tampered recipe was accepted: {r.stdout}{r.stderr}"
+
+
+@pytest.mark.parametrize("example", EXECUTED, ids=lambda p: p.name)
+@requires_bash
+def test_the_refused_recipe_is_not_left_on_disk(tmp_path, example):
+    """A rejected download that stays on disk is a loaded gun for the next step that assumes the
+    fetch succeeded — and for anything else sharing the workspace."""
+    _run_fetch(example, tmp_path, "#!/bin/sh\necho pwned\n", sealed=_sha("the original bytes"))
+    left = [p.name for p in tmp_path.iterdir() if "darnlink-gate" in p.name and p.suffix != ".json"]
+    assert not left, f"the unverified script survived rejection: {left}"
+
+
+@pytest.mark.parametrize("example", EXECUTED, ids=lambda p: p.name)
+@requires_bash
+def test_the_genuine_recipe_passes(tmp_path, example):
+    """The control. Without it, a step that always failed would satisfy the test above."""
+    payload = "#!/usr/bin/env bash\n# the real thing\n"
+    r = _run_fetch(example, tmp_path, payload, sealed=_sha(payload))
+    assert r.returncode == 0, f"the genuine recipe was rejected: {r.stdout}{r.stderr}"
+
+
+@pytest.mark.parametrize("example", EXECUTED, ids=lambda p: p.name)
+@requires_bash
+def test_an_UNSEALED_download_says_so_instead_of_passing_quietly(tmp_path, example):
+    """Absent key = keep working (a hard failure on arrival gets the gate deleted) but SAY IT.
+    Silence at this exact spot is indistinguishable from 'verified', which is the failure the whole
+    step exists to prevent, one layer up."""
+    r = _run_fetch(example, tmp_path, "#!/bin/sh\n", sealed=None)
+    assert r.returncode == 0, "an unsealed repo must keep working"
+    assert "NOT VERIFIED" in (r.stdout + r.stderr), (
+        f"an unverified download passed silently: {r.stdout!r} {r.stderr!r}")
+
+
+@pytest.mark.parametrize("example", EXECUTED, ids=lambda p: p.name)
+@requires_bash
+def test_the_mismatch_message_offers_the_MUNDANE_cause_first(tmp_path, example):
+    """A message that lists only alarming causes ('the tag moved, or it was tampered with') turns the
+    common maintenance slip — bumping `ref` without re-sealing the digest — into a suspected supply
+    chain attack. That omission cost about an hour of wrong suspicion once; naming the third cause is
+    the fix, and asserting it is what stops the wording drifting back."""
+    r = _run_fetch(example, tmp_path, "different\n", sealed=_sha("original"))
+    # ⚠️ Asserted on the MISMATCH LINE, not on the whole output. The first version of this test
+    # searched all of stdout+stderr for "re-seal" and was satisfied by the *remediation hint* two
+    # lines below ("re-seal with: curl … | sha256sum"), so deleting the cause from the message left
+    # it green. Measured by mutation: that is the only reason this narrower assertion exists.
+    line = next((l for l in (r.stdout + r.stderr).splitlines() if "checksum mismatch" in l), None)
+    assert line, f"no mismatch line at all: {r.stdout!r} {r.stderr!r}"
+    assert "re-sealing" in line.lower(), (
+        f"the mismatch message offers only alarming causes and omits the common one: {line.strip()}")
+
+
+@pytest.mark.parametrize("example", EXECUTED, ids=lambda p: p.name)
+def test_the_comparison_happens_BEFORE_chmod(example):
+    """Order is the whole property: verifying an already-executable file verifies nothing useful.
+    Comment lines are stripped first — both files *mention* `chmod +x` in prose explaining this."""
+    lines = example.read_text(encoding="utf-8").splitlines()
+    code = [(i, l) for i, l in enumerate(lines) if not l.strip().startswith(("#", "//"))]
+    sha = min(i for i, l in code if "sha256sum" in l and "re-seal" not in l)
+    chmod = min(i for i, l in code if "chmod +x" in l)
+    assert sha < chmod, f"{example.name}: verification at line {sha+1} is after chmod at {chmod+1}"
+
+
+@pytest.mark.parametrize("doc", [
+    Path(__file__).resolve().parent.parent / "recipes" / "darnlink-gate",
+    Path(__file__).resolve().parent.parent / "recipes" / "README.md",
+], ids=lambda p: p.name)
+def test_the_checksum_key_is_DOCUMENTED_not_only_used(doc):
+    """`recipe_sha256` existed in consumer configs for months while appearing nowhere in this repo —
+    every consumer that verified had invented the key locally. A key that lives only in the examples
+    is a key nobody knows to set, and one no reader can look up."""
+    assert RECIPE_SHA_KEY in doc.read_text(encoding="utf-8"), (
+        f"{doc.name} does not document {RECIPE_SHA_KEY}")

--- a/tests/test_recipe_examples.py
+++ b/tests/test_recipe_examples.py
@@ -246,13 +246,15 @@ def _fetch_shell(path: Path) -> str:
     return stub + body
 
 
-def _run_fetch(path: Path, cwd: Path, payload: str, sealed):
+def _run_fetch(path: Path, cwd: Path, payload: str, sealed, only_path: str | None = None):
     cfg = {"ref": "git+https://github.com/txemi/darnlink@main"}
     if sealed is not None:
         cfg[RECIPE_SHA_KEY] = sealed
     (cwd / "darnlink-gate.json").write_text(json.dumps(cfg), encoding="utf-8")
     env = {**os.environ, "PAYLOAD": payload, "RUNNER_TEMP": str(cwd),
            "WORKSPACE": str(cwd), "DARNLINK_GATE_VERSION": "main"}
+    if only_path:                        # a PATH without sha256sum: what a macOS agent looks like
+        env["PATH"] = only_path
     return subprocess.run(["bash", "-c", _fetch_shell(path)],
                           cwd=cwd, capture_output=True, text=True, env=env)
 
@@ -323,11 +325,18 @@ def test_the_mismatch_message_offers_the_MUNDANE_cause_first(tmp_path, example):
 def test_the_comparison_happens_BEFORE_chmod(example):
     """Order is the whole property: verifying an already-executable file verifies nothing useful.
     Comment lines are stripped first — both files *mention* `chmod +x` in prose explaining this."""
+    # ⚠️ ANCHOR ON THE COMPARISON, NOT ON THE WORD "sha256sum". This test was silently defanged
+    # once: it took the first non-comment line containing `sha256sum`, which used to be
+    # `GOT=$(sha256sum …)` — and then the macOS fallback added `if command -v sha256sum …` ABOVE it.
+    # A probe that verifies nothing became the anchor, and `chmod +x` could be moved below the probe
+    # but above the comparison with the whole suite green. Seeded and confirmed by a review round.
+    # The executing tests cannot cover this: they measure REJECTION, which happens either way.
     lines = example.read_text(encoding="utf-8").splitlines()
     code = [(i, l) for i, l in enumerate(lines) if not l.strip().startswith(("#", "//"))]
-    sha = min(i for i, l in code if "sha256sum" in l and "re-seal" not in l)
+    compare = min(i for i, l in code if '"$GOT" != "$WANT"' in l)
     chmod = min(i for i, l in code if "chmod +x" in l)
-    assert sha < chmod, f"{example.name}: verification at line {sha+1} is after chmod at {chmod+1}"
+    assert compare < chmod, (
+        f"{example.name}: the digest comparison is at line {compare+1}, AFTER chmod at {chmod+1}")
 
 
 @pytest.mark.parametrize("doc", [
@@ -361,24 +370,29 @@ def test_the_checksum_key_is_DOCUMENTED_not_only_used(doc):
 # CLASS IMPOSSIBLE instead of parsing: no backslash at all, except a line continuation. That is
 # strictly stronger than "it happens to parse today", and it is checkable everywhere.
 #
-# It is also what makes `_fetch_shell` honest: with no escapes, the raw text IS what Groovy hands to
-# the shell, so running the raw text tests the real thing. Without this, those tests measure a string
-# Jenkins never sees.
+# It is also what makes `_fetch_shell` honest. Precisely: the only transformation either side applies
+# is joining a backslash-newline, and both apply it, so bash's reading of the raw text and Groovy's
+# output are BEHAVIOURALLY identical. (Not byte-identical -- measured, they differ by four bytes and
+# two lines, because Groovy has already joined the continuations. The stronger word was in an earlier
+# draft and was false, and it is the sentence a maintainer leans on to judge a new construct.)
+# Without this invariant, those tests measure a string Jenkins never sees.
 
 def test_the_jenkins_example_contains_no_groovy_escape_the_shell_would_not_see():
+    # ⚠️ THE WHOLE FILE, not just the `sh` block. The first version scanned only the block, and a
+    # review seeded a backslash into the `environment` stanza: the suite passed and BOTH Groovy engines
+    # refused to parse. A compile error does not care which line it is on, so neither can this.
+    # (Scanning only the FIRST sh block had a second hole: a file with two left one unscanned.)
     text = JENKINS.read_text(encoding="utf-8")
-    m = re.search(r"sh\s+'''(.*?)'''", text, re.DOTALL)
-    assert m, "no sh ''' … ''' block in the Jenkins example"
-    body = m.group(1)
+    assert "sh " + "'" * 3 in text, "no sh block in the Jenkins example"
     offenders = []
-    for n, line in enumerate(body.splitlines(), 1):
+    for n, line in enumerate(text.splitlines(), 1):
         # A trailing backslash is a line continuation: Groovy drops backslash+newline, and so does
         # the shell, so both agree. Every other backslash is an escape only ONE of them resolves.
         stripped = line[:-1] if line.endswith("\\") else line
         if "\\" in stripped:
             offenders.append(f"line {n}: {line.strip()[:90]}")
     assert not offenders, (
-        "backslash escapes in the Jenkins sh block — Groovy resolves these before the shell sees "
+        "backslash escapes in the Jenkins example — Groovy resolves these before the shell sees "
         "them, so at best the shell gets different text and at worst the adopter's whole Jenkinsfile "
         "fails to compile:\n  " + "\n  ".join(offenders))
 
@@ -390,6 +404,7 @@ def test_both_examples_carry_the_same_verification_contract():
     a = ACTIONS.read_text(encoding="utf-8")
     j = JENKINS.read_text(encoding="utf-8")
     for token, what in [("recipe_sha256", "reads the digest key"),
+                        ("tr 'A-F' 'a-f'", "accepts an uppercase digest"),
                         ("sha256sum", "computes a digest"),
                         ("shasum -a 256", "has the macOS fallback"),
                         ("NOT VERIFIED", "warns when the key is absent"),
@@ -397,3 +412,60 @@ def test_both_examples_carry_the_same_verification_contract():
                         ("64 lowercase hex", "rejects a non-digest before crying mismatch")]:
         assert token in a, f"the Actions example no longer {what}"
         assert token in j, f"the Jenkins example no longer {what}"
+
+
+@pytest.mark.parametrize("example", EXECUTED, ids=lambda p: p.name)
+@requires_bash
+def test_the_README_placeholder_is_refused_as_a_PLACEHOLDER_not_as_tampering(tmp_path, example):
+    """The shape guard, EXECUTED. It shipped in round 1 covered only by a grep for the string
+    "64 lowercase hex" — and a review seeded it by deleting the whole guard while leaving the comment
+    that contains that phrase: 117 passed. A text assertion satisfied by a comment is not a test.
+
+    The value below is copied from the README's own config block, which is the realistic first-contact
+    mistake: non-empty, so without this guard it becomes a checksum MISMATCH whose first named cause
+    is an unsealed `ref` bump — sending the reader to hunt a tampered download they never had."""
+    r = _run_fetch(example, tmp_path, "#!/bin/sh\n",
+                   sealed="<64 hex chars — RESOLVE THIS, see below; do not paste it as-is>")
+    assert r.returncode != 0, "the placeholder was accepted as a digest"
+    out = r.stdout + r.stderr
+    assert "not a sha256 digest" in out, f"refused, but not as a placeholder: {out!r}"
+    assert "checksum mismatch" not in out, f"a placeholder was reported as tampering: {out!r}"
+
+
+@pytest.mark.parametrize("example", EXECUTED, ids=lambda p: p.name)
+@requires_bash
+def test_an_UPPERCASE_digest_is_accepted(tmp_path, example):
+    """PowerShell's `Get-FileHash` returns A-F, and the page tells Windows agents to fetch the recipe.
+    Rejecting uppercase would call a CORRECT value "not a digest" and tell the reader to replace it."""
+    payload = "#!/usr/bin/env bash\n# the real thing\n"
+    r = _run_fetch(example, tmp_path, payload, sealed=_sha(payload).upper())
+    assert r.returncode == 0, f"a legitimate uppercase digest was rejected: {r.stdout}{r.stderr}"
+
+
+@pytest.mark.parametrize("example", EXECUTED, ids=lambda p: p.name)
+@requires_bash
+def test_the_macOS_fallback_actually_works(tmp_path, example):
+    """`sha256sum` does not exist on macOS, so both templates fall back to `shasum -a 256`. Round 1
+    shipped that branch measured by nothing but a grep for the string `shasum -a 256`: a review seeded
+    it by dropping the branch's `| cut -d" " -f1` — so it would yield `<digest>  <path>` and never
+    match — and 117 tests passed.
+
+    ⚠️ A stub that merely FAILS does not work: the templates branch on `command -v sha256sum`, which
+    a non-executable-but-present stub still satisfies — the run then takes the sha256sum branch and
+    dies. `sha256sum` has to be genuinely ABSENT from PATH, which is what a macOS agent looks like.
+    So PATH is replaced with a directory holding only the tools the block needs, sha256sum excluded."""
+    if shutil.which("shasum") is None:
+        pytest.skip("no shasum here; this asserts the fallback a macOS agent would take")
+    fakebin = tmp_path / "bin"
+    fakebin.mkdir()
+    for tool in ("bash", "shasum", "cut", "tr", "rm", "chmod", "python3", "env", "sh", "cat"):
+        src = shutil.which(tool)
+        if src:
+            (fakebin / tool).symlink_to(src)
+    assert not (fakebin / "sha256sum").exists()
+    payload = "#!/usr/bin/env bash\n# genuine\n"
+    r = _run_fetch(example, tmp_path, payload, sealed=_sha(payload), only_path=str(fakebin))
+    assert r.returncode == 0, (
+        f"the shasum fallback did not produce a matching digest: {r.stdout}{r.stderr}")
+    assert "checksum OK" in (r.stdout + r.stderr), (
+        f"the fallback ran but did not confirm a match: {r.stdout}{r.stderr}")

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -950,35 +950,48 @@ def test_every_real_branch_name_still_survives_including_the_falsey_looking_ones
     assert f"--default-branch {name}" in argv, f"a branch legitimately named {name!r} was dropped"
 
 
-def test_every_config_key_used_as_a_FLAG_has_a_guard_at_all():
-    """⚠️ THE ADJACENCY TEST BELOW DOES NOT COVER THIS, and a review caught it by seeding: it loops
-    over keys that ALREADY have a `case`, so a brand-new key with NO normaliser whatsoever is
-    invisible to it. Its docstring promised to stop "the third instance" and missed precisely that.
+def test_every_config_key_is_guarded_or_explicitly_exempt():
+    """Every scalar that comes from `read_cfg` must be normalised, validated, or named below as a
+    free string. `read_cfg` renders a JSON `false` as the string "False", and every truthiness test
+    in shell is true for it, so an unguarded key can be turned ON by a config that asks for OFF.
 
-    This is the check that keeps the promise: every scalar that comes from `read_cfg` AND is then
-    tested with `[ -n "$X" ]` must be guarded somewhere, because `[ -n ]` is true for the string
-    "False" that a JSON `false` turns into. Guard = a `case` on it, or a numeric/regex validation.
+    ⚠️ INVERTED ON PURPOSE, after two rounds of getting this wrong. The first version required the
+    literal `[ -n "$VAR" ]`, and a review seeded four consumption forms that all evaded it:
+    `[ -n "${VAR}" ]`, `[ "$VAR" ]`, `[ -z "$VAR" ] || …`, and `[ -n "$A$B" ]`. The last is not
+    hypothetical -- this recipe ALREADY ships `[ -n "$OWN_WEB_FROM_ORIGIN$OWN_WEB_MAX" ]`, so a
+    future author has a precedent right here for the spelling the guard could not see.
 
-    Loop variables are deliberately out of scope: `[ -n "$e" ]` inside `for e in "${ARRAY[@]}"`
-    guards against an EMPTY LIST ENTRY, which is correct and must not be flagged."""
+    Enumerating consumption forms is unwinnable: shell has too many, and the test silently shrinks
+    each time someone invents one. Enumerating KEYS is finite and self-maintaining -- a new key is
+    guarded or it is listed here, and listing it is a decision someone has to write down."""
     text = RECIPE.read_text(encoding="utf-8")
-    lines = text.splitlines()
+
+    # Free strings: passed through as values, never used as flags. Each is a deliberate decision.
+    EXEMPT = {
+        "REF":   "a package spec, handed to uvx verbatim",
+        "MODE":  "compared with = / != against known words, so a boolean can only narrow, never widen",
+        "SCOPE": "same as MODE",
+    }
 
     scalars = {}
-    for i, l in enumerate(lines):
+    for n, l in enumerate(text.splitlines()):
         m = re.match(r'^([A-Z_]+)="\$\{DARNLINK_[A-Z_]*:-\$\(read_cfg ', l)
         if m:
-            scalars.setdefault(m.group(1), i)
+            scalars.setdefault(m.group(1), n)
 
-    used_as_flag = {v for v in scalars if re.search(r'\[ -n "\$' + v + r'" \]', text)}
-    guarded = {v for v in scalars
-               if re.search(r'^case "\$\{?' + v + r'[,"}]', text, re.M)
-               or re.search(r'\[\[ "\$' + v + r'" =~', text)}
+    def guarded(v):
+        return (re.search(r'^case "\$\{?' + v + r'[,"}]', text, re.M)      # truthiness or type case
+                or re.search(r'\[\[ "\$' + v + r'" =~', text)             # regex validation
+                or re.search(r'case "\$' + v + r'" in', text))             # plain case
 
-    missing = sorted(used_as_flag - guarded)
+    missing = sorted(v for v in scalars if v not in EXEMPT and not guarded(v))
     assert not missing, (
-        "these keys are read from JSON and then tested with `[ -n ]`, which is TRUE for the string "
-        '"False" a JSON `false` produces, and nothing normalises them: ' + ", ".join(missing))
+        "these keys come from JSON and nothing normalises or validates them, so a JSON `false` "
+        'reaches the shell as the non-empty string "False": ' + ", ".join(missing)
+        + " — guard them, or add them to EXEMPT with the reason they are safe as free strings.")
+
+    stale = sorted(set(EXEMPT) - set(scalars))
+    assert not stale, f"EXEMPT names keys that no longer exist, so it is not being maintained: {stale}"
 
 
 def test_every_boolean_key_is_normalised_next_to_its_own_assignment():

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -6,6 +6,7 @@ SHIM on PATH that drops the `--from <ref> darnlink` prefix and execs the locally
 console script instead (the same one CI installs via `uv pip install -e .`). No network, no version pin.
 """
 import json
+import re
 import os
 import shutil
 import subprocess
@@ -892,3 +893,92 @@ def test_a_bom_is_honoured_by_the_LENGTH_reader_too(sandbox, tmp_path):
                                      + _clean_env().get("PATH", "")})
     assert "empty entry/entries" in r2.stderr, (
         "con BOM, read_cfg_len devolvio 0 y el aviso de owners vacios no salio:\n" + r2.stderr)
+
+
+# --- (f) a JSON `false` must not turn a flag ON ------------------------------------------------
+#
+# `read_cfg` prints the raw Python value, so a JSON `false` reaches the shell as the STRING "False",
+# and the guard it feeds is `[ -n "$X" ]` -- true for ANY non-empty string. Every boolean key in this
+# recipe therefore needs a normalising `case` after its assignment, and two of them did not have one.
+#
+# ⚠️ The shape of the near-miss is worth keeping. Reading the file, five keys LOOKED guarded and two
+# did not; the two that did not were the two sitting directly above a `case` belonging to a key
+# assigned thirteen lines earlier. Counting `[ -n "$X" ]` occurrences gives seven "bugs"; running the
+# thing gives two. These tests run it.
+#
+# Asserted on DARNLINK_ARGV_LOG -- the argv the tool actually receives -- because the verdict cannot
+# tell you: with these flags the gate exits 0 either way, which is exactly how this survived.
+
+def _argv(sandbox, config, tmp_path):
+    repo, run = sandbox
+    log = tmp_path / "argv.log"
+    run(config, argv_log=log)
+    return log.read_text(encoding="utf-8") if log.exists() else ""
+
+
+@pytest.mark.parametrize("value", [False, "false", "False", "off", "no", 0])
+def test_include_mermaid_falsey_does_not_turn_the_axis_ON(sandbox, tmp_path, value):
+    """`include_mermaid: false` used to ADD `--include-mermaid`. The config said off and the gate
+    read on -- the one direction a config typo must never be able to go."""
+    argv = _argv(sandbox, {"ref": "x", "mode": "max", "web": True, "include_mermaid": value}, tmp_path)
+    assert "--include-mermaid" not in argv, f"include_mermaid={value!r} still turned the axis on"
+
+
+def test_include_mermaid_true_still_turns_the_axis_ON(sandbox, tmp_path):
+    """The control. A normaliser that blanks everything would pass the test above and break the
+    feature -- and no other test here would notice, because the verdict is 0 either way."""
+    argv = _argv(sandbox, {"ref": "x", "mode": "max", "web": True, "include_mermaid": True}, tmp_path)
+    assert "--include-mermaid" in argv, "include_mermaid: true no longer reaches the tool"
+
+
+@pytest.mark.parametrize("value", [False, True])
+def test_a_boolean_default_branch_is_REFUSED_not_passed_through(sandbox, tmp_path, value):
+    """`default_branch` is a NAME, so the fix is not a truthiness `case`: a branch may legitimately be
+    called `off` or `no`. What cannot be legitimate is a JSON boolean -- it arrives as "True"/"False"
+    and was passed straight through as `--default-branch False`, a branch that exists nowhere, which
+    makes every link look pending against it."""
+    argv = _argv(sandbox, {"ref": "x", "mode": "max", "web": True, "default_branch": value}, tmp_path)
+    assert "--default-branch" not in argv, f"default_branch={value!r} reached the tool as a branch name"
+
+
+@pytest.mark.parametrize("name", ["main", "master", "off", "no", "false"])
+def test_every_real_branch_name_still_survives_including_the_falsey_looking_ones(sandbox, tmp_path, name):
+    """The control that stops the obvious over-fix. Blanking `off`/`no`/`false` here would be a worse
+    bug than the one being fixed: a repo whose default branch is genuinely called `off` would silently
+    lose the setting, and the rung would go inert exactly like the failure this key exists to prevent."""
+    argv = _argv(sandbox, {"ref": "x", "mode": "max", "web": True, "default_branch": name}, tmp_path)
+    assert f"--default-branch {name}" in argv, f"a branch legitimately named {name!r} was dropped"
+
+
+def test_every_boolean_key_is_normalised_next_to_its_own_assignment():
+    """The class, not the two instances. Both bugs existed because a `case` sat thirteen lines below
+    its assignment, past two unrelated keys -- so the next person to add a key landed above a
+    normaliser that looked like theirs and was not. Adjacency is the property that stops the third."""
+    lines = RECIPE.read_text(encoding="utf-8").splitlines()
+    assigns, guards = {}, {}
+    for i, l in enumerate(lines):
+        m = re.match(r'^([A-Z_]+)="\$\{DARNLINK_[A-Z_]*:-\$\(read_cfg ', l)
+        if m:
+            assigns.setdefault(m.group(1), i)
+        m = re.match(r'^case "\$\{?([A-Z_]+)', l)
+        if m:
+            guards.setdefault(m.group(1), i)
+
+    # ⚠️ Measured as "is another key ASSIGNED in between", not as a line count. A line count is the
+    # wrong instrument twice over: it fires on a long explanatory comment (harmless) and it stays
+    # quiet when a second key is assigned three lines below (the actual trap). What made the two
+    # bugs possible was a `case` with somebody else's assignment sitting above it.
+    intruders = {}
+    for var, gi in guards.items():
+        ai = assigns.get(var)
+        if ai is None or gi < ai:
+            continue
+        between = [o for o, oi in assigns.items() if o != var and ai < oi < gi]
+        if between:
+            intruders[var] = (ai + 1, gi + 1, between)
+    assert not intruders, (
+        "a normaliser is separated from the key it guards by another key's assignment -- exactly the "
+        "shape that let two keys ship unguarded, because the next author landed above a `case` that "
+        "was not theirs: "
+        + "; ".join(f"{v} assigned at line {a}, normalised at line {g}, with {b} assigned in between"
+                    for v, (a, g, b) in intruders.items()))

--- a/tests/test_recipe_gate.py
+++ b/tests/test_recipe_gate.py
@@ -950,6 +950,37 @@ def test_every_real_branch_name_still_survives_including_the_falsey_looking_ones
     assert f"--default-branch {name}" in argv, f"a branch legitimately named {name!r} was dropped"
 
 
+def test_every_config_key_used_as_a_FLAG_has_a_guard_at_all():
+    """⚠️ THE ADJACENCY TEST BELOW DOES NOT COVER THIS, and a review caught it by seeding: it loops
+    over keys that ALREADY have a `case`, so a brand-new key with NO normaliser whatsoever is
+    invisible to it. Its docstring promised to stop "the third instance" and missed precisely that.
+
+    This is the check that keeps the promise: every scalar that comes from `read_cfg` AND is then
+    tested with `[ -n "$X" ]` must be guarded somewhere, because `[ -n ]` is true for the string
+    "False" that a JSON `false` turns into. Guard = a `case` on it, or a numeric/regex validation.
+
+    Loop variables are deliberately out of scope: `[ -n "$e" ]` inside `for e in "${ARRAY[@]}"`
+    guards against an EMPTY LIST ENTRY, which is correct and must not be flagged."""
+    text = RECIPE.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    scalars = {}
+    for i, l in enumerate(lines):
+        m = re.match(r'^([A-Z_]+)="\$\{DARNLINK_[A-Z_]*:-\$\(read_cfg ', l)
+        if m:
+            scalars.setdefault(m.group(1), i)
+
+    used_as_flag = {v for v in scalars if re.search(r'\[ -n "\$' + v + r'" \]', text)}
+    guarded = {v for v in scalars
+               if re.search(r'^case "\$\{?' + v + r'[,"}]', text, re.M)
+               or re.search(r'\[\[ "\$' + v + r'" =~', text)}
+
+    missing = sorted(used_as_flag - guarded)
+    assert not missing, (
+        "these keys are read from JSON and then tested with `[ -n ]`, which is TRUE for the string "
+        '"False" a JSON `false` produces, and nothing normalises them: ' + ", ".join(missing))
+
+
 def test_every_boolean_key_is_normalised_next_to_its_own_assignment():
     """The class, not the two instances. Both bugs existed because a `case` sat thirteen lines below
     its assignment, past two unrelated keys -- so the next person to add a key landed above a

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -26,7 +26,12 @@ _root="$(git rev-parse --show-toplevel)"
 #
 # The same leak also makes the suite report failures that do not exist: run by hand it is green, run
 # as a hook those same four fail. A gate that is red only when it is the gate is worse than no gate.
-unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_COMMON_DIR GIT_OBJECT_DIRECTORY GIT_NAMESPACE
+# ⚠️ GIT_CONFIG_PARAMETERS is in this list for a reason that is not obvious: it carries the `-c`
+# options of the invoking git, and `core.hooksPath` is one of them -- so a child `git commit`
+# in a test's temp repo could re-enter THIS repo's hooks. Found by a review that dumped a real
+# hook's environment instead of trusting the list.
+unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_COMMON_DIR GIT_OBJECT_DIRECTORY \
+      GIT_NAMESPACE GIT_CONFIG_PARAMETERS
 
 cd "$_root"
 

--- a/tools/check.sh
+++ b/tools/check.sh
@@ -6,7 +6,29 @@
 #
 # Exits non-zero on the first failure.
 set -euo pipefail
-cd "$(git rev-parse --show-toplevel)"
+_root="$(git rev-parse --show-toplevel)"
+
+# ⚠️ DROP GIT'S PER-INVOCATION ENVIRONMENT BEFORE RUNNING THE SUITE.
+#
+# This script IS the pre-commit and pre-push hook, and git runs hooks with GIT_DIR (and, for
+# pre-commit, GIT_INDEX_FILE) exported. Every `git` a child process runs inherits them -- so a test
+# that legitimately builds its own repo in a temp dir gets silently redirected at THIS one:
+#
+#     git init -q "$T/a"; git -C "$T/a" rev-parse --absolute-git-dir
+#       without GIT_DIR ->  /tmp/tmp.XXXX/a/.git          (the temp repo, as intended)
+#       with    GIT_DIR ->  <this repo>/.git              (this repo)
+#
+# Measured, and it is not theoretical: one ordinary `git commit` here produced a commit that DELETED
+# THE ENTIRE TREE, with a message ("i") belonging to a test fixture -- because the fixture's
+# `git add -A` and `git commit` had been redirected onto the real repo mid-commit. The working files
+# survive; the commit simply stops describing them, and `git status` then reports everything as
+# untracked. Four tests across two files drive git this way, so it is reachable from any commit.
+#
+# The same leak also makes the suite report failures that do not exist: run by hand it is green, run
+# as a hook those same four fail. A gate that is red only when it is the gate is worse than no gate.
+unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_PREFIX GIT_COMMON_DIR GIT_OBJECT_DIRECTORY GIT_NAMESPACE
+
+cd "$_root"
 
 # English-only gate. The rule is not new — CLAUDE.md has said "Everything in this repo is written
 # in English" since the start.


### PR DESCRIPTION
Four defects, found by measuring rather than reading. The first three are what this repo
**hands to its consumers**; the fourth is what its own gate did to this branch while fixing them.

## 1. The shipped CI templates downloaded the recipe and ran it without verifying a byte

Both copy-paste templates in `recipes/examples/` did this, at every released version — and still on
`main` today, so it is a live defect, not a historical one:

```
grep -c sha256 recipes/examples/github-actions-darnlink-gate.yml   ->  0   (v0.22.0, 571dd8c0, main)
grep -c sha256 recipes/examples/Jenkinsfile-stage.groovy           ->  0
```

**The pin is not the verification.** A tag is a mutable pointer, and this recipe deliberately accepts
a branch or a SHA too, so the pin says which *name* was requested, never which *bytes* arrived.

**And the key did not exist here.** `recipe_sha256` appeared nowhere in this repository — not in the
recipe's CONFIG header, not in `recipes/README.md`, not in the examples. Consumer configs elsewhere
already carried it: every surface that verified had **invented the key locally**, against a contract
that never mentioned it. So this is not "add a check to a YAML"; it is giving a contract key its
existence. It is also the one key the recipe never reads — it is consumed by whoever *fetches* the
script, because a downloaded script cannot vouch for its own download.

The mismatch error names **three** causes with the mundane one first (a `ref` bumped without
re-sealing the digest), because a message offering only catastrophic explanations turns a maintenance
slip into a suspected supply-chain attack. An absent key **warns loudly** instead of failing, so an
unsealed repo keeps working — silence there is indistinguishable from "verified".

## 2. A JSON `false` turned two config keys ON

`read_cfg` prints the raw Python value, so a JSON `false` arrives as the string `"False"`, and
`[ -n "$X" ]` is true for any non-empty string. Measured by running the recipe's own guards, in their
real order, against a config declaring all seven keys `false`:

```
ARGS PASSED TO THE TOOL:  --include-mermaid --default-branch False
```

Five keys were already normalised. **The finding is why exactly those two were not:**
`OWN_WEB_FROM_ORIGIN`'s `case` had drifted thirteen lines below its assignment, past both of them —
so whoever added a key landed directly above a `case` that looked like theirs. The orphan goes back
beside its own assignment, `DANGLING`/`DANGLING_MAX` are un-interleaved too (both correct, purely
prophylactic), and a test now fails if any normaliser is separated from its key by another key's
assignment. The class, not the two instances.

`default_branch` gets a **type** check rather than a truthiness one: a branch may legitimately be
called `off`, `no` or `false`, and blanking those would be worse than the bug being fixed. A control
test asserts all five falsey-looking real names still survive.

**Scope: this is armour, not a fire.** Neither key is misdeclared anywhere measurable today.

## 3. A docstring said the BOM survives the read; `utf-8-sig` consumes it

Documentation-only — behaviour is correct and unchanged. The same reader's docstring in
`frontmatter_edit.py` already said the opposite, and said it accurately, so the repo carried two
mutually contradicting descriptions of one function. A wrong docstring does not mislead in the
abstract: it sends the next reader to measure the wrong place.

## 4. Running the gate as a hook redirected the suite's git calls at this repo

git runs hooks with `GIT_DIR` exported, and every child `git` inherits it:

```
git init -q "$T/a"; git -C "$T/a" rev-parse --absolute-git-dir
  without GIT_DIR ->  /tmp/tmp.XXXX/a/.git     (the temp repo, as intended)
  with    GIT_DIR ->  <this repo>/.git         (this repo)
```

Measured twice on this branch: one ordinary `git commit` produced a commit that **deleted the entire
tree**, with a message belonging to a test fixture; and a `git push` poisoned the index so that the
*next* commit inherited stray files without anything being wrong with that commit. The working files
always survive, so it reads as operator error one step removed from its cause.

Quieter and arguably worse: run by hand the suite is green; run **as the hook**, four tests fail. A
gate that is red only when it is acting as the gate teaches people to reach for `--no-verify`.

⚠️ **This one was found early and deliberately left unfixed for three commits.** The first attempt
guessed `GIT_INDEX_FILE` and the control test written to demonstrate the damage **failed** — three
reductions would not reproduce it. Rather than ship a guard whose failure mode could not be shown,
the guard was reverted and only the measurement was recorded. What pinned it was the pre-push hook
hitting the same four tests a third time, which gave a deterministic reproduction and a one-variable
bisect. The control now passes for the right reason.

## Testing

The tests **execute** the shipped shell with a stubbed `curl` rather than grepping it, because text
assertions here are satisfied by a comment, a disabled branch, or a comparison placed after
`chmod +x`. The config tests assert on the argv the tool actually receives (via the existing
`DARNLINK_ARGV_LOG` shim), because with these flags the gate exits 0 either way — which is exactly
how the defect survived.

Every property was mutation-tested. One mutation initially **survived**: the mismatch-message test
searched all output for `re-seal` and was satisfied by the remediation hint two lines below, so
deleting the cause from the message left it green. It now asserts on the mismatch line itself.

Full gate green, and the last two commits passed the hook without `--no-verify` — which is itself the
end-to-end proof for defect 4.

## What this does not fix

**The copies.** These are copy-paste templates: every surface that already pasted the older version
still runs unverified, and nothing here reaches them. Measured across a fleet of consumers, the check
was present on the self-hosted-CI and local-script surfaces and absent from **every** hosted-CI one,
in every repo — so it was never a stray bad copy, it was one whole axis that had no wall.
`recipes/README.md` now says to grep your own surfaces rather than trust a list, and states the rule
that prevents the next incident: **`ref` and `recipe_sha256` move in the same commit.**
