### PR TITLE
gate: set newline on the three remaining heredocs so Windows does not glue a CR to every value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ it, because a downloaded script cannot vouch for its own download. It does **not
 `darnlink-gate.ps1`, which is a different file with a different digest.
 
 ### Fixed
+- `recipes/darnlink-gate`: the three remaining Python heredocs (finding filter, README-offender
+  count and staged summary) now set `sys.stdout.reconfigure(newline="\n")`, as `read_cfg` and
+  `read_cfg_len` do since #97. On Windows the offender count came back as `"N\r"`, so the
+  `[ "$cr" -gt 0 ]` test failed with "integer expression expected" and the gate aborted; the
+  finding details carried a trailing CR. Behaviour on POSIX is byte-identical.
 
 - **A JSON `false` turned `include_mermaid` ON**, and `default_branch: false` reached the tool as
   `--default-branch False`, a branch that exists nowhere. `read_cfg` renders a JSON boolean as the

--- a/recipes/darnlink-gate
+++ b/recipes/darnlink-gate
@@ -384,6 +384,7 @@ dangling_findings() {
   set +e
   out="$(python3 - "$tmp" <<'PY'
 import json, sys
+sys.stdout.reconfigure(newline="\n")  # Windows: print() would emit \r\n and the CR travels glued to every value
 try:
     with open(sys.argv[1], encoding="utf-8") as fh:
         data = json.load(fh)
@@ -425,6 +426,7 @@ create_readme_offenders() {
   set +e
   out="$(python3 - "$tmp" <<'PY'
 import json, sys
+sys.stdout.reconfigure(newline="\n")  # Windows: print() would emit \r\n and the CR travels glued to every value
 try:
     with open(sys.argv[1], encoding="utf-8") as fh:
         d = json.load(fh)
@@ -719,6 +721,7 @@ fi
 # script either way → no injection from finding text.
 python3 <<'PY'
 import json, os, sys
+sys.stdout.reconfigure(newline="\n")  # Windows: print() would emit \r\n and the CR travels glued to every value
 root = os.environ["DL_ROOT"]
 mode = os.environ.get("DL_MODE", "check")
 


### PR DESCRIPTION
Follow-up to #97, which fixed `read_cfg` and `read_cfg_len`. Three more Python heredocs in `recipes/darnlink-gate` (the finding filter, the README-offender count and the staged summary) still printed with the platform newline. On Windows the offender count came back as `"N\r"`, so `[ "$cr" -gt 0 ]` failed with "integer expression expected" and the gate aborted; the finding details carried a trailing CR. POSIX output is byte-identical (`cmp` against the previous recipe).

**CI limitation, stated on purpose:** `tests/test_recipe_gate.py` needs a POSIX shell, so the Windows path is not exercised by CI. Verified by hand on a Windows machine of the fleet; a reviewer with such a machine has been asked.

**Related, not in this PR:** consumers pin `v0.24.0` (2026-08-17), which predates #97 — every deploy re-downloads the old recipe. A release after #97 (or a pin bump to a commit) is the actual unblocker.

Review: one adversarial round (CHANGELOG bullet misattributed #97's symptom → rewritten; heredoc inventory complete, 5/5; recipe tests 61 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)