### PR TITLE
CHANGELOG: consolidate the unreleased sections into 0.26.0 ahead of the tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to darnlink are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## [Unreleased]
 
-⚠️ **The recipe is consumed AT A TAG, so the two behaviour fixes below reach nobody until this is
-released.** Anyone following the new README today seals a digest of a recipe that does not yet
-contain them.
+_Nothing yet._
+
+## [0.26.0] — 2026-08-28
+
+> Consolidates everything since 0.24.0: the `0.25.0` / `0.25.1` / `0.26.0` sections that had been
+> written ahead of a tag were never released on their own; this is the first tag that carries them.
+
+### The gate recipe: verified downloads, `recipe_sha256`, Windows CR
 
 **The shipped CI templates downloaded the recipe and executed it without verifying a byte** — both
 of them, at every released version. `recipes/examples/github-actions-darnlink-gate.yml` and
@@ -25,7 +30,7 @@ the same commit.** It is the one key the recipe never reads — whoever fetches 
 it, because a downloaded script cannot vouch for its own download. It does **not** cover
 `darnlink-gate.ps1`, which is a different file with a different digest.
 
-### Fixed
+#### Fixed
 - `recipes/darnlink-gate`: the three remaining Python heredocs (finding filter, README-offender
   count and staged summary) now set `sys.stdout.reconfigure(newline="\n")`, as `read_cfg` and
   `read_cfg_len` do since #97. On Windows the offender count came back as `"N\r"`, so the
@@ -45,7 +50,7 @@ it, because a downloaded script cannot vouch for its own download. It does **not
   here, and one ordinary `git commit` produced a commit that deleted the entire tree. It also made
   four tests fail *only* when the suite was acting as the gate.
 
-## 0.26.0
+### An inert rung now says so
 
 **An inert rung now says so.** When the pending-on-default-branch rung cannot identify the repo or
 its default branch it disables itself — correct — but it did so SILENTLY, and a disabled rung looks
@@ -58,18 +63,16 @@ cannot fail, and in CI it is often the only one that CAN answer: the checkout ha
 (only the PR ref is fetched) and the credentials for `ls-remote` are usually scoped to the checkout
 step rather than to what it spawns.
 
-## 0.25.1
+### The default-branch read was inert in CI
 
-The 0.25.0 rung was **inert in CI**, which is the only place it mattered. It read the default branch
-from  — a LOCAL symref that a CI checkout does not create: a multibranch PR job fetches
+The pending-on-default-branch rung was **inert in CI**, which is the only place it mattered. It read the default branch
+from `origin/HEAD` — a LOCAL symref that a CI checkout does not create: a multibranch PR job fetches
 only `+refs/pull/<n>/head:refs/remotes/origin/PR-<n>`, so there is no `refs/remotes/origin/master`
 and `symbolic-ref` fails. Every ordinary clone HAS that symref, which is why it looked correct.
 
 The local read stays first (free); the remote is asked with `ls-remote --symref` only when it
 fails. Unknown default branch still means inert — guessing `main` would forgive links in every repo
 whose default is something else.
-
-## 0.25.0
 
 ### A link pending on the default branch is not a broken link
 
@@ -100,8 +103,6 @@ worse than no rung.
 
 ⚠️ **Consumers pin by SHA**, so merging this changes nothing for them until each `darnlink-gate.json`
 `ref` is bumped.
-
-## [Unreleased]
 
 ### Added
 


### PR DESCRIPTION
## Why

`pyproject.toml` already says `0.26.0`, but `CHANGELOG.md` had five headings for work that has never been tagged: `## Unreleased` (with the #102 entry), `## 0.26.0`, `## 0.25.1`, `## 0.25.0` and a second `## [Unreleased]` (feature 017). Neither `v0.25.0` nor `v0.25.1` exists as a tag — the last release is `v0.24.0`.

## What

- One dated `## [0.26.0] — 2026-08-28` section holding everything since 0.24.0; the former version headings become `###` subsections, text unchanged.
- `## [Unreleased]` at the top, empty.
- Dropped the "consumed AT A TAG, reaches nobody until released" warning: it stops being true with this tag.
- Restored the missing `origin/HEAD` in the 0.25.1 paragraph (`from  — a LOCAL symref` had lost its code span).

Docs only; no code change. Followed by `gh release create v0.26.0` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)