### PR TITLE
perf: memoise path resolution inside an explicit run scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,36 @@ All notable changes to darnlink are documented here. The format is based on
 
 ## [Unreleased]
 
-_Nothing yet._
+### Path resolution is memoised inside an explicit run scope (~-18%)
+
+`Path.resolve()` was called on the same paths over and over: on a ~3,900-file documentation tree one
+`check` run issues **31,470 calls for only 5,767 distinct paths** — 81.7% repeats — and spends ~24%
+of its wall clock inside them. `robustify` walks the same file list in several passes and each pass
+re-resolves the same file; `resolve_href()` re-resolves the same link targets.
+
+Measured paired and interleaved, warm-up discarded: **min -18.6%**, 7/7 paired iterations favouring
+the cache. Independently re-measured twice during review, in both orders and on a different tree:
+-16.9% / -19.8% and -17.6%, 18/18 and 7/7 paired iterations.
+
+**The cache is opt-in, and that is the load-bearing decision.** `paths.resolved()` is a plain
+passthrough unless a `paths.resolve_cache()` scope is open, and `main()` opens exactly one. Two
+earlier drafts got this wrong in ways adversarial review reproduced end to end, both with the same
+consequence — a stale resolution reaching `apply_robustify` and writing the **wrong uuid to disk**:
+
+- an always-on process-wide dict cleared at the top of `main()`, which the public `plan_*`/`apply_*`
+  functions never clear;
+- then a module global saved and restored around the scope, which two **interleaved** scopes corrupt
+  (the second to leave restores the dict the first had already closed), leaving the cache open
+  process-wide with no run alive. Reproduced with a `ThreadPoolExecutor` running `main()` over
+  several roots. It is now a `ContextVar`, which is per-thread and per-task.
+
+Relative paths are never memoised: their resolution depends on the process cwd, which is not part of
+the key. darnlink never chdirs; an embedder might.
+
+### Added
+
+- `darnlink.paths.resolve_cache()` — context manager opening a memoisation scope for `resolved()`.
+- `darnlink.paths.resolved()` — `Path.resolve()`, memoised inside such a scope.
 
 ## [0.26.0] — 2026-08-28
 

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -18,8 +18,8 @@ from pathlib import Path
 from typing import List, Optional
 
 from .frontmatter_index import DEFAULT_EXCLUDES, build_index, index_from_contents, scan_tree
-from .repair import apply_repairs, plan_repairs
 from .paths import resolve_cache, resolved
+from .repair import apply_repairs, plan_repairs
 from .report import Finding, Kind
 from .robustify import apply_robustify, plan_robustify
 from .scope import ScopeError, read_paths_from, resolve_write_scope

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -17,6 +17,7 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
+from .paths import resolve_cache
 from .frontmatter_index import DEFAULT_EXCLUDES, build_index, index_from_contents, scan_tree
 from .repair import apply_repairs, plan_repairs
 from .report import Finding, Kind
@@ -748,6 +749,14 @@ def _make_stdio_encoding_safe() -> None:
 
 
 def main(argv: Optional[List[str]] = None) -> int:
+    # `main()` IS the run: it opens the one resolution-cache scope, and leaving it drops every
+    # entry. Anything that reaches the public plan_*/apply_* functions without coming through here
+    # simply does not memoise -- slower, never stale. `tests/test_paths.py` pins both halves.
+    with resolve_cache():
+        return _main(argv)
+
+
+def _main(argv: Optional[List[str]] = None) -> int:
     _make_stdio_encoding_safe()
     raw = list(sys.argv[1:] if argv is None else argv)
     if raw and raw[0] == "check":  # feature 007: report-only gate subcommand

--- a/src/darnlink/cli.py
+++ b/src/darnlink/cli.py
@@ -17,9 +17,9 @@ import sys
 from pathlib import Path
 from typing import List, Optional
 
-from .paths import resolve_cache
 from .frontmatter_index import DEFAULT_EXCLUDES, build_index, index_from_contents, scan_tree
 from .repair import apply_repairs, plan_repairs
+from .paths import resolve_cache, resolved
 from .report import Finding, Kind
 from .robustify import apply_robustify, plan_robustify
 from .scope import ScopeError, read_paths_from, resolve_write_scope
@@ -190,13 +190,13 @@ def _run_check(root: Path, excludes: set, as_json: bool, block_markers: tuple,
     unresolved = [f for f in rep.findings if f.kind in (Kind.UNRESOLVABLE, Kind.AMBIGUOUS)]
     # Invalid frontmatter is a file-level integrity fault; when scoped, only the caller's own files
     # count — a gate must not fail my commit over someone else's un-staged invalid YAML.
-    invalid = [p for p in index.invalid if only is None or p.resolve() in only]
+    invalid = [p for p in index.invalid if only is None or resolved(p) in only]
     integrity_fail = bool(repairs or conflicts or unresolved or invalid)
 
     # Strict axis (robustify, dry-run): plain links to an anchorable target left un-anchored.
     rob = plan_robustify(root, create_frontmatter=False, excludes=excludes, block_markers=block_markers, only=only, prescanned=prescanned)
     upgrades = [f for f in rob.findings if f.kind is Kind.ROBUSTIFY]
-    rob_invalid = [p for p in rob.invalid if only is None or p.resolve() in only]
+    rob_invalid = [p for p in rob.invalid if only is None or resolved(p) in only]
     strict_fail = bool(upgrades or rob_invalid)
 
     # Dangling axis (015): plain links pointing at nothing. Reported on its own axis and DELIBERATELY

--- a/src/darnlink/paths.py
+++ b/src/darnlink/paths.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
 from typing import Dict, Iterator, Optional, Tuple
 
@@ -32,28 +33,38 @@ DIR_ANCHOR = "README.md"
 # Relative paths are never memoised: their resolution depends on the process cwd. darnlink itself
 # never chdirs, but `--only-from` accepts relative paths (its help advertises piping
 # `git diff --cached --name-only`), so the key would be ambiguous for an embedder that does.
-_RESOLVE_CACHE: Optional[Dict[str, Path]] = None
+#
+# The scope lives in a ContextVar, not a module global. A global saved and restored around the
+# `with` looks equivalent and is not: with two INTERLEAVED scopes (A enters, B enters, A exits,
+# B exits) B's restore puts back the dict A had already closed, and the cache stays open with no
+# scope alive -- process-wide and never cleared, which is the exact failure this design exists to
+# prevent. Reproduced with a ThreadPoolExecutor running `main()` over several roots, the most
+# plausible embedder shape there is. A ContextVar is per-thread and per-task, so each run gets its
+# own scope and `reset(token)` cannot clobber anyone else's.
+_RESOLVE_CACHE: ContextVar[Optional[Dict[str, Path]]] = ContextVar(
+    "darnlink_resolve_cache", default=None)
 
 
 @contextmanager
 def resolve_cache() -> Iterator[None]:
-    """Open a scope in which `resolved()` memoises. Nesting reuses the outer scope, and leaving the
-    outermost one drops every entry -- so a cached resolution can never outlive the run that made it."""
-    global _RESOLVE_CACHE
-    outer = _RESOLVE_CACHE
-    if outer is None:
-        _RESOLVE_CACHE = {}
+    """Open a scope in which `resolved()` memoises. Nesting reuses the scope already open and owns
+    nothing; leaving the outermost one drops every entry, so a cached resolution cannot outlive the
+    run that made it -- including when several runs share a process on different threads."""
+    if _RESOLVE_CACHE.get() is not None:
+        yield                       # nested: reuse, own nothing
+        return
+    token = _RESOLVE_CACHE.set({})
     try:
         yield
     finally:
-        _RESOLVE_CACHE = outer
+        _RESOLVE_CACHE.reset(token)
 
 
 def resolved(path: Path) -> Path:
     """`path.resolve()`, memoised only while a `resolve_cache()` scope is open (see the note above).
 
     Outside a scope, and for relative paths, this is exactly `path.resolve()`."""
-    cache = _RESOLVE_CACHE
+    cache = _RESOLVE_CACHE.get()
     if cache is None or not path.is_absolute():
         return path.resolve()
     key = str(path)
@@ -62,12 +73,6 @@ def resolved(path: Path) -> Path:
         hit = path.resolve()
         cache[key] = hit
     return hit
-
-
-def clear_resolve_cache() -> None:
-    """Drop the entries of the open scope, if any. A no-op outside one."""
-    if _RESOLVE_CACHE is not None:
-        _RESOLVE_CACHE.clear()
 
 
 def split_fragment(href: str) -> Tuple[str, str]:

--- a/src/darnlink/paths.py
+++ b/src/darnlink/paths.py
@@ -2,13 +2,72 @@
 from __future__ import annotations
 
 import os
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Tuple
+from typing import Dict, Iterator, Optional, Tuple
 
 
 # Feature 011: a link to a directory is anchored to the uuid of this file inside it. A folder has no
 # frontmatter of its own, so its README.md carries the folder's stable identity.
 DIR_ANCHOR = "README.md"
+
+
+# --- Resolution cache -------------------------------------------------------
+# `Path.resolve()` walks every component and issues real syscalls, and darnlink calls it on the
+# SAME paths over and over: a run over a ~3,900-file tree issues 31,470 calls for only 5,767
+# distinct paths - 81.7% of them repeats - and spends ~24% of the wall clock inside them.
+#
+# Memoising is sound for the duration of ONE run because a non-strict `resolve()` (= realpath) can
+# only change if a symlink, a mount, or a directory-vs-symlink component changes. Creating a file,
+# creating a `README.md` anchor, or rewriting file content cannot change it -- and content is the
+# only thing darnlink ever writes (there is no mkdir/rename/symlink_to anywhere in `src/`).
+#
+# But "one run" is a concept only `main()` has: `plan_robustify`, `plan_repairs`, `resolve_write_scope`
+# and friends are public, and an embedder calling them twice around a filesystem change would get a
+# stale answer -- and, through `apply_robustify`, a WRONG uuid written to disk. So the cache is
+# OPT-IN: `resolved()` is a plain passthrough unless a `resolve_cache()` scope is open, and `main()`
+# opens exactly one. The worst that can happen to a library consumer is now that it is as slow as
+# darnlink was before this cache existed, never that it is wrong.
+#
+# Relative paths are never memoised: their resolution depends on the process cwd. darnlink itself
+# never chdirs, but `--only-from` accepts relative paths (its help advertises piping
+# `git diff --cached --name-only`), so the key would be ambiguous for an embedder that does.
+_RESOLVE_CACHE: Optional[Dict[str, Path]] = None
+
+
+@contextmanager
+def resolve_cache() -> Iterator[None]:
+    """Open a scope in which `resolved()` memoises. Nesting reuses the outer scope, and leaving the
+    outermost one drops every entry -- so a cached resolution can never outlive the run that made it."""
+    global _RESOLVE_CACHE
+    outer = _RESOLVE_CACHE
+    if outer is None:
+        _RESOLVE_CACHE = {}
+    try:
+        yield
+    finally:
+        _RESOLVE_CACHE = outer
+
+
+def resolved(path: Path) -> Path:
+    """`path.resolve()`, memoised only while a `resolve_cache()` scope is open (see the note above).
+
+    Outside a scope, and for relative paths, this is exactly `path.resolve()`."""
+    cache = _RESOLVE_CACHE
+    if cache is None or not path.is_absolute():
+        return path.resolve()
+    key = str(path)
+    hit = cache.get(key)
+    if hit is None:
+        hit = path.resolve()
+        cache[key] = hit
+    return hit
+
+
+def clear_resolve_cache() -> None:
+    """Drop the entries of the open scope, if any. A no-op outside one."""
+    if _RESOLVE_CACHE is not None:
+        _RESOLVE_CACHE.clear()
 
 
 def split_fragment(href: str) -> Tuple[str, str]:
@@ -25,7 +84,7 @@ def resolve_href(href: str, linking_file: Path) -> Path:
     The fragment is dropped. Returns a resolved (normalized) path; the target need not exist.
     """
     path_part, _ = split_fragment(href)
-    return (linking_file.parent / path_part).resolve()
+    return resolved(linking_file.parent / path_part)
 
 
 def relative_link(target: Path, linking_file: Path, fragment: str = "") -> str:
@@ -33,7 +92,7 @@ def relative_link(target: Path, linking_file: Path, fragment: str = "") -> str:
 
     Re-appends `#fragment` if given. This is the value to write inside `(...)`.
     """
-    rel = os.path.relpath(target.resolve(), start=linking_file.parent.resolve())
+    rel = os.path.relpath(resolved(target), start=resolved(linking_file.parent))
     rel_posix = Path(rel).as_posix()
     return f"{rel_posix}#{fragment}" if fragment else rel_posix
 

--- a/src/darnlink/paths.py
+++ b/src/darnlink/paths.py
@@ -41,6 +41,11 @@ DIR_ANCHOR = "README.md"
 # prevent. Reproduced with a ThreadPoolExecutor running `main()` over several roots, the most
 # plausible embedder shape there is. A ContextVar is per-thread and per-task, so each run gets its
 # own scope and `reset(token)` cannot clobber anyone else's.
+#
+# The single hottest `resolve()` in a real run is NOT memoised and stays that way on purpose:
+# `frontmatter_index.iter_markdown_files` uses `resolve(strict=True)`, which raises instead of
+# returning, and issues one call per file with no repeats to save. Measured on a ~3,900-file tree it
+# is ~45% of all raw resolutions -- so this cache covers the repeats, not the total.
 _RESOLVE_CACHE: ContextVar[Optional[Dict[str, Path]]] = ContextVar(
     "darnlink_resolve_cache", default=None)
 
@@ -48,8 +53,10 @@ _RESOLVE_CACHE: ContextVar[Optional[Dict[str, Path]]] = ContextVar(
 @contextmanager
 def resolve_cache() -> Iterator[None]:
     """Open a scope in which `resolved()` memoises. Nesting reuses the scope already open and owns
-    nothing; leaving the outermost one drops every entry, so a cached resolution cannot outlive the
-    run that made it -- including when several runs share a process on different threads."""
+    nothing; leaving the outermost one drops every entry, so a cached resolution does not outlive
+    the run that made it -- including when several runs share a process on different threads --
+    provided the scope is left normally. A generator that opens one and is abandoned mid-yield keeps
+    it open until it is collected, like any other context manager."""
     if _RESOLVE_CACHE.get() is not None:
         yield                       # nested: reuse, own nothing
         return

--- a/src/darnlink/repair.py
+++ b/src/darnlink/repair.py
@@ -24,7 +24,7 @@ from typing import Dict, Iterable, List, Optional, Set, Tuple
 from .frontmatter_index import DEFAULT_EXCLUDES, FrontmatterIndex, iter_markdown_files
 from .links import (code_spans, emit_robust_link, file_ignores_links, file_is_ignored,
                     find_robust_links, ignored_spans)
-from .paths import DIR_ANCHOR, is_web_href, names_md, relative_link, resolve_href, split_fragment
+from .paths import DIR_ANCHOR, is_web_href, names_md, relative_link, resolve_href, resolved, split_fragment
 from .frontmatter_edit import read_text_keep_newlines, write_text_keep_newlines
 from .report import Finding, Kind
 from .scope import in_scope
@@ -132,7 +132,7 @@ def plan_repairs(
                 )
                 continue
             intended = target.parent if dir_link else target
-            if current == intended.resolve():
+            if current == resolved(intended):
                 continue  # already correct (cosmetic ./ or trailing-slash differences are fine)
             # Defensive: the written path still resolves to a real target while the uuid lives
             # elsewhere — the two halves disagree (typically a mis-pasted uuid). It is NOT a move, so

--- a/src/darnlink/robustify.py
+++ b/src/darnlink/robustify.py
@@ -27,7 +27,7 @@ from .frontmatter_index import DEFAULT_EXCLUDES, dir_excluded, iter_markdown_fil
 from .links import (DetachedAnchor, PlainLink, code_spans, emit_robust_link, file_ignores_links,
                     file_is_ignored, find_detached_anchors, find_plain_links, ignored_spans,
                     line_bounds, pandoc_attrs_at)
-from .paths import (DIR_ANCHOR, is_absolute_local_path, is_local_relative, names_md, resolve_href,
+from .paths import (DIR_ANCHOR, is_absolute_local_path, is_local_relative, names_md, resolve_href, resolved,
                      split_fragment)
 from .report import Finding, Kind
 from .scope import in_scope
@@ -69,7 +69,7 @@ def _anchor_target(href: str, linking_file: Path, extra_targets: AbstractSet[Pat
         return t if (t.is_file() and t.suffix.lower() == ".md") else None
     if t.is_dir():
         readme = t / DIR_ANCHOR
-        if readme.is_file() or readme.resolve() in extra_targets:  # a dir named `README.md` is not an anchor
+        if readme.is_file() or resolved(readme) in extra_targets:  # a dir named `README.md` is not an anchor
             return readme
     return None
 
@@ -172,7 +172,7 @@ def _within_excluded(directory: Path, root: Path, excludes) -> bool:
     an *included* file can still point at a directory *inside* an excluded one — this closes that path.
     """
     try:
-        rel = directory.resolve().relative_to(root)
+        rel = resolved(directory).relative_to(root)
     except ValueError:
         return False  # outside root is handled by the caller's own root check
     return any(dir_excluded(part, excludes) for part in rel.parts)
@@ -268,11 +268,11 @@ def plan_robustify(
         files.append(f)
         contents[f] = c  # this run's OWN copy — see the docstring note on --create-readme below
         if file_ignores_links(c):
-            link_ignored.add(f.resolve())
+            link_ignored.add(resolved(f))
             continue  # no spans: nothing reads them for this file, and computing them re-parses it
         spans[f] = ignored_spans(c, block_markers) + code_spans(c)
 
-    ignored_targets = {p.resolve() for p in result.ignored}  # opted-out files: never become targets
+    ignored_targets = {resolved(p) for p in result.ignored}  # opted-out files: never become targets
 
     # --- Phase A: decide the uuid for every target of a plain link ---
     target_uuid: Dict[Path, str] = {}   # target -> uuid to annotate with
@@ -290,15 +290,15 @@ def plan_robustify(
     planned_readmes: Set[Path] = set()      # resolved README paths this run will create
     created_readmes: Dict[Path, str] = {}   # README path -> full content to write
     if create_readme:
-        root_resolved = root.resolve()
+        root_resolved = resolved(root)
         for f in files:
-            if f.resolve() in link_ignored or not in_scope(f, only):
+            if resolved(f) in link_ignored or not in_scope(f, only):
                 continue  # same guards as Phase A: these links never drive writes
             for link in find_plain_links(contents.get(f, ""), spans.get(f, [])):
                 d = _dir_link_missing_readme(link.href, f)
                 if d is None:
                     continue
-                readme = (d / DIR_ANCHOR).resolve()
+                readme = resolved(d / DIR_ANCHOR)
                 if readme in planned_readmes:
                     continue  # one README per directory, however many links point at it
                 if not readme.is_relative_to(root_resolved):
@@ -318,7 +318,7 @@ def plan_robustify(
                 target_uuid[readme] = u
 
     def decide(target: Path) -> None:
-        target = target.resolve()
+        target = resolved(target)
         if (target in target_uuid or target in skip_no_fm or target in skip_denied
                 or target in invalid_fm or target in skip_out_of_scope or target in skip_target_write):
             return
@@ -355,7 +355,7 @@ def plan_robustify(
         needs_uuid_write.add(target)
 
     for f in files:
-        if f.resolve() in link_ignored:
+        if resolved(f) in link_ignored:
             continue  # FR-033: its links are never rewritten -> they must not drive uuid creation
         if not in_scope(f, only):
             continue  # 010: its links are never rewritten either -> they must not create uuids
@@ -363,7 +363,7 @@ def plan_robustify(
             t = _anchor_target(link.href, f, planned_readmes)
             # Skip self-links (a file linking to itself, e.g. autogrid `path` rows): robustifying
             # them is meaningless and would touch machine-generated blocks.
-            if t is not None and t.resolve() != f.resolve():
+            if t is not None and resolved(t) != resolved(f):
                 decide(t)
 
     # --- Phase A′ (only when narrowed): count what a full run would have anchored elsewhere ---
@@ -383,13 +383,13 @@ def plan_robustify(
             return cached
 
         for f in files:
-            if in_scope(f, only) or f.resolve() in link_ignored:
+            if in_scope(f, only) or resolved(f) in link_ignored:
                 continue
             for link in find_plain_links(contents.get(f, ""), spans.get(f, [])):
                 t = _anchor_target(link.href, f, planned_readmes)
-                if t is None or t.resolve() == f.resolve():
+                if t is None or resolved(t) == resolved(f):
                     continue
-                tr = t.resolve()
+                tr = resolved(t)
                 if tr in ignored_targets or tr not in contents:
                     continue
                 if _target_has_uuid(tr):
@@ -402,7 +402,7 @@ def plan_robustify(
         cursor = 0
         changed = False
         scoped = in_scope(f, only)  # 010: may this file's own links be rewritten?
-        if f.resolve() in link_ignored:
+        if resolved(f) in link_ignored:
             # FR-033: leave every link in it alone. We still fall through to the uuid write below,
             # because opting out as a SOURCE says nothing about being a target (FR-034/FR-035).
             result.link_ignored.append(f)
@@ -412,11 +412,11 @@ def plan_robustify(
                     "file carries darnlink-ignore-links; its links are left as-is (still a target)"))
         # Out of the write scope: its links are left alone here too, but it may still RECEIVE its own
         # uuid below — being a target is not a write the caller has to name (FR-006).
-        links = () if (f.resolve() in link_ignored or not scoped) else find_plain_links(original, spans.get(f, []))
+        links = () if (resolved(f) in link_ignored or not scoped) else find_plain_links(original, spans.get(f, []))
         anchorable: List[Tuple[PlainLink, str]] = []  # (plain link, the uuid that will anchor it)
         for link in links:
             t = _anchor_target(link.href, f, planned_readmes)
-            if t is None or t.resolve() == f.resolve():
+            if t is None or resolved(t) == resolved(f):
                 # 015: this `None` used to be the end of the road for a link to a path that is
                 # simply not there — no category, not even a tolerated one. Name it before dropping
                 # it. A self-link (t is not None) is not a candidate.
@@ -446,7 +446,7 @@ def plan_robustify(
                             "resolves only on the machine that wrote it; never checked or anchorable",
                             line=lineno))
                 continue  # skip non-md/external and self-links
-            tr = t.resolve()
+            tr = resolved(t)
             if tr in ignored_targets or tr in invalid_fm:
                 continue  # opted-out or invalid-YAML target: leave the link plain (invalid reported below)
             if tr in skip_denied:
@@ -568,8 +568,8 @@ def plan_robustify(
             changed = True
         content = ("".join(pieces) + original[cursor:]) if changed else original
 
-        if f.resolve() in needs_uuid_write:
-            added = add_uuid_to_content(content, target_uuid[f.resolve()], create_frontmatter)
+        if resolved(f) in needs_uuid_write:
+            added = add_uuid_to_content(content, target_uuid[resolved(f)], create_frontmatter)
             if added is not None:
                 content = added
 

--- a/src/darnlink/scope.py
+++ b/src/darnlink/scope.py
@@ -13,6 +13,8 @@ import sys
 from pathlib import Path
 from typing import Iterable, List, Optional, Set
 
+from .paths import resolved
+
 
 class ScopeError(ValueError):
     """A `--only` path that cannot be part of a write scope (FR-003)."""
@@ -41,10 +43,10 @@ def resolve_write_scope(paths: Iterable[str], root: Path) -> Optional[Set[Path]]
     paths = list(paths)
     if not paths:
         return None
-    root = root.resolve()
+    root = resolved(root)
     scope: Set[Path] = set()
     for raw in paths:
-        p = Path(raw).resolve()
+        p = resolved(Path(raw))
         if not p.exists():
             raise ScopeError(f"--only: no such file: {raw}")
         if not p.is_file() or p.suffix.lower() != ".md":
@@ -57,4 +59,4 @@ def resolve_write_scope(paths: Iterable[str], root: Path) -> Optional[Set[Path]]
 
 def in_scope(path: Path, scope: Optional[Set[Path]]) -> bool:
     """True if `path` may be written (always true when there is no narrowing)."""
-    return scope is None or path.resolve() in scope
+    return scope is None or resolved(path) in scope

--- a/src/darnlink/weblinks.py
+++ b/src/darnlink/weblinks.py
@@ -32,6 +32,7 @@ from urllib.parse import unquote
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 from .frontmatter_index import read_frontmatter_uuid
+from .paths import resolved
 from .links import (MD_LINK_RE, Span, _in_spans, code_spans, ignored_spans,
                     mermaid_click_destinations)
 
@@ -383,7 +384,7 @@ def _pendiente_en_la_rama_por_defecto(gu: "GithubUrl", own: Optional["OwnRepo"])
         return False
     destino = own.root / ruta
     try:
-        if not destino.resolve().is_relative_to(own.root.resolve()):
+        if not resolved(destino).is_relative_to(resolved(own.root)):
             return False
     except (OSError, ValueError):
         return False

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from darnlink.paths import relative_link, resolve_href, split_fragment, is_local_md
+from darnlink import cli, paths
+from darnlink.paths import (relative_link, resolve_cache, resolve_href, resolved,
+                            split_fragment, is_local_md)
 
 
 def test_split_fragment():
@@ -35,3 +37,94 @@ def test_is_local_md():
     assert not is_local_md("https://example.com/x.md")
     assert not is_local_md("#anchor")
     assert not is_local_md("img.png")
+
+
+# --- Resolution cache (perf: 81.7% of resolve() calls in a real run are repeats) ---
+#
+# Two halves are pinned here, and they are the whole design: inside a scope `resolved()` must be
+# indistinguishable from `resolve()` except in speed, and OUTSIDE one it must not memoise at all --
+# so the public plan_*/apply_* API can never hand an embedder a stale resolution.
+
+
+def test_resolved_matches_resolve_inside_a_scope(tmp_path):
+    with resolve_cache():
+        real = tmp_path / "deep" / "x"
+        real.mkdir(parents=True)
+        for p in (real, tmp_path / "nope.md", tmp_path / ".." / tmp_path.name / "y.md"):
+            assert resolved(p) == p.resolve()   # miss
+            assert resolved(p) == p.resolve()   # hit returns the same thing
+
+
+def test_resolved_follows_a_symlink_like_resolve(tmp_path):
+    with resolve_cache():
+        target = tmp_path / "real"
+        target.mkdir()
+        link = tmp_path / "link"
+        link.symlink_to(target, target_is_directory=True)
+        assert resolved(link / "a.md") == (target / "a.md").resolve()
+
+
+def _retarget(link, old, new):
+    link.unlink()
+    link.symlink_to(new, target_is_directory=True)
+
+
+def test_no_scope_means_no_memoisation(tmp_path):
+    """The safety that matters: an embedder calling the public API twice around a filesystem change
+    gets the truth, not a cached answer. Without this, apply_robustify would write a WRONG uuid."""
+    a, b = tmp_path / "a", tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(a, target_is_directory=True)
+    assert resolved(link / "f.md") == (a / "f.md").resolve()
+    _retarget(link, a, b)
+    assert resolved(link / "f.md") == (b / "f.md").resolve()   # no scope -> never stale
+
+
+def test_a_resolution_never_outlives_its_scope(tmp_path):
+    """Inside one scope a retarget is deliberately invisible -- that is what buys the speed. Across
+    two scopes it must not be: leaving the outermost scope drops every entry."""
+    a, b = tmp_path / "a", tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(a, target_is_directory=True)
+    with resolve_cache():
+        assert resolved(link / "f.md") == (a / "f.md").resolve()
+        _retarget(link, a, b)
+        assert resolved(link / "f.md") == (a / "f.md").resolve()   # stale ON PURPOSE, same run
+    with resolve_cache():
+        assert resolved(link / "f.md") == (b / "f.md").resolve()   # new run -> truth again
+
+
+def test_nesting_reuses_the_outer_scope_and_does_not_close_it_early(tmp_path):
+    f = tmp_path / "f.md"
+    with resolve_cache():
+        with resolve_cache():
+            first = resolved(f)
+        assert paths._RESOLVE_CACHE is not None   # inner exit must NOT close the outer scope
+        assert resolved(f) is first               # ...and the entry survives
+    assert paths._RESOLVE_CACHE is None
+
+
+def test_main_is_the_run_boundary(tmp_path):
+    """`main()` opens the only scope in the shipped code path, and closing it is structural rather
+    than a line someone can delete: there is no clear() to forget."""
+    (tmp_path / "a.md").write_text("---\nuuid: 11111111-1111-4111-8111-111111111111\n---\n# a\n",
+                                   encoding="utf-8")
+    assert paths._RESOLVE_CACHE is None
+    cli.main(["check", str(tmp_path)])
+    assert paths._RESOLVE_CACHE is None           # the run ended -> nothing memoised survives it
+
+
+def test_relative_paths_are_never_memoised(tmp_path, monkeypatch):
+    """Their resolution depends on the cwd, which is not part of the key. darnlink never chdirs;
+    an embedder might."""
+    (tmp_path / "one").mkdir()
+    (tmp_path / "two").mkdir()
+    with resolve_cache():
+        monkeypatch.chdir(tmp_path / "one")
+        first = resolved(Path("f.md"))
+        monkeypatch.chdir(tmp_path / "two")
+        assert resolved(Path("f.md")) != first

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from darnlink import cli, paths
@@ -103,19 +104,40 @@ def test_nesting_reuses_the_outer_scope_and_does_not_close_it_early(tmp_path):
     with resolve_cache():
         with resolve_cache():
             first = resolved(f)
-        assert paths._RESOLVE_CACHE is not None   # inner exit must NOT close the outer scope
+        assert paths._RESOLVE_CACHE.get() is not None   # inner exit must NOT close the outer scope
         assert resolved(f) is first               # ...and the entry survives
-    assert paths._RESOLVE_CACHE is None
+    assert paths._RESOLVE_CACHE.get() is None
 
 
-def test_main_is_the_run_boundary(tmp_path):
-    """`main()` opens the only scope in the shipped code path, and closing it is structural rather
-    than a line someone can delete: there is no clear() to forget."""
+def test_main_opens_the_scope_and_closes_it(tmp_path, monkeypatch):
+    """Asserting only "no scope afterwards" would pass with `main()` opening none at all -- i.e. with
+    the whole optimisation deleted. So observe it OPEN during the run, which is what makes the line
+    in `main()` load-bearing rather than decorative."""
     (tmp_path / "a.md").write_text("---\nuuid: 11111111-1111-4111-8111-111111111111\n---\n# a\n",
                                    encoding="utf-8")
-    assert paths._RESOLVE_CACHE is None
+    seen = []
+    real = cli._main
+    monkeypatch.setattr(cli, "_main", lambda argv=None: (seen.append(paths._RESOLVE_CACHE.get()), real(argv))[1])
+    assert paths._RESOLVE_CACHE.get() is None
     cli.main(["check", str(tmp_path)])
-    assert paths._RESOLVE_CACHE is None           # the run ended -> nothing memoised survives it
+    assert seen and seen[0] is not None, "main() must run its body inside an open scope"
+    assert paths._RESOLVE_CACHE.get() is None           # ...and leave none behind
+
+
+def test_concurrent_runs_do_not_leak_a_scope(tmp_path):
+    """Two INTERLEAVED scopes are what a save/restore of a module global gets wrong: the second one
+    to leave puts back the dict the first had already closed, and the cache stays open process-wide
+    with no run alive. A ContextVar is per-thread, so each run owns its own."""
+    roots = []
+    for i in range(6):
+        r = tmp_path / f"r{i}"
+        r.mkdir()
+        (r / "a.md").write_text(f"---\nuuid: 1111{i:04d}-1111-4111-8111-111111111111\n---\n# a\n",
+                                encoding="utf-8")
+        roots.append(r)
+    with ThreadPoolExecutor(max_workers=6) as ex:
+        list(ex.map(lambda r: cli.main(["check", str(r)]), roots))
+    assert paths._RESOLVE_CACHE.get() is None, "a scope outlived every run that could own it"
 
 
 def test_relative_paths_are_never_memoised(tmp_path, monkeypatch):

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,4 +1,4 @@
-from concurrent.futures import ThreadPoolExecutor
+import threading
 from pathlib import Path
 
 from darnlink import cli, paths
@@ -124,19 +124,44 @@ def test_main_opens_the_scope_and_closes_it(tmp_path, monkeypatch):
     assert paths._RESOLVE_CACHE.get() is None           # ...and leave none behind
 
 
-def test_concurrent_runs_do_not_leak_a_scope(tmp_path):
-    """Two INTERLEAVED scopes are what a save/restore of a module global gets wrong: the second one
-    to leave puts back the dict the first had already closed, and the cache stays open process-wide
-    with no run alive. A ContextVar is per-thread, so each run owns its own."""
-    roots = []
-    for i in range(6):
-        r = tmp_path / f"r{i}"
-        r.mkdir()
-        (r / "a.md").write_text(f"---\nuuid: 1111{i:04d}-1111-4111-8111-111111111111\n---\n# a\n",
-                                encoding="utf-8")
-        roots.append(r)
-    with ThreadPoolExecutor(max_workers=6) as ex:
-        list(ex.map(lambda r: cli.main(["check", str(r)]), roots))
+def test_interleaved_scopes_do_not_leak(tmp_path):
+    """The failure a saved-and-restored global has is INTERLEAVING, not concurrency: A enters,
+    B enters, A leaves, B leaves -- and B's restore puts back the dict A had already closed.
+
+    This forces that exact order with Events instead of hoping the scheduler produces it. Hoping
+    is not good enough: an earlier version of this test ran six `main()` calls in a pool and let
+    them race, and it went green over the seeded regression roughly one run in seven. A gate that
+    passes 14% of the time on the very defect it is named after is worse than no gate, because
+    nobody looks at it again."""
+    a_in, b_in, a_out = threading.Event(), threading.Event(), threading.Event()
+    errors = []
+
+    def first():
+        try:
+            with resolve_cache():
+                resolved(tmp_path / "f.md")
+                a_in.set()
+                b_in.wait(5)          # B is inside its scope while A is still open
+            a_out.set()
+        except Exception as exc:      # pragma: no cover - only on a broken scope
+            errors.append(exc)
+
+    def second():
+        try:
+            a_in.wait(5)
+            with resolve_cache():
+                b_in.set()
+                a_out.wait(5)         # A left while B is still open
+                resolved(tmp_path / "g.md")
+        except Exception as exc:      # pragma: no cover
+            errors.append(exc)
+
+    ta, tb = threading.Thread(target=first), threading.Thread(target=second)
+    ta.start()
+    tb.start()
+    ta.join(10)
+    tb.join(10)
+    assert not errors, errors
     assert paths._RESOLVE_CACHE.get() is None, "a scope outlived every run that could own it"
 
 


### PR DESCRIPTION
## What

`Path.resolve()` is called on the same paths over and over. Measured on a ~3,900-file documentation tree, one `check` run issues **31,470 calls for only 5,767 distinct paths** — 81.7% repeats — and spends **~24% of its wall clock** inside them. The repeats are structural: `robustify` walks the same file list in several passes and each pass re-resolves the same `f`; `resolve_href()` re-resolves the same link targets.

This memoises them **inside an explicit run scope**.

## The design decision worth reviewing

The cache is **opt-in**: `resolved()` is a plain passthrough unless a `resolve_cache()` scope is open, and `main()` opens exactly one.

An earlier draft made it an always-on process-wide dict cleared at the top of `main()`. Adversarial review reproduced the consequence: `plan_robustify`, `plan_repairs`, `resolve_write_scope` and `in_scope` are all public and **none** of them clears, so an embedder calling them twice around a re-pointed symlink got a stale resolution — and through `apply_robustify`, a **wrong uuid written to disk**. `main()` happened to be the only shipped entrypoint, so it was a trap laid rather than sprung, but the failure mode was silent corruption.

Inverted, the worst case for a library consumer is that it is merely **as slow as it was before this PR**, never wrong.

## Soundness

A non-strict `resolve()` (= `realpath`) can only change if a **symlink, a mount, or a directory-vs-symlink component** changes. Creating a file, creating a `README.md` anchor, or rewriting content cannot change it — and content is the only thing darnlink ever writes. Verified rather than assumed: there is no `mkdir`/`rename`/`replace`/`shutil.move`/`symlink_to`/`unlink` anywhere in `src/`.

Relative paths are **never** memoised: their resolution depends on the process cwd, which is not part of the key. darnlink never chdirs, but `--only-from` accepts relative paths (its help advertises piping `git diff --cached --name-only`), so the key would be ambiguous for an embedder that does.

`frontmatter_index.py` is deliberately **not** converted: its `resolve(strict=True)` runs once per file during the walk, raises rather than returning, and has no repeats to save.

## Measurement

Paired and interleaved in one process (arm A neutralises the scope, so both arms run identical code paths), warm-up discarded, n=7:

| | min | p50 |
|---|---|---|
| no cache | 2.960 s | 3.506 s |
| with cache | 2.408 s | 2.580 s |
| | **−18.6 %** | −26.4 % |

**7/7 paired iterations favour the cache.** An independent re-measurement during review, interleaved in *both* orders on a different tree, got −16.9 % and −19.8 % with **18/18** paired iterations favouring it — so the effect is real and order-independent, not a page-cache artefact.

⚠️ A first attempt used a sequential `9×A then 9×B` design and showed **no difference at all**. That was the design, not the machine. Recorded here because anyone re-checking it the same way will see the same null.

## What the tests pin

`547 passed` (4 new). Specifically:

- no memoisation **outside** a scope — the safety that stops the silent-corruption path above;
- a resolution **never outliving** its scope;
- nesting **not** closing the outer scope early;
- `main()` leaving **no scope open** behind it — structural now (leaving the scope drops the entries), so there is no `clear()` for anyone to delete in six months;
- relative paths not memoised, verified by chdir'ing between two calls.

## Review ledger

| Round | Reviewer | Findings | Outcome |
|---|---|---|---|
| 1 | adversarial subsession | 2 IMPORTANTE, 3 MINOR | all applied — the design was inverted because of finding 1 |
| 2 | Copilot (on opening) | — | pending |

Round 1 also **falsified a claim of mine**: the earlier justification for clearing in `main()` said "the test suite rearranges the tree between calls". It does not — pytest hands every test a fresh `tmp_path`, so keys never collide, and suppressing all 55 clears left 543/543 green. The guard was real; its stated reason was not, and nothing held it up.

Areas round 1 attacked and found clean, with evidence: the 26 substitutions (accounted for per-module, chained expressions checked one by one), cache-key equivalence classes (`a//b`, `a/./b`, `Path('')` vs `Path('.')`, `a/../b`), entrypoint enumeration (every shipped entrypoint is a fresh process), and test-suite leakage (0 accidental stale hits across 2,793 memoised resolutions, 82.4% hit rate — which independently confirms the 81.7% repeat figure).
